### PR TITLE
[SDK2] fix template constructor order + improve tests

### DIFF
--- a/src/integration/java/org/springframework/data/couchbase/IntegrationTestApplicationConfig.java
+++ b/src/integration/java/org/springframework/data/couchbase/IntegrationTestApplicationConfig.java
@@ -1,0 +1,67 @@
+package org.springframework.data.couchbase;
+
+import java.util.Collections;
+import java.util.List;
+
+import com.couchbase.client.java.env.CouchbaseEnvironment;
+import com.couchbase.client.java.env.DefaultCouchbaseEnvironment;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
+import org.springframework.data.couchbase.config.AbstractCouchbaseConfiguration;
+import org.springframework.data.couchbase.core.CouchbaseTemplate;
+import org.springframework.data.couchbase.core.WriteResultChecking;
+
+@Configuration
+public class IntegrationTestApplicationConfig extends AbstractCouchbaseConfiguration {
+
+	@Autowired
+	private Environment springEnv;
+
+	@Bean
+	public String couchbaseAdminUser() {
+		return springEnv.getProperty("couchbase.adminUser", "Administrator");
+	}
+
+	@Bean
+	public String couchbaseAdminPassword() {
+		return springEnv.getProperty("couchbase.adminUser", "password");
+	}
+
+	@Override
+	protected List<String> getBootstrapHosts() {
+		return Collections.singletonList(springEnv.getProperty("couchbase.host", "127.0.0.1"));
+	}
+
+	@Override
+	protected String getBucketName() {
+		return springEnv.getProperty("couchbase.bucket", "default");
+	}
+
+	@Override
+	protected String getBucketPassword() {
+		return springEnv.getProperty("couchbase.password", "");
+	}
+
+
+	//TODO maybe create the bucket if doesn't exist
+
+	@Override
+	protected CouchbaseEnvironment getEnvironment() {
+		return DefaultCouchbaseEnvironment.builder()
+				.connectTimeout(10000)
+				.kvTimeout(10000)
+				.queryTimeout(10000)
+				.viewTimeout(10000)
+				.build();
+	}
+
+	@Override
+	public CouchbaseTemplate couchbaseTemplate() throws Exception {
+		CouchbaseTemplate template = super.couchbaseTemplate();
+		template.setWriteResultChecking(WriteResultChecking.LOG);
+		return template;
+	}
+}

--- a/src/integration/java/org/springframework/data/couchbase/config/CouchbaseTemplateParserIntegrationTests.java
+++ b/src/integration/java/org/springframework/data/couchbase/config/CouchbaseTemplateParserIntegrationTests.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.data.couchbase.config;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.beans.factory.support.BeanDefinitionReader;
+import org.springframework.beans.factory.support.DefaultListableBeanFactory;
+import org.springframework.beans.factory.xml.XmlBeanDefinitionReader;
+import org.springframework.core.io.ClassPathResource;
+
+/**
+ * @author Michael Nitschinger
+ */
+public class CouchbaseTemplateParserIntegrationTests {
+
+	DefaultListableBeanFactory factory;
+	BeanDefinitionReader reader;
+
+	@Before
+	public void setUp() {
+		factory = new DefaultListableBeanFactory();
+		reader = new XmlBeanDefinitionReader(factory);
+	}
+
+	@Test
+	public void readsCouchbaseTemplateAttributesCorrectly() {
+		reader.loadBeanDefinitions(new ClassPathResource("configurations/couchbase-template-bean.xml"));
+
+		BeanDefinition definition = factory.getBeanDefinition("couchbaseTemplate");
+		assertEquals(1, definition.getConstructorArgumentValues().getArgumentCount());
+
+		factory.getBean("couchbaseTemplate");
+	}
+
+	@Test
+	public void readsCouchbaseTemplateWithTranslationServiceAttributesCorrectly() {
+		reader.loadBeanDefinitions(new ClassPathResource("configurations/couchbase-template-with-translation-service-bean.xml"));
+
+		BeanDefinition definition = factory.getBeanDefinition("couchbaseTemplate");
+		assertEquals(2, definition.getConstructorArgumentValues().getArgumentCount());
+
+		factory.getBean("couchbaseTemplate");
+	}
+
+	/**
+	 * Test case for DATACOUCH-47.
+	 */
+	@Test
+	public void allowsMultipleBuckets() {
+		reader.loadBeanDefinitions(new ClassPathResource("configurations/couchbase-multi-bucket-bean.xml"));
+
+		factory.getBean("cb-template-first");
+		factory.getBean("cb-template-second");
+	}
+
+}

