### PR TITLE
DATACOUCH-136 - Add @N1QL query annotation.

### DIFF
--- a/src/integration/java/org/springframework/data/couchbase/core/CouchbaseTemplateTests.java
+++ b/src/integration/java/org/springframework/data/couchbase/core/CouchbaseTemplateTests.java
@@ -241,7 +241,7 @@ public class CouchbaseTemplateTests {
 				.where(x("type").eq(s("fullFragment"))
 				.and(x("criteria").gt(1))));
 
-		List<Fragment> fragments = template.findByN1QL(query, Fragment.class);
+		List<Fragment> fragments = template.findByN1QLProjection(query, Fragment.class);
 		assertNotNull(fragments);
 		assertFalse(fragments.isEmpty());
 		assertEquals(1, fragments.size());

--- a/src/integration/java/org/springframework/data/couchbase/repository/SimpleCouchbaseRepositoryTests.java
+++ b/src/integration/java/org/springframework/data/couchbase/repository/SimpleCouchbaseRepositoryTests.java
@@ -27,6 +27,7 @@ import org.junit.runner.RunWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.couchbase.IntegrationTestApplicationConfig;
+import org.springframework.data.couchbase.core.CouchbaseQueryExecutionException;
 import org.springframework.data.couchbase.core.CouchbaseTemplate;
 import org.springframework.data.couchbase.repository.support.CouchbaseRepositoryFactory;
 import org.springframework.data.repository.core.support.RepositoryFactorySupport;
@@ -109,6 +110,27 @@ public class SimpleCouchbaseRepositoryTests {
       assertNotNull(u.getUsername());
     }
     assertEquals(2, size);
+  }
+
+  @Test
+  public void shouldFindByUsernameUsingN1ql() {
+    User user = repository.findByUsername("uname-1");
+    assertNotNull(user);
+    assertEquals("testuser-1", user.getKey());
+    assertEquals("uname-1", user.getUsername());
+  }
+
+  @Test
+  public void shouldFailFindByUsernameWithNoIdOrCas() {
+    try {
+      User user = repository.findByUsernameBadSelect("uname-1");
+      fail("shouldFailFindByUsernameWithNoIdOrCas");
+    } catch (CouchbaseQueryExecutionException e) {
+      assertTrue(e.getMessage().contains("_ID"));
+      assertTrue(e.getMessage().contains("_CAS"));
+    } catch (Exception e) {
+      fail("CouchbaseQueryExecutionException expected");
+    }
   }
 
 }

--- a/src/integration/java/org/springframework/data/couchbase/repository/UserRepository.java
+++ b/src/integration/java/org/springframework/data/couchbase/repository/UserRepository.java
@@ -18,6 +18,7 @@ package org.springframework.data.couchbase.repository;
 
 import com.couchbase.client.java.view.ViewQuery;
 
+import org.springframework.data.couchbase.core.view.N1QL;
 import org.springframework.data.couchbase.core.view.View;
 
 /**
@@ -27,5 +28,11 @@ public interface UserRepository extends CouchbaseRepository<User, String> {
 
   @View(designDocument = "user", viewName = "all")
   Iterable<User> customViewQuery(ViewQuery query);
+
+  @N1QL("$SELECT_ENTITY$ WHERE username = $1")
+  User findByUsername(String username);
+
+  @N1QL("SELECT * FROM $BUCKET$ WHERE username = $1")
+  User findByUsernameBadSelect(String username);
 
 }

--- a/src/main/java/org/springframework/data/couchbase/core/view/N1QL.java
+++ b/src/main/java/org/springframework/data/couchbase/core/view/N1QL.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2012-2015 the original author or authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.data.couchbase.core.view;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.springframework.data.annotation.QueryAnnotation;
+import org.springframework.data.couchbase.core.CouchbaseTemplate;
+
+/**
+ * Annotation to support the use of N1QL queries with Couchbase.
+ *
+ * Using it without parameter will resolve the query from the method name. Providing a value
+ * (an inline N1QL statement) will execute that statement instead.
+ *
+ * In this case, one can use a placeholder notation of {@code ?0}, {@code ?1} and so on.
+ *
+ * Also, the placeholder {@code $BUCKET$} can be used to be replaced by the underlying {@link CouchbaseTemplate}
+ * associated bucket name.
+ *
+ * @author Simon Baslé.
+ */
+@Documented
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@QueryAnnotation
+public @interface N1QL {
+
+    /**
+     * Takes a N1QL statement string to define the actual query to be executed. This one will take precedence over the
+     * method name then.
+     */
+    String value() default "";
+
+}

