### PR TITLE
Provide CDI support for Spring Data Couchbase repositories

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -96,6 +96,29 @@
       <optional>true</optional>
     </dependency>
 
+    <!-- CDI -->
+    <dependency>
+      <groupId>javax.enterprise</groupId>
+      <artifactId>cdi-api</artifactId>
+      <version>${cdi}</version>
+      <scope>provided</scope>
+      <optional>true</optional>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.openwebbeans.test</groupId>
+      <artifactId>cditest-owb</artifactId>
+      <version>${webbeans}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>javax.servlet</groupId>
+      <artifactId>servlet-api</artifactId>
+      <version>3.0-alpha-1</version>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
   <repositories>

--- a/src/main/java/org/springframework/data/couchbase/repository/cdi/CouchbaseRepositoryBean.java
+++ b/src/main/java/org/springframework/data/couchbase/repository/cdi/CouchbaseRepositoryBean.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.data.couchbase.repository.cdi;
+
+import javax.enterprise.context.spi.CreationalContext;
+import javax.enterprise.inject.spi.Bean;
+import javax.enterprise.inject.spi.BeanManager;
+import java.lang.annotation.Annotation;
+import java.util.Set;
+
+import org.springframework.data.couchbase.core.CouchbaseOperations;
+import org.springframework.data.couchbase.repository.support.CouchbaseRepositoryFactory;
+import org.springframework.data.repository.cdi.CdiRepositoryBean;
+import org.springframework.data.repository.config.CustomRepositoryImplementationDetector;
+import org.springframework.util.Assert;
+
+/**
+ * A bean which represents a Couchbase repository.
+ * @author Mark Paluch
+ */
+public class CouchbaseRepositoryBean<T> extends CdiRepositoryBean<T> {
+
+    private final Bean<CouchbaseOperations> couchbaseOperationsBean;
+
+    /**
+     * Creates a new {@link CouchbaseRepositoryBean}.
+     *
+     * @param operations must not be {@literal null}.
+     * @param qualifiers must not be {@literal null}.
+     * @param repositoryType must not be {@literal null}.
+     * @param beanManager must not be {@literal null}.
+     * @param detector detector for the custom {@link org.springframework.data.repository.Repository} implementations
+     *          {@link org.springframework.data.repository.config.CustomRepositoryImplementationDetector}, can be {@literal null}.
+     */
+    public CouchbaseRepositoryBean(Bean<CouchbaseOperations> operations, Set<Annotation> qualifiers, Class<T> repositoryType,
+            BeanManager beanManager, CustomRepositoryImplementationDetector detector) {
+        super(qualifiers, repositoryType, beanManager, detector);
+
+        Assert.notNull(operations, "Cannot create repository with 'null' for CouchbaseOperations.");
+        this.couchbaseOperationsBean = operations;
+    }
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.repository.cdi.CdiRepositoryBean#create(javax.enterprise.context.spi.CreationalContext, java.lang.Class, java.lang.Object)
+	 */
+    @Override
+    protected T create(CreationalContext<T> creationalContext, Class<T> repositoryType, Object customImplementation) {
+        CouchbaseOperations couchbaseOperations = getDependencyInstance(couchbaseOperationsBean, CouchbaseOperations.class);
+        return new CouchbaseRepositoryFactory(couchbaseOperations).getRepository(repositoryType, customImplementation);
+    }
+
+    @Override
+    public Class<? extends Annotation> getScope() {
+        return couchbaseOperationsBean.getScope();
+    }
+}

