### PR TITLE
DATACOUCH-126: add the repositoryBaseClass annotation attribute.

### DIFF
--- a/src/main/java/org/springframework/data/couchbase/repository/config/EnableCouchbaseRepositories.java
+++ b/src/main/java/org/springframework/data/couchbase/repository/config/EnableCouchbaseRepositories.java
@@ -19,6 +19,7 @@ package org.springframework.data.couchbase.repository.config;
 import org.springframework.context.annotation.ComponentScan.Filter;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.couchbase.repository.support.CouchbaseRepositoryFactoryBean;
+import org.springframework.data.repository.config.DefaultRepositoryBaseClass;
 
 import java.lang.annotation.*;
 
@@ -81,6 +82,13 @@ public @interface EnableCouchbaseRepositories {
    * @return
    */
   String namedQueriesLocation() default "";
+
+  /**
+   * Configure the repository base class to be used to create repository proxies for this particular configuration.
+   *
+   * @return
+   */
+  Class<?> repositoryBaseClass() default DefaultRepositoryBaseClass.class;
 
 
   /**


### PR DESCRIPTION
The repositoryBaseClass attribute is needed for spring-data-commons 1.4 support.  Without it, an assertion fails while spring is trying to configure the repositories enabled by this annotation.

@see this ticket: https://jira.spring.io/browse/DATACOUCH-126