### PR TITLE
[SDK2] findByXXXQuery improvements

### DIFF
--- a/src/main/java/org/springframework/data/couchbase/core/CouchbaseExceptionTranslator.java
+++ b/src/main/java/org/springframework/data/couchbase/core/CouchbaseExceptionTranslator.java
@@ -38,11 +38,13 @@ import com.couchbase.client.java.error.InvalidPasswordException;
 import com.couchbase.client.java.error.RequestTooBigException;
 import com.couchbase.client.java.error.TemporaryFailureException;
 import com.couchbase.client.java.error.TemporaryLockFailureException;
+import com.couchbase.client.java.error.TranscodingException;
 import com.couchbase.client.java.error.ViewDoesNotExistException;
 
 import org.springframework.dao.DataAccessException;
 import org.springframework.dao.DataAccessResourceFailureException;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.dao.DataRetrievalFailureException;
 import org.springframework.dao.DuplicateKeyException;
 import org.springframework.dao.InvalidDataAccessResourceUsageException;
 import org.springframework.dao.QueryTimeoutException;
@@ -113,6 +115,12 @@ public class CouchbaseExceptionTranslator implements PersistenceExceptionTransla
 
 		if ((ex instanceof RuntimeException && ex.getCause() instanceof TimeoutException)) {
 			return new QueryTimeoutException(ex.getMessage(), ex);
+		}
+
+		if (ex instanceof TranscodingException) {
+			//note: the more specific CouchbaseQueryExecutionException should be thrown by the template
+			//when dealing with TranscodingException in the query/n1ql methods.
+			return new DataRetrievalFailureException(ex.getMessage(), ex);
 		}
 
 		// Unable to translate exception, therefore just throw the original!

--- a/src/main/java/org/springframework/data/couchbase/core/CouchbaseQueryExecutionException.java
+++ b/src/main/java/org/springframework/data/couchbase/core/CouchbaseQueryExecutionException.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2012-2015 the original author or authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.data.couchbase.core;
+
+import org.springframework.dao.DataRetrievalFailureException;
+
+/**
+ * An {@link DataRetrievalFailureException} that denotes an error during a query (N1QL).
+ */
+public class CouchbaseQueryExecutionException extends DataRetrievalFailureException {
+
+	public CouchbaseQueryExecutionException(String msg) {
+		super(msg);
+	}
+
+	public CouchbaseQueryExecutionException(String msg, Throwable cause) {
+		super(msg, cause);
+	}
+}

--- a/src/main/java/org/springframework/data/couchbase/core/CouchbaseTemplate.java
+++ b/src/main/java/org/springframework/data/couchbase/core/CouchbaseTemplate.java
@@ -359,7 +359,7 @@ public class CouchbaseTemplate implements CouchbaseOperations, ApplicationEventP
 		final String operationDesc = failOnExist ? "Insert" : failOnMissing ? "Update" : "Upsert";
 
 		final BeanWrapper<Object> beanWrapper = BeanWrapper.create(objectToPersist, converter.getConversionService());
-		CouchbasePersistentEntity<?> persistentEntity = mappingContext.getPersistentEntity(objectToPersist.getClass());
+		final CouchbasePersistentEntity<?> persistentEntity = mappingContext.getPersistentEntity(objectToPersist.getClass());
 		final CouchbasePersistentProperty versionProperty = persistentEntity.getVersionProperty();
 		final Long version = versionProperty != null ? beanWrapper.getProperty(versionProperty, Long.class) : null;
 
@@ -384,7 +384,7 @@ public class CouchbaseTemplate implements CouchbaseOperations, ApplicationEventP
 						storedDoc = client.insert(doc, persistTo, replicateTo);
 					}
 