--- a/src/main/java/org/springframework/data/couchbase/repository/cdi/CouchbaseRepositoryExtension.java
+++ b/src/main/java/org/springframework/data/couchbase/repository/cdi/CouchbaseRepositoryExtension.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.data.couchbase.repository.cdi;
+
+import javax.enterprise.event.Observes;
+import javax.enterprise.inject.UnsatisfiedResolutionException;
+import javax.enterprise.inject.spi.AfterBeanDiscovery;
+import javax.enterprise.inject.spi.Bean;
+import javax.enterprise.inject.spi.BeanManager;
+import javax.enterprise.inject.spi.ProcessBean;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import org.springframework.data.couchbase.core.CouchbaseOperations;
+import org.springframework.data.repository.cdi.CdiRepositoryBean;
+import org.springframework.data.repository.cdi.CdiRepositoryExtensionSupport;
+
+/**
+ * A portable CDI extension which registers beans for Spring Data Couchbase repositories.
+ * @author Mark Paluch
+ */
+public class CouchbaseRepositoryExtension extends CdiRepositoryExtensionSupport{
+
+	private final Map<String, Bean<CouchbaseOperations>> couchbaseOperationsMap = new HashMap<String, Bean<CouchbaseOperations>>();
+
+	/**
+	 * Implementation of a an observer which checks for CouchbaseOperations beans and stores them in {@link #couchbaseOperationsMap} for
+	 * later association with corresponding repository beans.
+	 *
+	 * @param <T> The type.
+	 * @param processBean The annotated type as defined by CDI.
+	 */
+	@SuppressWarnings("unchecked")
+	<T> void processBean(@Observes ProcessBean<T> processBean) {
+		Bean<T> bean = processBean.getBean();
+		for (Type type : bean.getTypes()) {
+			if (type instanceof Class<?> && CouchbaseOperations.class.isAssignableFrom((Class<?>) type)) {
+				couchbaseOperationsMap.put(bean.getQualifiers().toString(), ((Bean<CouchbaseOperations>) bean));
+			}
+		}
+	}
+
+	/**
+	 * Implementation of a an observer which registers beans to the CDI container for the detected Spring Data
+	 * repositories.
+	 * <p>
+	 * The repository beans are associated to the CouchbaseOperations using their qualifiers.
+	 *
+	 * @param beanManager The BeanManager instance.
+	 */
+	void afterBeanDiscovery(@Observes AfterBeanDiscovery afterBeanDiscovery, BeanManager beanManager) {
+		for (Map.Entry<Class<?>, Set<Annotation>> entry : getRepositoryTypes()) {
+
+			Class<?> repositoryType = entry.getKey();
+			Set<Annotation> qualifiers = entry.getValue();
+
+			CdiRepositoryBean<?> repositoryBean = createRepositoryBean(repositoryType, qualifiers, beanManager);
+			afterBeanDiscovery.addBean(repositoryBean);
+			registerBean(repositoryBean);
+		}
+	}
+
+	/**
+	 * Creates a {@link Bean}.
+	 *
+	 * @param <T> The type of the repository.
+	 * @param repositoryType The class representing the repository.
+	 * @param beanManager The BeanManager instance.
+	 * @return The bean.
+	 */
+	private <T> CdiRepositoryBean<T> createRepositoryBean(Class<T> repositoryType, Set<Annotation> qualifiers, BeanManager beanManager) {
+
+		Bean<CouchbaseOperations> couchbaseOperationsBean = this.couchbaseOperationsMap.get(qualifiers
+				.toString());
+
+		if (couchbaseOperationsBean == null) {
+			throw new UnsatisfiedResolutionException(String.format("Unable to resolve a bean for '%s' with qualifiers %s.",
+					CouchbaseOperations.class.getName(), qualifiers));
+		}
+
+		return new CouchbaseRepositoryBean<T>(couchbaseOperationsBean, qualifiers, repositoryType, beanManager, getCustomImplementationDetector());
+	}
+}

--- a/src/main/resources/META-INF/services/javax.enterprise.inject.spi.Extension
+++ b/src/main/resources/META-INF/services/javax.enterprise.inject.spi.Extension
@@ -1,0 +1,1 @@
+org.springframework.data.couchbase.repository.cdi.CouchbaseRepositoryExtension

--- a/src/test/java/org/springframework/data/couchbase/repository/cdi/CdiPersonRepository.java
+++ b/src/test/java/org/springframework/data/couchbase/repository/cdi/CdiPersonRepository.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.data.couchbase.repository.cdi;
+
+import org.springframework.data.couchbase.repository.CouchbaseRepository;
+import org.springframework.data.couchbase.repository.User;
+
+/**
+ * @author Mark Paluch
+ */
+public interface CdiPersonRepository extends CouchbaseRepository<Person, String>, CdiPersonRepositoryCustom {
+
+}