--- a/src/main/java/org/springframework/data/couchbase/repository/query/AbstractN1qlBasedQuery.java
+++ b/src/main/java/org/springframework/data/couchbase/repository/query/AbstractN1qlBasedQuery.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2012-2015 the original author or authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.data.couchbase.repository.query;
+
+import java.util.Iterator;
+import java.util.List;
+
+import com.couchbase.client.java.document.json.JsonArray;
+import com.couchbase.client.java.query.Query;
+import com.couchbase.client.java.query.QueryParams;
+import com.couchbase.client.java.query.QueryPlan;
+import com.couchbase.client.java.query.Statement;
+
+import org.springframework.data.couchbase.core.CouchbaseOperations;
+import org.springframework.data.repository.query.ParameterAccessor;
+import org.springframework.data.repository.query.ParametersParameterAccessor;
+import org.springframework.data.repository.query.QueryMethod;
+import org.springframework.data.repository.query.RepositoryQuery;
+import org.springframework.data.util.StreamUtils;
+
+/**
+ * Abstract base for all Couchbase {@link RepositoryQuery}. It is in charge of inspecting the parameters
+ * and choosing the correct {@link Query} implementation to use.
+ */
+public abstract class AbstractN1qlBasedQuery implements RepositoryQuery {
+
+  private final CouchbaseQueryMethod queryMethod;
+  private final CouchbaseOperations couchbaseOperations;
+
+  protected AbstractN1qlBasedQuery(CouchbaseQueryMethod queryMethod, CouchbaseOperations couchbaseOperations) {
+    this.queryMethod = queryMethod;
+    this.couchbaseOperations = couchbaseOperations;
+  }
+
+  protected abstract Statement getStatement();
+
+  @Override
+  public Object execute(Object[] parameters) {
+    Statement statement = getStatement();
+
+    ParameterAccessor parameterAccessor = new ParametersParameterAccessor(queryMethod.getParameters(), parameters);
+    Query query = buildQuery(statement, parameterAccessor.iterator());
+    return executeDependingOnType(query, queryMethod, queryMethod.isPageQuery(), queryMethod.isModifyingQuery(),
+        queryMethod.isSliceQuery());
+  }
+
+  protected static Query buildQuery(Statement statement, Iterator<Object> paramIterator) {
+    JsonArray queryValues = JsonArray.create();
+    QueryParams queryParams = null;
+    QueryPlan preparedPayload = null;
+
+    while (paramIterator.hasNext()) {
+      Object next = paramIterator.next();
+      if (next instanceof QueryParams) {
+        queryParams = (QueryParams) next;
+      }
+      else if (next instanceof QueryPlan) {
+        preparedPayload = (QueryPlan) next;
+      }
+      else {
+        queryValues.add(next);
+      }
+    }
+
+    Query query;
+    if (preparedPayload != null) {
+      query = Query.prepared(preparedPayload, queryValues.isEmpty() ? null : queryValues, queryParams);
+    }
+    else if (!queryValues.isEmpty()) {
+      query = Query.parametrized(statement, queryValues, queryParams);
+    }
+    else {
+      query = Query.simple(statement, queryParams);
+    }
+
+    return query;
+  }
+
+  protected Object executeDependingOnType(Query query, QueryMethod queryMethod,
+                                          boolean isPage, boolean isSlice, boolean isModifying) {
+    if (isPage || isSlice || isModifying) {
+      throw new UnsupportedOperationException("Slice, page and modifying queries not yet supported");
+    }
+
+    if (queryMethod.isCollectionQuery()) {
+      return executeCollection(query);
+    } else if (queryMethod.isQueryForEntity()) {
+      return executeEntity(query);
+    } else {
+      return executeStream(query);
+    }
+  }
+
+  protected List<?> executeCollection(Query query) {
+    List<?> result = couchbaseOperations.findByN1QL(query, queryMethod.getEntityInformation().getJavaType());
+    return result;
+  }
+
+  protected Object executeEntity(Query query) {
+    List<?> result = executeCollection(query);
+    return result.isEmpty() ? null : result.get(0);
+  }
+
+  protected Object executeStream(Query query) {
+    return StreamUtils.createStreamFromIterator(executeCollection(query).iterator());
+  }
+
+  @Override
+  public CouchbaseQueryMethod getQueryMethod() {
+    return this.queryMethod;
+  }
+}