--- a/src/integration/java/org/springframework/data/couchbase/core/CouchbaseTemplateTests.java
+++ b/src/integration/java/org/springframework/data/couchbase/core/CouchbaseTemplateTests.java
@@ -47,7 +47,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.OptimisticLockingFailureException;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.annotation.Version;
-import org.springframework.data.couchbase.TestApplicationConfig;
+import org.springframework.data.couchbase.IntegrationTestApplicationConfig;
 import org.springframework.data.couchbase.core.mapping.Document;
 import org.springframework.data.couchbase.core.mapping.Field;
 import org.springframework.test.context.ContextConfiguration;
@@ -58,7 +58,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
  * @author Michael Nitschinger
  */
 @RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration(classes = TestApplicationConfig.class)
+@ContextConfiguration(classes = IntegrationTestApplicationConfig.class)
 @TestExecutionListeners(CouchbaseTemplateViewListener.class)
 public class CouchbaseTemplateTests {
 

--- a/src/integration/java/org/springframework/data/couchbase/monitor/ClientInfoTests.java
+++ b/src/integration/java/org/springframework/data/couchbase/monitor/ClientInfoTests.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.data.couchbase.monitor;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.isEmptyString;
+import static org.hamcrest.core.IsNot.not;
+
+import com.couchbase.client.java.Bucket;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.couchbase.IntegrationTestApplicationConfig;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+/**
+ * @author Michael Nitschinger
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(classes = IntegrationTestApplicationConfig.class)
+public class ClientInfoTests {
+
+	/**
+	 * Contains a reference to the actual CouchbaseClient.
+	 */
+	@Autowired
+	private Bucket client;
+
+	private ClientInfo ci;
+
+	@Before
+	public void setup() throws Exception {
+		ci = new ClientInfo(client);
+	}
+
+	@Test
+	public void hostNames() {
+		String hostnames = ci.getHostNames();
+		assertThat(hostnames, not(isEmptyString()));
+	}
+
+}

--- a/src/integration/java/org/springframework/data/couchbase/monitor/ClusterInfoTests.java
+++ b/src/integration/java/org/springframework/data/couchbase/monitor/ClusterInfoTests.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.data.couchbase.monitor;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThan;
+
+import com.couchbase.client.java.Bucket;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.couchbase.IntegrationTestApplicationConfig;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+/**
+ * @author Michael Nitschinger
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(classes = IntegrationTestApplicationConfig.class)
+public class ClusterInfoTests {
+
+	/**
+	 * Contains a reference to the actual CouchbaseClient.
+	 */
+	@Autowired
+	private Bucket client;
+
+	private ClusterInfo ci;
+
+	@Before
+	public void setup() throws Exception {
+		ci = new ClusterInfo(client);
+	}
+
+	@Test
+	public void totalDiskAssigned() {
+		assertThat(ci.getTotalDiskAssigned(), greaterThan(0L));
+	}
+
+	@Test
+	public void totalRAMUsed() {
+		assertThat(ci.getTotalRAMUsed(), greaterThan(0L));
+	}
+
+}