--- a/src/test/java/org/springframework/data/couchbase/repository/cdi/CdiPersonRepositoryCustom.java
+++ b/src/test/java/org/springframework/data/couchbase/repository/cdi/CdiPersonRepositoryCustom.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.data.couchbase.repository.cdi;
+
+/**
+ * @author Mark Paluch
+ */
+public interface CdiPersonRepositoryCustom {
+
+	int returnTwo();
+
+}

--- a/src/test/java/org/springframework/data/couchbase/repository/cdi/CdiPersonRepositoryImpl.java
+++ b/src/test/java/org/springframework/data/couchbase/repository/cdi/CdiPersonRepositoryImpl.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.data.couchbase.repository.cdi;
+
+/**
+ * @author Mark Paluch
+ */
+public class CdiPersonRepositoryImpl implements CdiPersonRepositoryCustom {
+
+	@Override
+	public int returnTwo() {
+		return 2;
+	}
+}

--- a/src/test/java/org/springframework/data/couchbase/repository/cdi/CdiRepositoryClient.java
+++ b/src/test/java/org/springframework/data/couchbase/repository/cdi/CdiRepositoryClient.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.data.couchbase.repository.cdi;
+
+import javax.inject.Inject;
+
+import com.couchbase.client.CouchbaseClient;
+import org.springframework.data.couchbase.repository.UserRepository;
+
+/**
+ * @author Mark Paluch
+ */
+class CdiRepositoryClient {
+
+	@Inject
+	private CdiPersonRepository cdiPersonRepository;
+
+	@Inject
+	private CouchbaseClient couchbaseClient;
+
+	public CdiPersonRepository getCdiPersonRepository() {
+		return cdiPersonRepository;
+	}
+
+	public CouchbaseClient getCouchbaseClient() {
+		return couchbaseClient;
+	}
+}

--- a/src/test/java/org/springframework/data/couchbase/repository/cdi/CdiRepositoryTests.java
+++ b/src/test/java/org/springframework/data/couchbase/repository/cdi/CdiRepositoryTests.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.data.couchbase.repository.cdi;
+
+import static org.junit.Assert.*;
+
+import org.apache.webbeans.cditest.CdiTestContainer;
+import org.apache.webbeans.cditest.CdiTestContainerLoader;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.couchbase.client.CouchbaseClient;
+import com.couchbase.client.protocol.views.DesignDocument;
+import com.couchbase.client.protocol.views.ViewDesign;
+
+/**
+ * @author Mark Paluch
+ */
+public class CdiRepositoryTests {
+
+	private static CdiTestContainer cdiContainer;
+	private CdiPersonRepository repository;
+	private CouchbaseClient couchbaseClient;
+
+	@BeforeClass
+	public static void init() throws Exception {
+		cdiContainer = CdiTestContainerLoader.getCdiContainer();
+		cdiContainer.startApplicationScope();
+		cdiContainer.bootContainer();
+	}
+
+	@AfterClass
+	public static void shutdown() throws Exception {
+		cdiContainer.stopContexts();
+		cdiContainer.shutdownContainer();
+	}
+
+	@Before
+	public void setUp() {
+		CdiRepositoryClient repositoryClient = cdiContainer.getInstance(CdiRepositoryClient.class);
+		repository = repositoryClient.getCdiPersonRepository();
+
+		couchbaseClient = repositoryClient.getCouchbaseClient();
+		createAndWaitForDesignDocs(couchbaseClient);
+
+	}
+
+	private void createAndWaitForDesignDocs(CouchbaseClient client) {
+		DesignDocument designDoc = new DesignDocument("person");
+		String mapFunction = "function (doc, meta) { if(doc._class == \"" + Person.class.getName()
+				+ "\") { emit(null, null); } }";
+		designDoc.setView(new ViewDesign("all", mapFunction, "_count"));
+		client.createDesignDoc(designDoc);
+	}
+
+	/**
+	 * @see DATACOUCH-109
+	 */
+	@Test
+	public void testCdiRepository() {
+		assertNotNull(repository);
+		repository.deleteAll();
+
+		Person bean = new Person("key", "username");
+
+		repository.save(bean);
+
+		assertTrue(repository.exists(bean.getId()));
+
+		Person retrieved = repository.findOne(bean.getId());
+		assertNotNull(retrieved);
+		assertEquals(bean.getName(), retrieved.getName());
+		assertEquals(bean.getId(), retrieved.getId());
+
+	}
+
+	/**
+	 * @see DATACOUCH-109
+	 */
+	@Test
+	public void testCustomRepository() {
+
+		assertEquals(2, repository.returnTwo());
+	}
+
+}