-					if (storedDoc != null && storedDoc.cas() != 0) {
+					if (persistentEntity.hasVersionProperty() && storedDoc != null && storedDoc.cas() != 0) {
 						//inject new cas into the bean
 						beanWrapper.setProperty(versionProperty, storedDoc.cas());
 						return true;

--- a/src/main/java/org/springframework/data/couchbase/core/CouchbaseTemplate.java
+++ b/src/main/java/org/springframework/data/couchbase/core/CouchbaseTemplate.java
@@ -34,12 +34,12 @@ import com.couchbase.client.java.document.RawJsonDocument;
 import com.couchbase.client.java.error.CASMismatchException;
 import com.couchbase.client.java.query.Query;
 import com.couchbase.client.java.query.QueryResult;
+import com.couchbase.client.java.query.QueryRow;
 import com.couchbase.client.java.view.ViewQuery;
 import com.couchbase.client.java.view.ViewResult;
 import com.couchbase.client.java.view.ViewRow;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import sun.reflect.generics.reflectiveObjects.NotImplementedException;
 
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.ApplicationEventPublisherAware;
@@ -286,9 +286,17 @@ public class CouchbaseTemplate implements CouchbaseOperations, ApplicationEventP
 
 	@Override
 	public <T> List<T> findByN1QL(Query n1ql, Class<T> entityClass) {
-		//TODO find a way of mapping content to T
+		QueryResult queryResult = queryN1QL(n1ql);
+
+		List<QueryRow> allRows = queryResult.allRows();
+		List<T> result = new ArrayList<T>(allRows.size());
+		for (QueryRow row : allRows) {
+			String json = row.value().toString();
+			T decoded = translationService.decodeFragment(json, entityClass);
+			result.add(decoded);
+		}
 		//TODO error handling
-		throw new NotImplementedException();
+		return result;
 	}
 
 	@Override

--- a/src/main/java/org/springframework/data/couchbase/core/convert/translation/JacksonTranslationService.java
+++ b/src/main/java/org/springframework/data/couchbase/core/convert/translation/JacksonTranslationService.java
@@ -236,7 +236,17 @@ public class JacksonTranslationService implements TranslationService, Initializi
 			case VALUE_NULL:
 				return null;
 			default:
-				throw new MappingException("Could not decode primitve value " + token);
+				throw new MappingException("Could not decode primitive value " + token);
+		}
+	}
+
+	@Override
+	public <T> T decodeFragment(String source, Class<T> target) {
+		try {
+			return objectMapper.readValue(source, target);
+		}
+		catch (IOException e) {
+			throw new RuntimeException("Cannot decode ad-hoc JSON", e);
 		}
 	}
 

--- a/src/main/java/org/springframework/data/couchbase/core/convert/translation/TranslationService.java
+++ b/src/main/java/org/springframework/data/couchbase/core/convert/translation/TranslationService.java
@@ -16,6 +16,8 @@
 
 package org.springframework.data.couchbase.core.convert.translation;
 
+import com.couchbase.client.java.query.QueryRow;
+
 import org.springframework.data.couchbase.core.mapping.CouchbaseDocument;
 import org.springframework.data.couchbase.core.mapping.CouchbaseStorable;
 
@@ -42,4 +44,14 @@ public interface TranslationService {
 	 * @return a properly populated document to work with.
 	 */
 	CouchbaseStorable decode(String source, CouchbaseStorable target);
+
+	/**
+	 * Decodes an ad-hoc JSON object into a corresponding "case" class.
+	 *
+	 * @param source the JSON for the ad-hoc JSON object (from a N1QL {@link QueryRow} for instance).
+	 * @param target the target class information.
+	 * @param <T> the target class.
+	 * @return an ad-hoc instance of the decoded JSON into the corresponding "case" class.
+	 */
+	<T> T decodeFragment(String source, Class<T> target);
 }

--- a/src/test/java/org/springframework/data/couchbase/core/convert/translation/JacksonTranslationServiceTests.java
+++ b/src/test/java/org/springframework/data/couchbase/core/convert/translation/JacksonTranslationServiceTests.java
@@ -17,6 +17,7 @@
 package org.springframework.data.couchbase.core.convert.translation;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -35,6 +36,7 @@ public class JacksonTranslationServiceTests {
 	@Before
 	public void setup() {
 		service = new JacksonTranslationService();
+		((JacksonTranslationService) service).afterPropertiesSet();
 	}
 
 	@Test
@@ -51,5 +53,17 @@ public class JacksonTranslationServiceTests {
 		CouchbaseDocument target = new CouchbaseDocument();
 		service.decode(source, target);
 		assertEquals("русский", target.get("language"));
+	}
+
+	@Test
+	public void shouldDecodeAdHocFragment() {
+		String source = "{\"language\":\"french\"}";
+		LanguageFragment f = service.decodeFragment(source, LanguageFragment.class);
+		assertNotNull(f);
+		assertEquals("french", f.language);
+	}
+
+	private static class LanguageFragment {
+		public String language;
 	}
 }


### PR DESCRIPTION
implement findByQuery by allowing TranslationService to unmarshall an adhoc fragment of JSON (the N1QL rows).
added error handling for both findByView and findByQuery.

also fixed the template trying to set a Version field even if no such field is declared in the EntityClass.