### PR TITLE
DATACOUCH-34 - Can't deserialize long/Long/Date fields.

### DIFF
--- a/src/main/java/org/springframework/data/couchbase/core/convert/translation/JacksonTranslationService.java
+++ b/src/main/java/org/springframework/data/couchbase/core/convert/translation/JacksonTranslationService.java
@@ -50,6 +50,7 @@ public class JacksonTranslationService implements TranslationService {
    * Encode a {@link CouchbaseStorable} to a JSON string.
    *
    * @param source the source document to encode.
+   *
    * @return the encoded JSON String.
    */
   @Override
@@ -72,6 +73,7 @@ public class JacksonTranslationService implements TranslationService {
    *
    * @param source the source document
    * @param generator the JSON generator.
+   *
    * @throws IOException
    */
   private void encodeRecursive(final CouchbaseStorable source, final JsonGenerator generator) throws IOException {
@@ -103,6 +105,7 @@ public class JacksonTranslationService implements TranslationService {
    *
    * @param source the source formatted document.
    * @param target the target of the populated data.
+   *
    * @return the decoded structure.
    */
   @Override
@@ -132,8 +135,9 @@ public class JacksonTranslationService implements TranslationService {
    *
    * @param parser the JSON parser with the content.
    * @param target the target where the content should be stored.
-   * @returns the decoded object.
+   *
    * @throws IOException
+   * @returns the decoded object.
    */
   private CouchbaseDocument decodeObject(final JsonParser parser, final CouchbaseDocument target) throws IOException {
     JsonToken currentToken = parser.nextToken();
@@ -161,8 +165,9 @@ public class JacksonTranslationService implements TranslationService {
    *
    * @param parser the JSON parser with the content.
    * @param target the target where the content should be stored.
-   * @returns the decoded list.
+   *
    * @throws IOException
+   * @returns the decoded list.
    */
   private CouchbaseList decodeArray(final JsonParser parser, final CouchbaseList target) throws IOException {
     JsonToken currentToken = parser.nextToken();
@@ -187,7 +192,9 @@ public class JacksonTranslationService implements TranslationService {
    *
    * @param token the type of token.
    * @param parser the parser with the content.
+   *
    * @return the decoded primitve.
+   *
    * @throws IOException
    */
   private Object decodePrimitive(final JsonToken token, final JsonParser parser) throws IOException {
@@ -198,7 +205,11 @@ public class JacksonTranslationService implements TranslationService {
       case VALUE_STRING:
         return parser.getValueAsString();
       case VALUE_NUMBER_INT:
-        return parser.getValueAsInt();
+        try {
+          return parser.getValueAsInt();
+        } catch (final JsonParseException e) {
+          return parser.getValueAsLong();
+        }
       case VALUE_NUMBER_FLOAT:
         return parser.getValueAsDouble();
       default:

--- a/src/test/java/org/springframework/data/couchbase/core/CouchbaseTemplateTests.java
+++ b/src/test/java/org/springframework/data/couchbase/core/CouchbaseTemplateTests.java
@@ -19,8 +19,6 @@ package org.springframework.data.couchbase.core;
 import com.couchbase.client.CouchbaseClient;
 import com.couchbase.client.protocol.views.Query;
 import com.couchbase.client.protocol.views.Stale;
-import net.spy.memcached.internal.OperationFuture;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -32,9 +30,18 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestExecutionListeners;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * @author Michael Nitschinger
@@ -191,6 +198,14 @@ public class CouchbaseTemplateTests {
       assertTrue(true);
     }
   }
+
+  @Test
+  public void shouldDeserialiseLongs() {
+    SimpleWithLong simpleWithLong = new SimpleWithLong("simpleWithLong:simple", new Date().getTime());
+    template.save(simpleWithLong);
+    simpleWithLong = template.findById("simpleWithLong:simple", SimpleWithLong.class);
+    assertNotNull(simpleWithLong);
+  }
   
   /**
    * A sample document with just an id and property.
@@ -263,6 +278,32 @@ public class CouchbaseTemplateTests {
 
     String getId() {
       return id;
+    }
+  }
+
+  @Document
+  static class SimpleWithLong {
+
+    @Id
+    private String id;
+
+    private long value;
+
+    SimpleWithLong(final String id, final long value) {
+      this.id = id;
+      this.value = value;
+    }
+
+    String getId() {
+      return id;
+    }
+
+    long getValue() {
+      return value;
+    }
+
+    void setValue(final long value) {
+      this.value = value;
     }
   }
 }


### PR DESCRIPTION
Catch the attempt to parse a long as an int, then attempt to return a long value.

I'm not tooooo sure of the approach here, it's bizarre. There appears to be no VALUE_NUMBER_LONG in the JsonToken class and I find that confusing! At the moment, I'm just catching the attempt to parse an int where it throws an exception and then attempt to parse as a long. Seems to work grand.

-=david=-
