### PR TITLE
DATACOUCH-28 - Remove explicit setting of setIncludeDocs on View queries.

### DIFF
--- a/src/main/java/org/springframework/data/couchbase/core/CouchbaseOperations.java
+++ b/src/main/java/org/springframework/data/couchbase/core/CouchbaseOperations.java
@@ -103,8 +103,9 @@ public interface CouchbaseOperations {
   /**
    * Query a View for a list of documents of type T.
    *
-   * <p>There is no need to {@link Query#setIncludeDocs(boolean)} explicitely, because it will be set to true all the
-   * time. It is valid to pass in a empty constructed {@link Query} object.</p>
+   * {@link Query#setIncludeDocs(boolean)} defaults to false. If you require the query to include the entire
+   * document, you will need to set it to true before calling this method. It is valid to pass in a empty
+   * constructed {@link Query} object.
    *
    * <p>This method does not work with reduced views, because they by design do not contain references to original
    * objects. Use the provided {@link #queryView} method for more flexibility and direct access.</p>
@@ -130,7 +131,7 @@ public interface CouchbaseOperations {
    * @param design the name of the design document.
    * @param view the name of the view.
    * @param query the Query object to customize the view query.
-   * @return
+   * @return the view response.
    */
   ViewResponse queryView(String design, String view, Query query);
 

--- a/src/main/java/org/springframework/data/couchbase/core/CouchbaseTemplate.java
+++ b/src/main/java/org/springframework/data/couchbase/core/CouchbaseTemplate.java
@@ -168,9 +168,6 @@ public class CouchbaseTemplate implements CouchbaseOperations {
   public <T> List<T> findByView(final String designName, final String viewName,
     final Query query, final Class<T> entityClass) {
 
-    if (!query.willIncludeDocs()) {
-      query.setIncludeDocs(true);
-    }
     if (query.willReduce()) {
       query.setReduce(false);
     }

--- a/src/main/java/org/springframework/data/couchbase/repository/support/SimpleCouchbaseRepository.java
+++ b/src/main/java/org/springframework/data/couchbase/repository/support/SimpleCouchbaseRepository.java
@@ -119,7 +119,7 @@ public class SimpleCouchbaseRepository<T, ID extends Serializable> implements Co
     String design = entityInformation.getJavaType().getSimpleName().toLowerCase();
     String view = "all";
 
-    return couchbaseOperations.findByView(design, view, new Query().setReduce(false),
+    return couchbaseOperations.findByView(design, view, new Query().setIncludeDocs(true).setReduce(false),
       entityInformation.getJavaType());
   }
 

--- a/src/test/java/org/springframework/data/couchbase/core/CouchbaseTemplateTests.java
+++ b/src/test/java/org/springframework/data/couchbase/core/CouchbaseTemplateTests.java
@@ -168,6 +168,7 @@ public class CouchbaseTemplateTests {
   @Test
   public void shouldLoadAndMapViewDocs() {
     Query query = new Query();
+    query.setIncludeDocs(true);
     query.setStale(Stale.FALSE);
 
     final List<Beer> beers = template.findByView("test_beers", "by_name", query, Beer.class);

--- a/src/test/java/org/springframework/data/couchbase/repository/SimpleCouchbaseRepositoryTests.java
+++ b/src/test/java/org/springframework/data/couchbase/repository/SimpleCouchbaseRepositoryTests.java
@@ -77,7 +77,7 @@ public class SimpleCouchbaseRepositoryTests {
   @Test
   public void shouldFindAll() {
     // do a non-stale query to populate data for testing.
-    client.query(client.getView("user", "all"), new Query().setStale(Stale.FALSE));
+    client.query(client.getView("user", "all"), new Query().setIncludeDocs(true).setStale(Stale.FALSE));
 
     Iterable<User> allUsers = repository.findAll();
     int size = 0;


### PR DESCRIPTION
Instead of always setting includeDocs to true for all View queries, it is now
the assumption that the programmer will enable this if they desire documents
to be returned on their query. The reasoning is to allow for an optimisation
when performing queries so that documents are not returned unless asked for.
This increases performance and reduces payload size in the communication from
Couchbase to the client.

-=david=-
