### PR TITLE
DATACOUCH-129 - Ensure Spring Framework 4.2 compatibility.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ repository style data access layer.
 
 For a comprehensive treatment of all the Spring Data Couchbase features, please refer to:
 
-* the [User Guide](http://static.springsource.org/spring-data/data-couchbase/docs/current/reference/html/)
-* the [JavaDocs](http://static.springsource.org/spring-data/data-couchbase/docs/current/api/) have extensive comments
+* the [User Guide](http://static.springsource.org/spring-data/couchbase/docs/current/reference/html/)
+* the [JavaDocs](http://static.springsource.org/spring-data/couchbase/docs/current/api/) have extensive comments
   in them as well.
 * for more detailed questions, use the [forum](http://forum.springsource.org/forumdisplay.php?f=80).
 

--- a/README.md
+++ b/README.md
@@ -92,8 +92,8 @@ This is an example view for the `findByLastname` method:
 
 ```javascript
 function (doc, meta) {
-  if(doc._class == "com.example.entity.User" && doc.firstname) {
-    emit(doc.firstname, null);
+  if(doc._class == "com.example.entity.User" && doc.lastname) {
+    emit(doc.lastname, null);
   }
 }
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>org.springframework.data</groupId>
   <artifactId>spring-data-couchbase</artifactId>
-  <version>1.4.0.M1</version>
+  <version>1.4.0.BUILD-SNAPSHOT</version>
 
   <name>Spring Data Couchbase</name>
   <description>Spring Data integration for Couchbase</description>

--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
@@ -14,7 +14,7 @@
   <parent>
     <groupId>org.springframework.data.build</groupId>
     <artifactId>spring-data-parent</artifactId>
-    <version>1.7.0.M1</version>
+    <version>1.7.0.BUILD-SNAPSHOT</version>
   </parent>
 
   <properties>
@@ -23,7 +23,7 @@
 
     <couchbase>1.4.7</couchbase>
     <jackson>2.3.2</jackson>
-    <springdata.commons>1.11.0.M1</springdata.commons>
+    <springdata.commons>1.11.0.BUILD-SNAPSHOT</springdata.commons>
     <validation>1.0.0.GA</validation>
   </properties>
 
@@ -123,8 +123,8 @@
 
   <repositories>
     <repository>
-      <id>spring-libs-milestone</id>
-      <url>https://repo.spring.io/libs-milestone</url>
+      <id>spring-libs-snapshot</id>
+      <url>https://repo.spring.io/libs-snapshot</url>
     </repository>
   </repositories>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>org.springframework.data</groupId>
   <artifactId>spring-data-couchbase</artifactId>
-  <version>1.4.0.BUILD-SNAPSHOT</version>
+  <version>1.4.0.DATACOUCH--SNAPSHOT</version>
 
   <name>Spring Data Couchbase</name>
   <description>Spring Data integration for Couchbase</description>

--- a/src/main/java/org/springframework/data/couchbase/core/convert/MappingCouchbaseConverter.java
+++ b/src/main/java/org/springframework/data/couchbase/core/convert/MappingCouchbaseConverter.java
@@ -20,7 +20,7 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
 import org.springframework.core.CollectionFactory;
 import org.springframework.core.convert.ConversionService;
-import org.springframework.core.convert.support.ConversionServiceFactory;
+import org.springframework.core.convert.support.DefaultConversionService;
 import org.springframework.data.convert.EntityInstantiator;
 import org.springframework.data.couchbase.core.mapping.CouchbaseDocument;
 import org.springframework.data.couchbase.core.mapping.CouchbaseList;
@@ -80,7 +80,7 @@ public class MappingCouchbaseConverter extends AbstractCouchbaseConverter
   @SuppressWarnings("deprecation")
   public MappingCouchbaseConverter(final MappingContext<? extends CouchbasePersistentEntity<?>,
     CouchbasePersistentProperty> mappingContext) {
-    super(ConversionServiceFactory.createDefaultConversionService());
+    super(new DefaultConversionService());
 
     this.mappingContext = mappingContext;
     typeMapper = new DefaultCouchbaseTypeMapper(DefaultCouchbaseTypeMapper.DEFAULT_TYPE_KEY);


### PR DESCRIPTION
Removed deprecated (and in 4.2 removed) usage of `ConversionServiceFactory` in `MappingCouchbaseConverter`.

----

This one should be back ported to the Fowler, Evans and even Dijkstra branches if applicable.