--- a/src/integration/resources/configurations/couchbase-multi-bucket-bean.xml
+++ b/src/integration/resources/configurations/couchbase-multi-bucket-bean.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:couchbase="http://www.springframework.org/schema/data/couchbase"
+       xmlns:data-repository="http://www.springframework.org/schema/data/repository"
+       xsi:schemaLocation="http://www.springframework.org/schema/data/couchbase http://www.springframework.org/schema/data/couchbase/spring-couchbase.xsd
+		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd http://www.springframework.org/schema/data/repository http://www.springframework.org/schema/data/repository/spring-repository.xsd">
+
+    <couchbase:env/>
+    <couchbase:cluster/>
+
+    <couchbase:bucket id="cb-first"/>
+    <couchbase:bucket id="cb-second"/>
+
+    <couchbase:template id="cb-template-first"  bucket-ref="cb-first" />
+    <couchbase:template id="cb-template-second" bucket-ref="cb-second" />
+</beans>

--- a/src/integration/resources/configurations/couchbase-template-bean.xml
+++ b/src/integration/resources/configurations/couchbase-template-bean.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:couchbase="http://www.springframework.org/schema/data/couchbase"
+       xsi:schemaLocation="http://www.springframework.org/schema/data/couchbase http://www.springframework.org/schema/data/couchbase/spring-couchbase.xsd
+		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+
+    <couchbase:env/>
+    <couchbase:cluster/>
+    <couchbase:bucket/>
+
+    <couchbase:template/>
+
+</beans>

--- a/src/integration/resources/configurations/couchbase-template-with-translation-service-bean.xml
+++ b/src/integration/resources/configurations/couchbase-template-with-translation-service-bean.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:couchbase="http://www.springframework.org/schema/data/couchbase"
+       xsi:schemaLocation="http://www.springframework.org/schema/data/couchbase http://www.springframework.org/schema/data/couchbase/spring-couchbase.xsd
+		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+
+    <couchbase:env/>
+    <couchbase:cluster/>
+    <couchbase:bucket/>
+
+    <couchbase:template translation-service-ref="myCustomTranslationService"/>
+
+    <bean id="myCustomTranslationService" class="org.springframework.data.couchbase.core.convert.translation.JacksonTranslationService"/>
+
+</beans>

--- a/src/main/java/org/springframework/data/couchbase/core/CouchbaseTemplate.java
+++ b/src/main/java/org/springframework/data/couchbase/core/CouchbaseTemplate.java
@@ -92,8 +92,8 @@ public class CouchbaseTemplate implements CouchbaseOperations, ApplicationEventP
 		this(client, null, null);
 	}
 
