### PR TITLE
Fix DATACOUCH-111

### DIFF
--- a/src/main/java/org/springframework/data/couchbase/core/convert/DateConverters.java
+++ b/src/main/java/org/springframework/data/couchbase/core/convert/DateConverters.java
@@ -54,6 +54,8 @@ public final class DateConverters {
     converters.add(CalendarToLongConverter.INSTANCE);
     converters.add(LongToDateConverter.INSTANCE);
     converters.add(LongToCalendarConverter.INSTANCE);
+    converters.add(IntegerToDateConverter.INSTANCE);
+    converters.add(IntegerToCalendarConverter.INSTANCE);
 
     if (JODA_TIME_IS_PRESENT) {
       converters.add(LocalDateToLongConverter.INSTANCE);
@@ -64,6 +66,10 @@ public final class DateConverters {
       converters.add(LongToLocalDateTimeConverter.INSTANCE);
       converters.add(LongToDateTimeConverter.INSTANCE);
       converters.add(LongToDateMidnightConverter.INSTANCE);
+      converters.add(IntegerToLocalDateConverter.INSTANCE);
+      converters.add(IntegerToLocalDateTimeConverter.INSTANCE);
+      converters.add(IntegerToDateTimeConverter.INSTANCE);
+      converters.add(IntegerToDateMidnightConverter.INSTANCE);
     }
 
     return converters;
@@ -117,6 +123,38 @@ public final class DateConverters {
 
       Calendar calendar = Calendar.getInstance();
       calendar.setTimeInMillis(source * 1000);
+      return calendar;
+    }
+  }
+
+  @ReadingConverter
+  public enum IntegerToDateConverter implements Converter<Integer, Date> {
+    INSTANCE;
+
+    @Override
+    public Date convert(Integer source) {
+      if (source == null) {
+        return null;
+      }
+
+      Date date = new Date();
+      date.setTime(new Long(source));
+      return date;
+    }
+  }
+
+  @ReadingConverter
+  public enum IntegerToCalendarConverter implements Converter<Integer, Calendar> {
+    INSTANCE;
+
+    @Override
+    public Calendar convert(Integer source) {
+      if (source == null) {
+        return null;
+      }
+
+      Calendar calendar = Calendar.getInstance();
+      calendar.setTimeInMillis(new Long(source * 1000));
       return calendar;
     }
   }
@@ -198,6 +236,46 @@ public final class DateConverters {
     @Override
     public DateMidnight convert(Long source) {
       return source == null ? null : new DateMidnight(source);
+    }
+  }
+
+  @ReadingConverter
+  public enum IntegerToLocalDateConverter implements Converter<Integer, LocalDate> {
+    INSTANCE;
+
+    @Override
+    public LocalDate convert(Integer source) {
+      return source == null ? null : new LocalDate(new Long(source));
+    }
+  }
+
+  @ReadingConverter
+  public enum IntegerToLocalDateTimeConverter implements Converter<Integer, LocalDateTime> {
+    INSTANCE;
+
+    @Override
+    public LocalDateTime convert(Integer source) {
+      return source == null ? null : new LocalDateTime(new Long(source));
+    }
+  }
+
+  @ReadingConverter
+  public enum IntegerToDateTimeConverter implements Converter<Integer, DateTime> {
+    INSTANCE;
+
+    @Override
+    public DateTime convert(Integer source) {
+      return source == null ? null : new DateTime(new Long(source));
+    }
+  }
+
+  @ReadingConverter
+  public enum IntegerToDateMidnightConverter implements Converter<Integer, DateMidnight> {
+    INSTANCE;
+
+    @Override
+    public DateMidnight convert(Integer source) {
+      return source == null ? null : new DateMidnight(new Long(source));
     }
   }
 


### PR DESCRIPTION
Hi,

Not entirely sure what the protocol is for contributions here, but this is a pretty straightforward fix for https://jira.spring.io/browse/DATACOUCH-111.

The issue is that when `java.util.Date` or `org.joda.time.DateTime` (or similar) are persisted, they are persisted as # of milliseconds since the Unix Epoch. If the date/time in question falls into the range of an `Integer` (any time <= 1970-01-25T20:31:23.647Z), it can't currently be converted back to a date/time when the document is read back from Couchbase.

The following exception is produced: 
```
org.springframework.core.convert.ConverterNotFoundException: No converter found capable of converting from type java.lang.Integer to type org.joda.time.DateTime 
at org.springframework.core.convert.support.GenericConversionService.handleConverterNotFound(GenericConversionService.java:276) ~[spring-core-3.2.9.RELEASE.jar:3.2.9.RELEASE] 
at org.springframework.core.convert.support.GenericConversionService.convert(GenericConversionService.java:171) ~[spring-core-3.2.9.RELEASE.jar:3.2.9.RELEASE] 
at org.springframework.core.convert.support.GenericConversionService.convert(GenericConversionService.java:153) ~[spring-core-3.2.9.RELEASE.jar:3.2.9.RELEASE] 
at org.springframework.data.couchbase.core.convert.MappingCouchbaseConverter.getPotentiallyConvertedSimpleRead(MappingCouchbaseConverter.java:294) ~[spring-data-couchbase-1.1.0.RELEASE.jar:na] 
at org.springframework.data.couchbase.core.convert.MappingCouchbaseConverter.readValue(MappingCouchbaseConverter.java:687) ~[spring-data-couchbase-1.1.0.RELEASE.jar:na] 
at org.springframework.data.couchbase.core.convert.MappingCouchbaseConverter.access$200(MappingCouchbaseConverter.java:51) ~[spring-data-couchbase-1.1.0.RELEASE.jar:na]
....
```

This fixes the issue by providing converters for `Integer`, based off the current converters for `Long`.

I would like to add tests, but was not sure where exactly they should go. I would be happy to add some, given a bit of direction. At any rate, the existing tests pass.

Thanks!