### PR TITLE
DATACOUCH-25 - added TTL support to Couchbase Cache Manager

### DIFF
--- a/src/main/java/org/springframework/data/couchbase/cache/CouchbaseCache.java
+++ b/src/main/java/org/springframework/data/couchbase/cache/CouchbaseCache.java
@@ -42,15 +42,28 @@ public class CouchbaseCache implements Cache {
   private final String name;
   
   /**
+   * TTL value for objects in this cache
    */
   private final int ttl;
+  
+  /**
+   * Construct the cache and pass in the CouchbaseClient instance.
+   *
+   * @param name the name of the cache reference.
+   * @param client the CouchbaseClient instance.
+   */
+  public CouchbaseCache(final String name, final CouchbaseClient client) {
+    this.name = name;
+    this.client = client;
+    this.ttl = 0;
+  }
 
   /**
    * Construct the cache and pass in the CouchbaseClient instance.
    *
    * @param name the name of the cache reference.
    * @param client the CouchbaseClient instance.
-   * @param ttl TTL value for this cache
+   * @param ttl TTL value for objects in this cache
    */
   public CouchbaseCache(final String name, final CouchbaseClient client, int ttl) {
     this.name = name;

--- a/src/main/java/org/springframework/data/couchbase/cache/CouchbaseCache.java
+++ b/src/main/java/org/springframework/data/couchbase/cache/CouchbaseCache.java
@@ -27,6 +27,7 @@ import org.springframework.cache.support.SimpleValueWrapper;
  * @see <a href="http://static.springsource.org/spring/docs/current/spring-framework-reference/html/cache.html">
  *   Official Spring Cache Reference</a>
  * @author Michael Nitschinger
+ * @author Konrad Król
  */
 public class CouchbaseCache implements Cache {
 
@@ -39,16 +40,22 @@ public class CouchbaseCache implements Cache {
    * The name of the cache.
    */
   private final String name;
+  
+  /**
+   */
+  private final int ttl;
 
   /**
    * Construct the cache and pass in the CouchbaseClient instance.
    *
    * @param name the name of the cache reference.
    * @param client the CouchbaseClient instance.
+   * @param ttl TTL value for this cache
    */
-  public CouchbaseCache(final String name, final CouchbaseClient client) {
+  public CouchbaseCache(final String name, final CouchbaseClient client, int ttl) {
     this.name = name;
     this.client = client;
+    this.ttl = ttl;
   }
 
   /**
@@ -67,6 +74,15 @@ public class CouchbaseCache implements Cache {
    */
   public final CouchbaseClient getNativeCache() {
     return client;
+  }
+  
+  /**
+   * Returns the TTL value for this cache.
+   * 
+   * @return TTL value
+   */
+  public final int getTtl() {
+	  return ttl;
   }
 
   /**
@@ -96,7 +112,7 @@ public class CouchbaseCache implements Cache {
   public final void put(final Object key, final Object value) {
     if (value != null) {
       String documentId = key.toString();
-      client.set(documentId, 0, value);
+      client.set(documentId, ttl, value);
     } else {
       evict(key);
     }

--- a/src/main/java/org/springframework/data/couchbase/cache/CouchbaseCacheManager.java
+++ b/src/main/java/org/springframework/data/couchbase/cache/CouchbaseCacheManager.java
@@ -39,6 +39,11 @@ public class CouchbaseCacheManager extends AbstractCacheManager {
    * Holds the reference to all stored CouchbaseClient cache connections.
    */
   private final HashMap<String, CouchbaseClient> clients;
+  
+  /**
+   * Holds the TTL configuration for each cache.
+   */
+  private final HashMap<String, Integer> ttlConfiguration;
 
   /**
    * Construct a new CouchbaseCacheManager.
@@ -47,6 +52,18 @@ public class CouchbaseCacheManager extends AbstractCacheManager {
    */
   public CouchbaseCacheManager(final HashMap<String, CouchbaseClient> clients) {
     this.clients = clients;
+    this.ttlConfiguration = new HashMap<String, Integer>();
+  }
+  
+  /**
+   * Construct a new CouchbaseCacheManager.
+   *
+   * @param clients one ore more CouchbaseClients to reference.
+   * @param ttlConfiguration one or more TTL values (in seconds)
+   */
+  public CouchbaseCacheManager(final HashMap<String, CouchbaseClient> clients, final HashMap<String, Integer> ttlConfiguration) {
+    this.clients = clients;
+    this.ttlConfiguration = ttlConfiguration;
   }
 
   /**
@@ -68,10 +85,24 @@ public class CouchbaseCacheManager extends AbstractCacheManager {
     Collection<Cache> caches = new LinkedHashSet<Cache>();
 
     for (Map.Entry<String, CouchbaseClient> cache : clients.entrySet()) {
-      caches.add(new CouchbaseCache(cache.getKey(), cache.getValue()));
+      caches.add(new CouchbaseCache(cache.getKey(), cache.getValue(), getTtl(cache.getKey())));
     }
 
     return caches;
+  }
+  
+  /**
+   * Returns TTL value for single cache
+   * @param name cache name
+   * @return either the cache TTL value or 0 as a default value
+   */
+  private int getTtl ( Object name ) {
+      Integer expirationTime = ttlConfiguration.get(name);
+      if(expirationTime == null) {
+          expirationTime = 0;
+      }
+      
+      return expirationTime;
   }
 
 }

--- a/src/main/java/org/springframework/data/couchbase/cache/CouchbaseCacheManager.java
+++ b/src/main/java/org/springframework/data/couchbase/cache/CouchbaseCacheManager.java
@@ -32,6 +32,7 @@ import java.util.Map;
  * {@link CouchbaseCacheManager} orchestrates and handles them for the Spring Cache abstraction layer.
  *
  * @author Michael Nitschinger
+ * @author Konrad Król
  */
 public class CouchbaseCacheManager extends AbstractCacheManager {
 

--- a/src/main/java/org/springframework/data/couchbase/cache/CouchbaseCacheManager.java
+++ b/src/main/java/org/springframework/data/couchbase/cache/CouchbaseCacheManager.java
@@ -97,13 +97,9 @@ public class CouchbaseCacheManager extends AbstractCacheManager {
    * @param name cache name
    * @return either the cache TTL value or 0 as a default value
    */
-  private int getTtl ( Object name ) {
+  private int getTtl ( String name ) {
       Integer expirationTime = ttlConfiguration.get(name);
-      if(expirationTime == null) {
-          expirationTime = 0;
-      }
-      
-      return expirationTime;
+      return (expirationTime != null ? expirationTime : 0);
   }
 
 }

--- a/src/test/java/org/springframework/data/couchbase/cache/CouchbaseCacheManagerTests.java
+++ b/src/test/java/org/springframework/data/couchbase/cache/CouchbaseCacheManagerTests.java
@@ -17,9 +17,11 @@
 package org.springframework.data.couchbase.cache;
 
 import com.couchbase.client.CouchbaseClient;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cache.Cache;
 import org.springframework.data.couchbase.TestApplicationConfig;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
@@ -27,6 +29,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import java.util.HashMap;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 /**
  * Verifies the correct functionality of the CouchbaseCacheManager.
@@ -53,7 +56,55 @@ public class CouchbaseCacheManagerTests {
     instances.put("test", client);
 
     CouchbaseCacheManager manager = new CouchbaseCacheManager(instances);
+    manager.afterPropertiesSet();
+    
     assertEquals(instances, manager.getClients());
+    
+    Cache cache = manager.getCache("test");
+    
+    assertNotNull(cache);
+    
+    assertEquals(cache.getClass(), CouchbaseCache.class);
+    assertEquals(((CouchbaseCache) cache).getName(), "test");
+    assertEquals(((CouchbaseCache) cache).getTtl(), 0); // default TTL value
+    assertEquals(((CouchbaseCache) cache).getNativeCache(), client);
+  }
+  
+  /**
+   * Test cache creation with custom TTL values.
+   */
+  @Test
+  public void testCacheInitWithTtl() {
+    HashMap<String, CouchbaseClient> instances = new HashMap<String, CouchbaseClient>();
+    instances.put("cache1", client);
+    instances.put("cache2", client);
+    
+    HashMap<String, Integer> ttlConfiguration = new HashMap<String, Integer>();
+    ttlConfiguration.put("cache1", 100);
+    ttlConfiguration.put("cache2", 200);
+
+    CouchbaseCacheManager manager = new CouchbaseCacheManager(instances, ttlConfiguration);
+    manager.afterPropertiesSet();
+    
+    assertEquals(instances, manager.getClients());
+    
+    Cache cache1 = manager.getCache("cache1");
+    Cache cache2 = manager.getCache("cache2");
+    
+    assertNotNull(cache1);
+    assertNotNull(cache2);
+    
+    assertEquals(cache1.getClass(), CouchbaseCache.class);
+    assertEquals(cache2.getClass(), CouchbaseCache.class);
+    
+    assertEquals(((CouchbaseCache) cache1).getName(), "cache1");
+    assertEquals(((CouchbaseCache) cache2).getName(), "cache2");
+    
+    assertEquals(((CouchbaseCache) cache1).getTtl(), 100);
+    assertEquals(((CouchbaseCache) cache2).getTtl(), 200);
+    
+    assertEquals(((CouchbaseCache) cache1).getNativeCache(), client);
+    assertEquals(((CouchbaseCache) cache2).getNativeCache(), client);
   }
 
 }

--- a/src/test/java/org/springframework/data/couchbase/cache/CouchbaseCacheTests.java
+++ b/src/test/java/org/springframework/data/couchbase/cache/CouchbaseCacheTests.java
@@ -17,6 +17,7 @@
 package org.springframework.data.couchbase.cache;
 
 import com.couchbase.client.CouchbaseClient;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -33,6 +34,7 @@ import static org.junit.Assert.*;
  * Tests the CouchbaseCache class and verifies its functionality.
  *
  * @author Michael Nitschinger
+ * @author Konrad Król
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(classes = TestApplicationConfig.class)
@@ -54,7 +56,7 @@ public class CouchbaseCacheTests {
    */
   @Test
   public void testConstruction() {
-    CouchbaseCache cache = new CouchbaseCache(cacheName, client);
+    CouchbaseCache cache = new CouchbaseCache(cacheName, client, 0);
 
     assertEquals(cacheName, cache.getName());
     assertEquals(client, cache.getNativeCache());
@@ -65,7 +67,7 @@ public class CouchbaseCacheTests {
    */
   @Test
   public void testGetSet() {
-    CouchbaseCache cache = new CouchbaseCache(cacheName, client);
+    CouchbaseCache cache = new CouchbaseCache(cacheName, client, 0);
 
     String key = "couchbase-cache-test";
     String value = "Hello World!";
@@ -78,10 +80,28 @@ public class CouchbaseCacheTests {
     ValueWrapper loaded = cache.get(key);
     assertEquals(value, loaded.get());
   }
+  
+  /**
+   * Verifies set() with TTL value.
+   */
+  @Test
+  public void testSetWithTtl() throws InterruptedException {
+    CouchbaseCache cache = new CouchbaseCache(cacheName, client, 1);
+
+    String key = "couchbase-cache-test";
+    String value = "Hello World!";
+    cache.put(key, value);
+    
+    // wait for TTL to expire (double time of TTL)
+    Thread.sleep(2000);
+
+    String stored = (String) client.get(key);
+    assertNull(stored);
+  }
 
   @Test
   public void testGetSetWithCast() {
-    CouchbaseCache cache = new CouchbaseCache(cacheName, client);
+    CouchbaseCache cache = new CouchbaseCache(cacheName, client, 0);
 
     String key = "couchbase-cache-user";
     User user = new User();
@@ -101,7 +121,7 @@ public class CouchbaseCacheTests {
    */
   @Test
   public void testEvict() throws Exception {
-    CouchbaseCache cache = new CouchbaseCache(cacheName, client);
+    CouchbaseCache cache = new CouchbaseCache(cacheName, client, 0);
 
     String key = "couchbase-cache-test";
     String value = "Hello World!";
@@ -120,7 +140,7 @@ public class CouchbaseCacheTests {
    */
   @Test
   public void testSettingNullAndGetting() {
-    CouchbaseCache cache = new CouchbaseCache(cacheName, client);
+    CouchbaseCache cache = new CouchbaseCache(cacheName, client, 0);
 
     String key = "couchbase-cache-test";
     String value = "Hello World!";

--- a/src/test/java/org/springframework/data/couchbase/cache/CouchbaseCacheTests.java
+++ b/src/test/java/org/springframework/data/couchbase/cache/CouchbaseCacheTests.java
@@ -56,7 +56,7 @@ public class CouchbaseCacheTests {
    */
   @Test
   public void testConstruction() {
-    CouchbaseCache cache = new CouchbaseCache(cacheName, client, 0);
+    CouchbaseCache cache = new CouchbaseCache(cacheName, client);
 
     assertEquals(cacheName, cache.getName());
     assertEquals(client, cache.getNativeCache());
@@ -67,7 +67,7 @@ public class CouchbaseCacheTests {
    */
   @Test
   public void testGetSet() {
-    CouchbaseCache cache = new CouchbaseCache(cacheName, client, 0);
+    CouchbaseCache cache = new CouchbaseCache(cacheName, client);
 
     String key = "couchbase-cache-test";
     String value = "Hello World!";
@@ -86,7 +86,7 @@ public class CouchbaseCacheTests {
    */
   @Test
   public void testSetWithTtl() throws InterruptedException {
-    CouchbaseCache cache = new CouchbaseCache(cacheName, client, 1);
+    CouchbaseCache cache = new CouchbaseCache(cacheName, client, 1); // cache for 1 second
 
     String key = "couchbase-cache-test";
     String value = "Hello World!";
@@ -101,7 +101,7 @@ public class CouchbaseCacheTests {
 
   @Test
   public void testGetSetWithCast() {
-    CouchbaseCache cache = new CouchbaseCache(cacheName, client, 0);
+    CouchbaseCache cache = new CouchbaseCache(cacheName, client);
 
     String key = "couchbase-cache-user";
     User user = new User();
@@ -121,7 +121,7 @@ public class CouchbaseCacheTests {
    */
   @Test
   public void testEvict() throws Exception {
-    CouchbaseCache cache = new CouchbaseCache(cacheName, client, 0);
+    CouchbaseCache cache = new CouchbaseCache(cacheName, client);
 
     String key = "couchbase-cache-test";
     String value = "Hello World!";
@@ -140,7 +140,7 @@ public class CouchbaseCacheTests {
    */
   @Test
   public void testSettingNullAndGetting() {
-    CouchbaseCache cache = new CouchbaseCache(cacheName, client, 0);
+    CouchbaseCache cache = new CouchbaseCache(cacheName, client);
 
     String key = "couchbase-cache-test";
     String value = "Hello World!";


### PR DESCRIPTION
This pull request adds the functionality requested very long time ago, mentioned in this bug: https://jira.spring.io/browse/DATACOUCH-25

These commits updates CouchbaseCacheManager and provides addtional constructor which allows to provide TTL configuration for each cache. There are also JUnit tests that verifies new functionallity.