### PR TITLE
Added stable spring data repository to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,14 @@ The preferred way is to install the package through maven:
 </dependency>
 ```
 
+To use stable resease of spring data, please add this reposotory to your `pom.xml` file
+```xml
+<repository>
+  <id>springframework-release</id>
+  <url>http://maven.springframework.org/release</url>
+</repository>
+```
+
 If you want to get a pre-release, please use the springsource snapshot and milestone repositories.
 
 ## Configuration


### PR DESCRIPTION
If none of spring framework repositories is present in pom, maven can't find spring data dependencies.