-	public CouchbaseTemplate(final Bucket client, final CouchbaseConverter converter) {
-		this(client, converter, null);
+	public CouchbaseTemplate(final Bucket client, final TranslationService translationService) {
+		this(client, null, translationService);
 	}
 
 	public CouchbaseTemplate(final Bucket client, final CouchbaseConverter converter,

--- a/src/test/java/org/springframework/data/couchbase/UnitTestApplicationConfig.java
+++ b/src/test/java/org/springframework/data/couchbase/UnitTestApplicationConfig.java
@@ -3,8 +3,14 @@ package org.springframework.data.couchbase;
 import java.util.Collections;
 import java.util.List;
 
+import com.couchbase.client.java.Bucket;
+import com.couchbase.client.java.Cluster;
+import com.couchbase.client.java.CouchbaseBucket;
+import com.couchbase.client.java.CouchbaseCluster;
 import com.couchbase.client.java.env.CouchbaseEnvironment;
 import com.couchbase.client.java.env.DefaultCouchbaseEnvironment;
+import org.mockito.Mock;
+import org.mockito.Mockito;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
@@ -15,47 +21,41 @@ import org.springframework.data.couchbase.core.CouchbaseTemplate;
 import org.springframework.data.couchbase.core.WriteResultChecking;
 
 @Configuration
-public class TestApplicationConfig extends AbstractCouchbaseConfiguration {
-
-	@Autowired
-	private Environment springEnv;
+public class UnitTestApplicationConfig extends AbstractCouchbaseConfiguration {
 
 	@Bean
 	public String couchbaseAdminUser() {
-		return springEnv.getProperty("couchbase.adminUser", "Administrator");
+		return "someLogin";
 	}
 
 	@Bean
 	public String couchbaseAdminPassword() {
-		return springEnv.getProperty("couchbase.adminUser", "password");
+		return "somePassword";
 	}
 
 	@Override
 	protected List<String> getBootstrapHosts() {
-		return Collections.singletonList(springEnv.getProperty("couchbase.host", "127.0.0.1"));
+		return Collections.singletonList("192.1.2.3");
 	}
 
 	@Override
 	protected String getBucketName() {
-		return springEnv.getProperty("couchbase.bucket", "default");
+		return "someBucket";
 	}
 
 	@Override
 	protected String getBucketPassword() {
-		return springEnv.getProperty("couchbase.password", "");
+		return "someBucketPassword";
 	}
 
-
-	//TODO maybe create the bucket if doesn't exist
+	@Override
+	public Cluster couchbaseCluster() throws Exception {
+		return Mockito.mock(CouchbaseCluster.class);
+	}
 
 	@Override
-	protected CouchbaseEnvironment getEnvironment() {
-		return DefaultCouchbaseEnvironment.builder()
-				.connectTimeout(10000)
-				.kvTimeout(10000)
-				.queryTimeout(10000)
-				.viewTimeout(10000)
-				.build();
+	public Bucket couchbaseClient() throws Exception {
+		return Mockito.mock(CouchbaseBucket.class);
 	}
 
 	@Override

--- a/src/test/java/org/springframework/data/couchbase/core/mapping/CustomConvertersTests.java
+++ b/src/test/java/org/springframework/data/couchbase/core/mapping/CustomConvertersTests.java
@@ -34,7 +34,7 @@ import org.springframework.core.convert.converter.Converter;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.convert.ReadingConverter;
 import org.springframework.data.convert.WritingConverter;
-import org.springframework.data.couchbase.TestApplicationConfig;
+import org.springframework.data.couchbase.UnitTestApplicationConfig;
 import org.springframework.data.couchbase.core.convert.CustomConversions;
 import org.springframework.data.couchbase.core.convert.MappingCouchbaseConverter;
 import org.springframework.test.context.ContextConfiguration;
@@ -46,7 +46,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
  * @author Michael Nitschinger
  */
 @RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration(classes = TestApplicationConfig.class)
+@ContextConfiguration(classes = UnitTestApplicationConfig.class)
 public class CustomConvertersTests {
 
 	@Autowired

--- a/src/test/java/org/springframework/data/couchbase/core/mapping/MappingCouchbaseConverterTests.java
+++ b/src/test/java/org/springframework/data/couchbase/core/mapping/MappingCouchbaseConverterTests.java
@@ -42,7 +42,7 @@ import org.springframework.core.convert.converter.Converter;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.convert.ReadingConverter;
 import org.springframework.data.convert.WritingConverter;
-import org.springframework.data.couchbase.TestApplicationConfig;
+import org.springframework.data.couchbase.UnitTestApplicationConfig;
 import org.springframework.data.couchbase.core.convert.CustomConversions;
 import org.springframework.data.couchbase.core.convert.MappingCouchbaseConverter;
 import org.springframework.data.mapping.model.MappingException;
@@ -53,7 +53,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
  * @author Michael Nitschinger
  */
 @RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration(classes = TestApplicationConfig.class)
+@ContextConfiguration(classes = UnitTestApplicationConfig.class)
 public class MappingCouchbaseConverterTests {
 
 	@Autowired


### PR DESCRIPTION
integration tests have been better separated from unit tests (and each have their own configuration).
new integration tests have been put in place for templateParser and monitor classes.