--- a/src/main/java/org/springframework/data/couchbase/repository/query/CouchbaseQueryMethod.java
+++ b/src/main/java/org/springframework/data/couchbase/repository/query/CouchbaseQueryMethod.java
@@ -16,19 +16,24 @@
 
 package org.springframework.data.couchbase.repository.query;
 
+import org.springframework.core.annotation.AnnotationUtils;
 import org.springframework.data.couchbase.core.mapping.CouchbasePersistentEntity;
 import org.springframework.data.couchbase.core.mapping.CouchbasePersistentProperty;
+import org.springframework.data.couchbase.core.view.N1QL;
 import org.springframework.data.couchbase.core.view.View;
 import org.springframework.data.mapping.context.MappingContext;
 import org.springframework.data.repository.core.RepositoryMetadata;
 import org.springframework.data.repository.query.QueryMethod;
+import org.springframework.util.StringUtils;
 
 import java.lang.reflect.Method;
 
 /**
- * Represents a query method with couchbase extensions.
+ * Represents a query method with couchbase extensions, allowing to discover
+ * if View-based query or N1QL-based query must be used.
  *
  * @author Michael Nitschinger
+ * @author Simon Baslé
  */
 public class CouchbaseQueryMethod extends QueryMethod {
 
@@ -53,7 +58,7 @@ public class CouchbaseQueryMethod extends QueryMethod {
   }
 
   /**
-   * Returns the @View annoation if set, null otherwise.
+   * Returns the @View annotation if set, null otherwise.
    *
    * @return the view annotation of present.
    */
@@ -61,6 +66,41 @@ public class CouchbaseQueryMethod extends QueryMethod {
     return method.getAnnotation(View.class);
   }
 
+  /**
+   * If the method has a @N1QL annotation.
+   *
+   * @return true if it has the annotation, false otherwise.
+   */
+  public boolean hasN1qlAnnotation() {
+    return getN1qlAnnotation() != null;
+  }
 
+  /**
+   * Returns the @N1QL annotation if set, null otherwise.
+   *
+   * @return the n1ql annotation if present.
+   */
+  public N1QL getN1qlAnnotation() {
+    return method.getAnnotation(N1QL.class);
+  }
 
+  /**
+   * If the method has a @N1QL annotation with an inline N1QL statement inside.
+   *
+   * @return true if this has the annotation and N1QL inline statement, false otherwise.
+   */
+  public boolean hasInlineN1qlQuery() {
+    return getInlineN1qlQuery() != null;
+  }
+
+  /**
+   * Returns the query string declared in a {@link N1QL} annotation or {@literal null} if neither the annotation found
+   * nor the attribute was specified.
+   *
+   * @return the query statement if present.
+   */
+  public String getInlineN1qlQuery() {
+    String query = (String) AnnotationUtils.getValue(getN1qlAnnotation());
+    return StringUtils.hasText(query) ? query : null;
+  }
 }