--- a/src/test/java/org/springframework/data/couchbase/repository/cdi/CouchbaseClientProducer.java
+++ b/src/test/java/org/springframework/data/couchbase/repository/cdi/CouchbaseClientProducer.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.data.couchbase.repository.cdi;
+
+import javax.enterprise.inject.Disposes;
+import javax.enterprise.inject.Produces;
+
+import org.springframework.data.couchbase.core.CouchbaseFactoryBean;
+
+import com.couchbase.client.CouchbaseClient;
+
+/**
+ * Producer for {@link CouchbaseClient}. Defaults from {@link CouchbaseFactoryBean} are sufficient for our test.
+ * 
+ * @author Mark Paluch
+ */
+class CouchbaseClientProducer {
+
+	@Produces
+	public CouchbaseClient createCouchbaseClient() throws Exception {
+
+		CouchbaseFactoryBean couchbaseFactoryBean = new CouchbaseFactoryBean();
+		couchbaseFactoryBean.setBucket("default");
+		couchbaseFactoryBean.afterPropertiesSet();
+		return couchbaseFactoryBean.getObject();
+	}
+
+	public void close(@Disposes CouchbaseClient couchbaseClient) {
+		couchbaseClient.shutdown();
+	}
+}

--- a/src/test/java/org/springframework/data/couchbase/repository/cdi/CouchbaseOperationsProducer.java
+++ b/src/test/java/org/springframework/data/couchbase/repository/cdi/CouchbaseOperationsProducer.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.data.couchbase.repository.cdi;
+
+import javax.enterprise.inject.Produces;
+
+import org.springframework.data.couchbase.core.CouchbaseOperations;
+import org.springframework.data.couchbase.core.CouchbaseTemplate;
+
+import com.couchbase.client.CouchbaseClient;
+
+/**
+ * Produces a {@link CouchbaseOperations} instance for test usage.
+ * @author Mark Paluch
+ */
+class CouchbaseOperationsProducer {
+
+	@Produces
+	public CouchbaseOperations createCouchbaseOperations(CouchbaseClient couchbaseClient) throws Exception {
+
+		CouchbaseTemplate couchbaseTemplate = new CouchbaseTemplate(couchbaseClient);
+
+		return couchbaseTemplate;
+	}
+
+}

--- a/src/test/java/org/springframework/data/couchbase/repository/cdi/Person.java
+++ b/src/test/java/org/springframework/data/couchbase/repository/cdi/Person.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.data.couchbase.repository.cdi;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.couchbase.core.mapping.Field;
+
+/**
+ * @author Mark Paluch
+ */
+public class Person {
+
+	@Id private String id;
+
+	@Field private String name;
+
+	public Person() {}
+
+	public Person(String id, String name) {
+		this.id = id;
+		this.name = name;
+	}
+
+	public String getId() {
+		return id;
+	}
+
+	public void setId(String id) {
+		this.id = id;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+}

--- a/src/test/resources/META-INF/beans.xml
+++ b/src/test/resources/META-INF/beans.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://java.sun.com/xml/ns/javaee" 
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/beans_1_0.xsd">
+</beans>
+

--- a/template.mf
+++ b/template.mf
@@ -7,6 +7,7 @@ Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Export-Template:
  org.springframework.data.couchbase.*;version="${project.version}"
 Import-Template:
+ javax.enterprise.*;version="${cdi:[=.=.=,+1.0.0)}";resolution:=optional,
  com.couchbase.client.*;version="${couchbase:[=.=.=,+1.0.0)}",
  net.spy.memcached.*;version="[2.8.0,3.0.0)",
  com.fasterxml.jackson.*;version="${jackson:[=.=.=,+1.0.0)}",


### PR DESCRIPTION
Initial integration to enable CDI usage of Spring Data Couchbase repositories along with custom repository implementations.

Reference: DATACOUCH-109