### PR TITLE
NullPointerException on autoboxing

### DIFF
--- a/src/main/java/org/springframework/data/couchbase/core/CouchbaseTemplate.java
+++ b/src/main/java/org/springframework/data/couchbase/core/CouchbaseTemplate.java
@@ -314,7 +314,8 @@ public class CouchbaseTemplate implements CouchbaseOperations, ApplicationEventP
           if (cas == CASResponse.EXISTS) {
             throw new OptimisticLockingFailureException("Saving document with version value failed: " + cas);
           } else {
-            long newCas = casFuture.getCas();
+            Long casValue = casFuture.getCas();
+            long newCas = (casValue == null) ? 0 : casValue.longValue();
             beanWrapper.setProperty(versionProperty, newCas);
             return true;
           }


### PR DESCRIPTION
Getting randomly NullPointerException. Reviwed code - there is one from spring data which can be because of autoboxing.

```java
java.lang.NullPointerException
	at net.spy.memcached.internal.OperationFuture.getCas(OperationFuture.java:226)
	at org.springframework.data.couchbase.core.CouchbaseTemplate$4.doInBucket(CouchbaseTemplate.java:317)
	at org.springframework.data.couchbase.core.CouchbaseTemplate$4.doInBucket(CouchbaseTemplate.java:299)
	at org.springframework.data.couchbase.core.CouchbaseTemplate.execute(CouchbaseTemplate.java:244)
	at org.springframework.data.couchbase.core.CouchbaseTemplate.save(CouchbaseTemplate.java:299)
	at org.springframework.data.couchbase.core.CouchbaseTemplate.save(CouchbaseTemplate.java:149)
	at org.springframework.data.couchbase.repository.support.SimpleCouchbaseRepository.save(SimpleCouchbaseRepository.java:82)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:483)
	at org.springframework.data.repository.core.support.RepositoryFactorySupport$QueryExecutorMethodInterceptor.executeMethodOn(RepositoryFactorySupport.java:416)
	at org.springframework.data.repository.core.support.RepositoryFactorySupport$QueryExecutorMethodInterceptor.doInvoke(RepositoryFactorySupport.java:401)
	at org.springframework.data.repository.core.support.RepositoryFactorySupport$QueryExecutorMethodInterceptor.invoke(RepositoryFactorySupport.java:373)
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:179)
	at org.springframework.data.repository.core.support.RepositoryFactorySupport$DefaultMethodInvokingMethodInterceptor.invoke(RepositoryFactorySupport.java:486)
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:179)
	at org.springframework.data.couchbase.repository.support.ViewPostProcessor$ViewInterceptor.invoke(ViewPostProcessor.java:87)
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:179)
	at org.springframework.aop.interceptor.ExposeInvocationInterceptor.invoke(ExposeInvocationInterceptor.java:92)
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:179)
	at org.springframework.aop.framework.JdkDynamicAopProxy.invoke(JdkDynamicAopProxy.java:207)
	at com.sun.proxy.$Proxy109.save(Unknown Source)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:483)
	at org.springframework.aop.support.AopUtils.invokeJoinpointUsingReflection(AopUtils.java:317)
	at org.springframework.aop.framework.JdkDynamicAopProxy.invoke(JdkDynamicAopProxy.java:201)
	at com.sun.proxy.$Proxy82.save(Unknown Source)
```