### PR TITLE
DATACOUCH-38 - Can't Deserialize Enum.

### DIFF
--- a/src/main/java/org/springframework/data/couchbase/core/convert/translation/JacksonTranslationService.java
+++ b/src/main/java/org/springframework/data/couchbase/core/convert/translation/JacksonTranslationService.java
@@ -88,7 +88,7 @@ public class JacksonTranslationService implements TranslationService {
         continue;
       }
 
-      if (simpleTypeHolder.isSimpleType(value.getClass())) {
+      if (simpleTypeHolder.isSimpleType(value.getClass()) && !Enum.class.isAssignableFrom(value.getClass())) {
         generator.writeObject(value);
       } else {
         ObjectMapper mapper = new ObjectMapper();


### PR DESCRIPTION
Enums, even although they are a simple type, must not use writeSimpleObject
since there is no "handler" in writeSimpleObject for Enums. Instead, we just
drop back to using the built-in ObjectMapper for handling enums.

-=david=-