--- a/src/main/java/org/springframework/data/couchbase/repository/query/StringN1qlBasedQuery.java
+++ b/src/main/java/org/springframework/data/couchbase/repository/query/StringN1qlBasedQuery.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2012-2015 the original author or authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.data.couchbase.repository.query;
+
+import com.couchbase.client.java.query.Query;
+import com.couchbase.client.java.query.Statement;
+
+import org.springframework.data.couchbase.core.CouchbaseOperations;
+import org.springframework.data.repository.query.RepositoryQuery;
+
+/**
+ * A {@link RepositoryQuery} for Couchbase, based on N1QL and a String statement.
+ * The statement can contain placeholders for the {@link #PLACEHOLDER_BUCKET bucket namespace},
+ * the {@link #PLACEHOLDER_ENTITY ID and CAS fields} necessary for entity reconstruction or
+ * a shortcut that covers {@link #PLACEHOLDER_SELECT_FROM SELECT AND FROM clauses}.
+ *
+ * @author Simon Baslé
+ */
+public class StringN1qlBasedQuery extends AbstractN1qlBasedQuery {
+
+  public static final String PLACEHOLDER_SELECT_FROM = "$SELECT_ENTITY$";
+  public static final String PLACEHOLDER_BUCKET = "$BUCKET$";
+  public static final String PLACEHOLDER_ENTITY = "$ENTITY$";
+
+  private final Statement statement;
+
+  public StringN1qlBasedQuery(String statement, CouchbaseQueryMethod queryMethod, CouchbaseOperations couchbaseOperations) {
+    super(queryMethod, couchbaseOperations);
+    this.statement = prepare(statement, couchbaseOperations.getCouchbaseBucket().name());
+  }
+
+  protected static Statement prepare(String statement, String bucketName) {
+    String b = "`" + bucketName + "`";
+    String entity = "META(" + b + ").id AS " + CouchbaseOperations.SELECT_ID +
+        ", META(" + b + ").cas AS " + CouchbaseOperations.SELECT_CAS;
+    String selectEntity = "SELECT " + entity + ", " + b + ".* FROM " + b;
+    String result = statement;
+    if (statement.contains(PLACEHOLDER_SELECT_FROM)) {
+      result = result.replaceFirst("\\$SELECT_ENTITY\\$", selectEntity);
+    } else {
+      if (statement.contains(PLACEHOLDER_BUCKET)) {
+        result = result.replaceAll("\\$BUCKET\\$", b);
+      }
+      if (statement.contains(PLACEHOLDER_ENTITY)) {
+        result = result.replaceFirst("\\$ENTITY\\$", entity);
+      }
+    }
+    return Query.simple(result).statement();
+  }
+
+  @Override
+  public Statement getStatement() {
+    return this.statement;
+  }
+}

--- a/src/main/java/org/springframework/data/couchbase/repository/query/ViewBasedCouchbaseQuery.java
+++ b/src/main/java/org/springframework/data/couchbase/repository/query/ViewBasedCouchbaseQuery.java
@@ -44,6 +44,7 @@ public class ViewBasedCouchbaseQuery implements RepositoryQuery {
     for (Object param : runtimeParams) {
       if (param instanceof ViewQuery) {
         query = (ViewQuery) param;
+        //FIXME clone the ViewQuery and use the @View design / viewname
       } else {
         throw new IllegalStateException("Unknown query param: " + param);
       }

--- a/src/test/java/org/springframework/data/couchbase/UnitTestApplicationConfig.java
+++ b/src/test/java/org/springframework/data/couchbase/UnitTestApplicationConfig.java
@@ -7,15 +7,10 @@ import com.couchbase.client.java.Bucket;
 import com.couchbase.client.java.Cluster;
 import com.couchbase.client.java.CouchbaseBucket;
 import com.couchbase.client.java.CouchbaseCluster;
-import com.couchbase.client.java.env.CouchbaseEnvironment;
-import com.couchbase.client.java.env.DefaultCouchbaseEnvironment;
-import org.mockito.Mock;
 import org.mockito.Mockito;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.core.env.Environment;
 import org.springframework.data.couchbase.config.AbstractCouchbaseConfiguration;
 import org.springframework.data.couchbase.core.CouchbaseTemplate;
 import org.springframework.data.couchbase.core.WriteResultChecking;

--- a/src/test/java/org/springframework/data/couchbase/repository/query/AbstractN1qlBasedQueryTest.java
+++ b/src/test/java/org/springframework/data/couchbase/repository/query/AbstractN1qlBasedQueryTest.java
@@ -1,0 +1,190 @@
+package org.springframework.data.couchbase.repository.query;
+
+import static com.couchbase.client.java.query.Select.select;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import com.couchbase.client.java.document.json.JsonArray;
+import com.couchbase.client.java.document.json.JsonObject;
+import com.couchbase.client.java.query.ParametrizedQuery;
+import com.couchbase.client.java.query.PreparedQuery;
+import com.couchbase.client.java.query.Query;
+import com.couchbase.client.java.query.QueryParams;
+import com.couchbase.client.java.query.QueryPlan;
+import com.couchbase.client.java.query.Select;
+import com.couchbase.client.java.query.SimpleQuery;
+import com.couchbase.client.java.query.Statement;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import org.springframework.data.couchbase.UnitTestApplicationConfig;
+import org.springframework.data.couchbase.core.mapping.CouchbasePersistentEntity;
+import org.springframework.data.couchbase.core.mapping.CouchbasePersistentProperty;
+import org.springframework.data.domain.Page;
+import org.springframework.data.mapping.context.MappingContext;
+import org.springframework.data.repository.core.RepositoryMetadata;
+import org.springframework.data.repository.query.Parameters;
+import org.springframework.data.repository.query.QueryMethod;
+import org.springframework.data.util.ReflectionUtils;
+
+public class AbstractN1qlBasedQueryTest {
+
+  @Test
+  public void testQueryPlanShouldProducePreparedQuery() throws Exception {
+    Statement st = select("*");
+    QueryPlan plan = new QueryPlan(JsonObject.create());
+    List<Object> params = new ArrayList<Object>(2);
+    params.add("test");
+    params.add(plan);
+
+    Query query = AbstractN1qlBasedQuery.buildQuery(st, params.iterator());
+    JsonObject queryObject = query.n1ql();
+    assertTrue(query instanceof PreparedQuery);
+    assertEquals(plan, query.statement());
+    assertNull(query.params());
+    assertNotNull(queryObject.get("args"));
+    assertEquals(1, queryObject.getArray("args").size());
+    assertEquals("test", queryObject.getArray("args").getString(0));
+
+    params.add(QueryParams.build());
+    query = AbstractN1qlBasedQuery.buildQuery(st, params.iterator());
+    assertNotNull(query.params());
+  }
+
+  @Test
+  public void testEmptyArgumentsShouldProduceSimpleQuery() throws Exception {
+    Statement st = select("*");
+    List<Object> params = Collections.emptyList();
+
+    Query query = AbstractN1qlBasedQuery.buildQuery(st, params.iterator());
+    JsonObject queryObject = query.n1ql();
+    assertTrue(query instanceof SimpleQuery);
+    assertEquals(st.toString(), query.statement().toString());
+    assertNull(query.params());
+    assertFalse(queryObject.containsKey("args"));
+  }
+
+  @Test
+  public void testOnlyQueryParamsShouldProduceSimpleQuery() {
+    Statement st = select("*");
+    QueryParams queryParams = QueryParams.build().scanWait(1, TimeUnit.DAYS);
+    List<Object> params = new ArrayList<Object>(1);
+    params.add(queryParams);
+
+    Query query = AbstractN1qlBasedQuery.buildQuery(st, params.iterator());
+    JsonObject queryObject = query.n1ql();
+    assertTrue(query instanceof SimpleQuery);
+    assertEquals(st.toString(), query.statement().toString());
+    assertEquals(queryParams, query.params());
+    assertFalse(queryObject.containsKey("args"));
+  }
+
+  @Test
+  public void testSimpleArgumentsShouldProduceParametrizedQuery() throws Exception {
+    Statement st = select("*");
+    List<Object> params = new ArrayList<Object>(2);
+    params.add(123L);
+    params.add("test");
+
+    Query query = AbstractN1qlBasedQuery.buildQuery(st, params.iterator());
+    JsonObject queryObject = query.n1ql();
+    assertTrue(query instanceof ParametrizedQuery);
+    assertEquals(st.toString(), query.statement().toString());
+    assertNull(query.params());
+    assertTrue(queryObject.containsKey("args"));
+    JsonArray args = queryObject.getArray("args");
+    assertEquals(2, args.size());
+    assertEquals(123L, args.get(0));
+    assertEquals("test", args.get(1));
+  }
+
+  @Test
+  public void testSimpleArgumentsAndQueryParamsShouldProduceParametrizedQuery() throws Exception {
+    Statement st = select("*");
+    QueryParams queryParams = QueryParams.build().withContextId("toto");
+    List<Object> params = new ArrayList<Object>(2);
+    params.add(123L);
+    params.add(queryParams);
+    params.add("test");
+
+    Query query = AbstractN1qlBasedQuery.buildQuery(st, params.iterator());
+    JsonObject queryObject = query.n1ql();
+    assertTrue(query instanceof ParametrizedQuery);
+    assertEquals(st.toString(), query.statement().toString());
+    assertEquals(queryParams, query.params());
+    assertTrue(queryObject.containsKey("args"));
+    JsonArray args = queryObject.getArray("args");
+    assertEquals(2, args.size());
+    assertEquals(123L, args.get(0));
+    assertEquals("test", args.get(1));
+  }
+
+  @Test
+  public void shouldChooseCollectionExecutionWhenCollectionType() {
+    CouchbaseQueryMethod queryMethod = Mockito.mock(CouchbaseQueryMethod.class);
+    Query query = Mockito.mock(Query.class);
+    AbstractN1qlBasedQuery mock = mock(AbstractN1qlBasedQuery.class);
+    when(mock.executeDependingOnType(any(Query.class), any(QueryMethod.class), anyBoolean(), anyBoolean(), anyBoolean()))
+        .thenCallRealMethod();
+    when(queryMethod.isCollectionQuery()).thenReturn(true);
+
+    mock.executeDependingOnType(query, queryMethod, false, false, false);
+    verify(mock).executeCollection(any(Query.class));
+    verify(mock, never()).executeEntity(any(Query.class));
+    verify(mock, never()).executeStream(any(Query.class));
+  }
+
+  @Test
+  public void shouldChooseEntityExecutionWhenEntityType() {
+    CouchbaseQueryMethod queryMethod = Mockito.mock(CouchbaseQueryMethod.class);
+    Query query = Mockito.mock(Query.class);
+    AbstractN1qlBasedQuery mock = mock(AbstractN1qlBasedQuery.class);
+    when(mock.executeDependingOnType(any(Query.class), any(QueryMethod.class), anyBoolean(), anyBoolean(), anyBoolean()))
+        .thenCallRealMethod();
+    when(queryMethod.isQueryForEntity()).thenReturn(true);
+
+    mock.executeDependingOnType(query, queryMethod, false, false, false);
+    verify(mock, never()).executeCollection(any(Query.class));
+    verify(mock).executeEntity(any(Query.class));
+    verify(mock, never()).executeStream(any(Query.class));
+  }
+
+  @Test
+  public void shouldChooseStreamExecutionWhenStreamType() {
+    CouchbaseQueryMethod queryMethod = Mockito.mock(CouchbaseQueryMethod.class);
+    Query query = Mockito.mock(Query.class);
+    AbstractN1qlBasedQuery mock = mock(AbstractN1qlBasedQuery.class);
+    when(mock.executeDependingOnType(any(Query.class), any(QueryMethod.class), anyBoolean(), anyBoolean(), anyBoolean()))
+        .thenCallRealMethod();
+    when(queryMethod.isStreamQuery()).thenReturn(true);
+
+    mock.executeDependingOnType(query, queryMethod, false, false, false);
+    verify(mock, never()).executeCollection(any(Query.class));
+    verify(mock, never()).executeEntity(any(Query.class));
+    verify(mock).executeStream(any(Query.class));
+  }
+
+  @Test
+  public void shouldThrowWhenUnsupportedType() throws NoSuchMethodException {
+    CouchbaseQueryMethod queryMethod = Mockito.mock(CouchbaseQueryMethod.class);
+    Query query = Mockito.mock(Query.class);
+    AbstractN1qlBasedQuery mock = mock(AbstractN1qlBasedQuery.class);
+    when(mock.executeDependingOnType(any(Query.class), any(QueryMethod.class), anyBoolean(), anyBoolean(), anyBoolean()))
+        .thenCallRealMethod();
+
+    try { mock.executeDependingOnType(query, queryMethod, true, false, false); } catch (UnsupportedOperationException e) { }
+    try { mock.executeDependingOnType(query, queryMethod, false, true, false); } catch (UnsupportedOperationException e) { }
+    try { mock.executeDependingOnType(query, queryMethod, false, false, true); } catch (UnsupportedOperationException e) { }
+    verify(mock, never()).executeCollection(any(Query.class));
+    verify(mock, never()).executeEntity(any(Query.class));
+    verify(mock, never()).executeStream(any(Query.class));
+  }
+}

--- a/src/test/java/org/springframework/data/couchbase/repository/query/StringN1QlBasedQueryTest.java
+++ b/src/test/java/org/springframework/data/couchbase/repository/query/StringN1QlBasedQueryTest.java
@@ -1,0 +1,38 @@
+package org.springframework.data.couchbase.repository.query;
+
+import static org.junit.Assert.*;
+import static org.springframework.data.couchbase.repository.query.StringN1qlBasedQuery.PLACEHOLDER_BUCKET;
+import static org.springframework.data.couchbase.repository.query.StringN1qlBasedQuery.PLACEHOLDER_ENTITY;
+import static org.springframework.data.couchbase.repository.query.StringN1qlBasedQuery.PLACEHOLDER_SELECT_FROM;
+
+import com.couchbase.client.java.query.Statement;
+import org.junit.Test;
+
+public class StringN1QlBasedQueryTest {
+
+  @Test
+  public void testReplaceFullSelectPlaceholderOnce() throws Exception {
+    String statement = PLACEHOLDER_SELECT_FROM + " where " + PLACEHOLDER_SELECT_FROM;
+    Statement parsed = StringN1qlBasedQuery.prepare(statement, "B");
+
+    assertEquals("SELECT META(`B`).id AS _ID, META(`B`).cas AS _CAS, `B`.* FROM `B` where "
+        + PLACEHOLDER_SELECT_FROM, parsed.toString());
+  }
+
+  @Test
+  public void testReplaceAllBucketPlaceholder() throws Exception {
+    String statement = "SELECT * FROM " + PLACEHOLDER_BUCKET + " WHERE " + PLACEHOLDER_BUCKET + ".test = 1";
+    Statement parsed = StringN1qlBasedQuery.prepare(statement, "B");
+
+    assertEquals("SELECT * FROM `B` WHERE `B`.test = 1", parsed.toString());
+  }
+
+  @Test
+  public void testReplaceFirstEntityPlaceholder() throws Exception {
+    String statement = "SELECT " + PLACEHOLDER_ENTITY + " FROM b where b.test = 1 and " + PLACEHOLDER_ENTITY;
+    Statement parsed = StringN1qlBasedQuery.prepare(statement, "A");
+
+    assertEquals("SELECT META(`A`).id AS _ID, META(`A`).cas AS _CAS FROM b where b.test = 1 and "
+        + PLACEHOLDER_ENTITY, parsed.toString());
+  }
+}


### PR DESCRIPTION
The annotation allows to execute N1QL queries that are provided inline. For ease of use, one can use the placeholder $SELECT_ENTITY$ instead of writing the SELECT and FROM clauses.

QueryParams passed in as a method parameter will be used to enrich the Query. Other parameters on the annotated method will be used as values for positional placeholders in the statement.

The template's findByN1QL now expect enough data to reconstruct the full CouchbaseDocument (including ID and CAS), the ad hoc version of it has been renamed findByN1QLProjection.