### PR TITLE
DATACOUCH-144 - Detect N1QL dependency and fail fast if not available.

### DIFF
--- a/src/integration/java/org/springframework/data/couchbase/config/CouchbaseTemplateParserIntegrationTests.java
+++ b/src/integration/java/org/springframework/data/couchbase/config/CouchbaseTemplateParserIntegrationTests.java
@@ -51,7 +51,7 @@ public class CouchbaseTemplateParserIntegrationTests {
 		reader.loadBeanDefinitions(new ClassPathResource("configurations/couchbase-template-bean.xml"));
 
 		BeanDefinition definition = factory.getBeanDefinition("couchbaseTemplate");
-		assertEquals(1, definition.getConstructorArgumentValues().getArgumentCount());
+		assertEquals(2, definition.getConstructorArgumentValues().getArgumentCount());
 
 		factory.getBean("couchbaseTemplate");
 	}
@@ -61,7 +61,7 @@ public class CouchbaseTemplateParserIntegrationTests {
 		reader.loadBeanDefinitions(new ClassPathResource("configurations/couchbase-template-with-translation-service-bean.xml"));
 
 		BeanDefinition definition = factory.getBeanDefinition("couchbaseTemplate");
-		assertEquals(2, definition.getConstructorArgumentValues().getArgumentCount());
+		assertEquals(3, definition.getConstructorArgumentValues().getArgumentCount());
 
 		factory.getBean("couchbaseTemplate");
 	}

--- a/src/integration/java/org/springframework/data/couchbase/repository/CouchbaseRepositoryViewListener.java
+++ b/src/integration/java/org/springframework/data/couchbase/repository/CouchbaseRepositoryViewListener.java
@@ -23,6 +23,7 @@ import java.util.List;
 import com.couchbase.client.java.Bucket;
 import com.couchbase.client.java.PersistTo;
 import com.couchbase.client.java.ReplicateTo;
+import com.couchbase.client.java.cluster.ClusterInfo;
 import com.couchbase.client.java.view.DefaultView;
 import com.couchbase.client.java.view.DesignDocument;
 import com.couchbase.client.java.view.View;
@@ -40,12 +41,13 @@ public class CouchbaseRepositoryViewListener extends DependencyInjectionTestExec
   @Override
   public void beforeTestClass(final TestContext testContext) throws Exception {
     Bucket client = (Bucket) testContext.getApplicationContext().getBean("couchbaseBucket");
-    populateTestData(client);
+    ClusterInfo clusterInfo = (ClusterInfo) testContext.getApplicationContext().getBean("couchbaseClusterInfo");
+    populateTestData(client, clusterInfo);
     createAndWaitForDesignDocs(client);
   }
 
-  private void populateTestData(final Bucket client) {
-    CouchbaseTemplate template = new CouchbaseTemplate(client);
+  private void populateTestData(final Bucket client, ClusterInfo clusterInfo) {
+    CouchbaseTemplate template = new CouchbaseTemplate(clusterInfo, client);
     for (int i = 0; i < 100; i++) {
       template.save(new User("testuser-" + i, "uname-" + i), PersistTo.MASTER, ReplicateTo.NONE);
     }

--- a/src/integration/java/org/springframework/data/couchbase/repository/QueryDerivationConversionListener.java
+++ b/src/integration/java/org/springframework/data/couchbase/repository/QueryDerivationConversionListener.java
@@ -2,12 +2,12 @@ package org.springframework.data.couchbase.repository;
 
 import java.util.Calendar;
 import java.util.Collections;
-import java.util.Date;
 import java.util.List;
 
 import com.couchbase.client.java.Bucket;
 import com.couchbase.client.java.PersistTo;
 import com.couchbase.client.java.ReplicateTo;
+import com.couchbase.client.java.cluster.ClusterInfo;
 import com.couchbase.client.java.view.DefaultView;
 import com.couchbase.client.java.view.DesignDocument;
 import com.couchbase.client.java.view.View;
@@ -24,12 +24,13 @@ public class QueryDerivationConversionListener extends DependencyInjectionTestEx
   @Override
   public void beforeTestClass(final TestContext testContext) throws Exception {
     Bucket client = (Bucket) testContext.getApplicationContext().getBean("couchbaseBucket");
-    populateTestData(client);
+    ClusterInfo clusterInfo = (ClusterInfo) testContext.getApplicationContext().getBean("couchbaseClusterInfo");
+    populateTestData(client, clusterInfo);
     createAndWaitForDesignDocs(client);
   }
 
-  private void populateTestData(Bucket client) {
-    CouchbaseTemplate template = new CouchbaseTemplate(client);
+  private void populateTestData(Bucket client, ClusterInfo clusterInfo) {
+    CouchbaseTemplate template = new CouchbaseTemplate(clusterInfo, client);
 
     Calendar cal = Calendar.getInstance();
     cal.clear();

--- a/src/integration/java/org/springframework/data/couchbase/repository/SimpleCouchbaseRepositoryListener.java
+++ b/src/integration/java/org/springframework/data/couchbase/repository/SimpleCouchbaseRepositoryListener.java
@@ -22,6 +22,7 @@ import java.util.List;
 import com.couchbase.client.java.Bucket;
 import com.couchbase.client.java.PersistTo;
 import com.couchbase.client.java.ReplicateTo;
+import com.couchbase.client.java.cluster.ClusterInfo;
 import com.couchbase.client.java.view.DefaultView;
 import com.couchbase.client.java.view.DesignDocument;
 import com.couchbase.client.java.view.View;
@@ -38,12 +39,13 @@ public class SimpleCouchbaseRepositoryListener extends DependencyInjectionTestEx
   @Override
   public void beforeTestClass(final TestContext testContext) throws Exception {
     Bucket client = (Bucket) testContext.getApplicationContext().getBean("couchbaseBucket");
-    populateTestData(client);
+    ClusterInfo clusterInfo = (ClusterInfo) testContext.getApplicationContext().getBean("couchbaseClusterInfo");
+    populateTestData(client, clusterInfo);
     createAndWaitForDesignDocs(client);
   }
 
-  private void populateTestData(Bucket client) {
-    CouchbaseTemplate template = new CouchbaseTemplate(client);
+  private void populateTestData(Bucket client, ClusterInfo clusterInfo) {
+    CouchbaseTemplate template = new CouchbaseTemplate(clusterInfo, client);
 
     for (int i = 0; i < 100; i++) {
       User u = new User("testuser-" + i, "uname-" + i);

--- a/src/integration/java/org/springframework/data/couchbase/repository/cdi/CouchbaseClusterInfoProducer.java
+++ b/src/integration/java/org/springframework/data/couchbase/repository/cdi/CouchbaseClusterInfoProducer.java
@@ -19,24 +19,24 @@ package org.springframework.data.couchbase.repository.cdi;
 import javax.enterprise.inject.Produces;
 
 import com.couchbase.client.java.Bucket;
+import com.couchbase.client.java.Cluster;
+import com.couchbase.client.java.CouchbaseCluster;
 import com.couchbase.client.java.cluster.ClusterInfo;
 
 import org.springframework.data.couchbase.core.CouchbaseOperations;
 import org.springframework.data.couchbase.core.CouchbaseTemplate;
 
 /**
- * Produces a {@link CouchbaseOperations} instance for test usage.
+ * Produces a {@link ClusterInfo} instance for test usage.
  *
- * @author Mark Paluch
+ * @author Simon Baslé
  */
-class CouchbaseOperationsProducer {
+class CouchbaseClusterInfoProducer {
 
   @Produces
-  public CouchbaseOperations createCouchbaseOperations(Bucket couchbaseClient, ClusterInfo clusterInfo) throws Exception {
-
-    CouchbaseTemplate couchbaseTemplate = new CouchbaseTemplate(clusterInfo, couchbaseClient);
-
-    return couchbaseTemplate;
+  public ClusterInfo createClusterInfo() throws Exception {
+    Cluster cluster = CouchbaseCluster.create();
+    return cluster.clusterManager("default", "").info();
   }
 
 }

--- a/src/integration/java/org/springframework/data/couchbase/repository/feature/FeatureDetectionRepositoryTests.java
+++ b/src/integration/java/org/springframework/data/couchbase/repository/feature/FeatureDetectionRepositoryTests.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.data.couchbase.repository.feature;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
+
+import com.couchbase.client.java.cluster.ClusterInfo;
+import com.couchbase.client.java.query.Query;
+import com.couchbase.client.java.util.features.CouchbaseFeature;
+import com.couchbase.client.java.util.features.Version;
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.couchbase.core.CouchbaseTemplate;
+import org.springframework.data.couchbase.core.UnsupportedCouchbaseFeatureException;
+import org.springframework.data.couchbase.repository.User;
+import org.springframework.data.couchbase.repository.UserRepository;
+import org.springframework.data.couchbase.repository.support.CouchbaseRepositoryFactory;
+import org.springframework.data.repository.core.support.RepositoryFactorySupport;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+/**
+ * An integration test that validates feature checking with Java Config.
+ *
+ * @author Simon Baslé
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(classes = FeatureDetectionTestApplicationConfig.class)
+public class FeatureDetectionRepositoryTests {
+
+  @Autowired
+  private CouchbaseTemplate template;
+
+  @Autowired
+  private ClusterInfo clusterInfo;
+
+  @Before
+  public void checkClusterInfo() {
+    Assume.assumeTrue(clusterInfo.getMinVersion() == Version.NO_VERSION);
+  }
+
+  @Test
+  public void testN1qlIncompatibleClusterFailsFastForN1qlBasedRepository() throws Exception {
+    RepositoryFactorySupport factory = new CouchbaseRepositoryFactory(template);
+    try {
+      factory.getRepository(UserRepository.class);
+      fail("expected UnsupportedCouchbaseFeatureException");
+    } catch (UnsupportedCouchbaseFeatureException e) {
+      assertEquals(CouchbaseFeature.N1QL, e.getFeature());
+    }
+  }
+
+  @Test
+  public void testN1qlIncompatibleClusterDoesntFailForViewBasedRepository() throws Exception {
+    RepositoryFactorySupport factory = new CouchbaseRepositoryFactory(template);
+    ViewOnlyUserRepository repository = factory.getRepository(ViewOnlyUserRepository.class);
+    assertNotNull(repository);
+  }
+
+  @Test
+  public void testN1qlIncompatibleClusterTemplateFails() {
+    Query query = Query.simple("SELECT * FROM `" + template.getCouchbaseBucket().name() + "`");
+    try {
+      template.findByN1QL(query, User.class);
+      fail("expected findByN1QL to fail with UnsupportedCouchbaseFeatureException");
+    } catch (UnsupportedCouchbaseFeatureException e) {
+      assertEquals(CouchbaseFeature.N1QL, e.getFeature());
+    }
+
+    try {
+      template.findByN1QLProjection(query, User.class);
+      fail("expected findByN1QLProjection to fail with UnsupportedCouchbaseFeatureException");
+    } catch (UnsupportedCouchbaseFeatureException e) {
+      assertEquals(CouchbaseFeature.N1QL, e.getFeature());
+    }
+
+    try {
+      template.queryN1QL(query);
+      fail("expected queryN1QL to fail with UnsupportedCouchbaseFeatureException");
+    } catch (UnsupportedCouchbaseFeatureException e) {
+      assertEquals(CouchbaseFeature.N1QL, e.getFeature());
+    }
+  }
+}

--- a/src/integration/java/org/springframework/data/couchbase/repository/feature/FeatureDetectionTestApplicationConfig.java
+++ b/src/integration/java/org/springframework/data/couchbase/repository/feature/FeatureDetectionTestApplicationConfig.java
@@ -1,0 +1,79 @@
+package org.springframework.data.couchbase.repository.feature;
+
+import java.util.Collections;
+import java.util.List;
+
+import com.couchbase.client.java.cluster.ClusterInfo;
+import com.couchbase.client.java.cluster.DefaultClusterInfo;
+import com.couchbase.client.java.document.json.JsonObject;
+import com.couchbase.client.java.env.CouchbaseEnvironment;
+import com.couchbase.client.java.env.DefaultCouchbaseEnvironment;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
+import org.springframework.data.couchbase.config.AbstractCouchbaseConfiguration;
+import org.springframework.data.couchbase.core.CouchbaseTemplate;
+import org.springframework.data.couchbase.core.WriteResultChecking;
+
+@Configuration
+public class FeatureDetectionTestApplicationConfig extends AbstractCouchbaseConfiguration {
+
+  @Autowired
+  private Environment springEnv;
+
+  @Bean
+  public String couchbaseAdminUser() {
+    return springEnv.getProperty("couchbase.adminUser", "Administrator");
+  }
+
+  @Bean
+  public String couchbaseAdminPassword() {
+    return springEnv.getProperty("couchbase.adminUser", "password");
+  }
+
+  @Override
+  protected List<String> getBootstrapHosts() {
+    return Collections.singletonList(springEnv.getProperty("couchbase.host", "127.0.0.1"));
+  }
+
+  @Override
+  protected String getBucketName() {
+    return springEnv.getProperty("couchbase.bucket", "default");
+  }
+
+  @Override
+  protected String getBucketPassword() {
+    return springEnv.getProperty("couchbase.password", "");
+  }
+
+
+  @Override
+  protected CouchbaseEnvironment getEnvironment() {
+    return DefaultCouchbaseEnvironment.builder()
+        .connectTimeout(10000)
+        .kvTimeout(10000)
+        .queryTimeout(10000)
+        .viewTimeout(10000)
+        .build();
+  }
+
+  @Override
+  public CouchbaseTemplate couchbaseTemplate() throws Exception {
+    CouchbaseTemplate template = super.couchbaseTemplate();
+    template.setWriteResultChecking(WriteResultChecking.LOG);
+    return template;
+  }
+
+  @Override
+  public ClusterInfo couchbaseClusterInfo() throws Exception {
+    return new DefaultClusterInfo(JsonObject.empty());
+  }
+
+  //change the name of the field that will hold type information
+  @Override
+  public String typeKey() {
+    return "javaClass";
+  }
+}

--- a/src/integration/java/org/springframework/data/couchbase/repository/feature/ViewOnlyUserRepository.java
+++ b/src/integration/java/org/springframework/data/couchbase/repository/feature/ViewOnlyUserRepository.java
@@ -1,0 +1,7 @@
+package org.springframework.data.couchbase.repository.feature;
+
+import org.springframework.data.couchbase.repository.User;
+import org.springframework.data.repository.CrudRepository;
+
+public interface ViewOnlyUserRepository extends CrudRepository<User, String> {
+}

--- a/src/integration/resources/configurations/couchbase-multi-bucket-bean.xml
+++ b/src/integration/resources/configurations/couchbase-multi-bucket-bean.xml
@@ -8,6 +8,7 @@
 
     <couchbase:env/>
     <couchbase:cluster/>
+    <couchbase:clusterInfo/>
 
     <couchbase:bucket id="cb-first"/>
     <couchbase:bucket id="cb-second"/>

--- a/src/integration/resources/configurations/couchbase-template-bean.xml
+++ b/src/integration/resources/configurations/couchbase-template-bean.xml
@@ -7,6 +7,7 @@
 
     <couchbase:env/>
     <couchbase:cluster/>
+    <couchbase:clusterInfo/>
     <couchbase:bucket/>
 
     <couchbase:template/>

--- a/src/integration/resources/configurations/couchbase-template-with-translation-service-bean.xml
+++ b/src/integration/resources/configurations/couchbase-template-with-translation-service-bean.xml
@@ -7,6 +7,7 @@
 
     <couchbase:env/>
     <couchbase:cluster/>
+    <couchbase:clusterInfo/>
     <couchbase:bucket/>
 
     <couchbase:template translation-service-ref="myCustomTranslationService"/>

--- a/src/integration/resources/configurations/couchbase-typekey.xml
+++ b/src/integration/resources/configurations/couchbase-typekey.xml
@@ -7,6 +7,7 @@
 
     <couchbase:env/>
     <couchbase:cluster/>
+    <couchbase:clusterInfo/>
     <couchbase:bucket/>
 
     <!--note that the template needs both converter and translation service if you want to customize converter-->

--- a/src/main/asciidoc/configuration.adoc
+++ b/src/main/asciidoc/configuration.adoc
@@ -111,6 +111,10 @@ The library provides a custom namespace that you can use in your XML configurati
       <couchbase:node>127.0.0.1</couchbase:node>
     </couchbase:cluster>
 
+    <!-- This is needed to probe the server for N1QL support -->
+    <!-- Can be either cluster credentials or a bucket credentials -->
+    <couchbase:clusterInfo login="beer-sample" password=""/>
+
     <couchbase:bucket bucketName="beer-sample" bucketPassword=""/>
 </beans:beans>
 ----

--- a/src/main/asciidoc/repository.adoc
+++ b/src/main/asciidoc/repository.adoc
@@ -102,6 +102,8 @@ As of version `4.0`, Couchbase Server ships with a new query language called `N1
 
 Prerequisite is to have a N1QL-compatible cluster and to have created a PRIMARY INDEX on the bucket where the entities will be stored.
 
+WARNING: If it is detected at configuration time that the cluster doesn't support N1QL while there are @N1QL annotated methods or non-annotated methods in your repository interface, a `UnsupportedCouchbaseFeatureException` will be thrown.
+
 Here is an example:
 
 .An extended User repository with N1QL queries

--- a/src/main/asciidoc/template.adoc
+++ b/src/main/asciidoc/template.adoc
@@ -16,6 +16,8 @@ Removing documents through the `remove` methods works exactly the same.
 
 If you want to load documents, you can do that through the `findById` method, which is the fastest and if possible your tool of choice. The find methods for views are `findByView` which converts it into the target entity, but also `queryView` which exposes lower level semantics. Similarly, find methods using N1QL are provided in `findByN1QL` and `queryN1QL`. Additionally, since N1QL allows you to select specific fields in documents (or even across documents using joins), `findByN1QLProjection` will allow you to skip full `Document` conversion and map these fields to an ad-hoc class.
 
+WARNING: If it is detected at runtime that the cluster doesn't support N1QL, these methods will throw a `UnsupportedCouchbaseFeatureException`.
+
 If you really need low-level semantics, the `couchbaseBucket` is also always in scope through `getCouchbaseBucket()`.
 
 [[couchbase.template.xml]]
@@ -35,6 +37,7 @@ The template can be configured via xml, including setting a custom `TranslationS
 
     <couchbase:env/>
     <couchbase:cluster/>
+    <couchbase:clusterInfo/>
     <couchbase:bucket/>
 
     <couchbase:template translation-service-ref="myCustomTranslationService"/>
@@ -44,4 +47,6 @@ The template can be configured via xml, including setting a custom `TranslationS
 </beans>
 ----
 ====
+
+NOTE: In the example above most tags assume their default values, that is a localhost cluster and bucket "default". In production you would have to also provide specifics to these tags.
 

--- a/src/main/java/org/springframework/data/couchbase/config/AbstractCouchbaseConfiguration.java
+++ b/src/main/java/org/springframework/data/couchbase/config/AbstractCouchbaseConfiguration.java
@@ -24,6 +24,7 @@ import java.util.Set;
 import com.couchbase.client.java.Bucket;
 import com.couchbase.client.java.Cluster;
 import com.couchbase.client.java.CouchbaseCluster;
+import com.couchbase.client.java.cluster.ClusterInfo;
 import com.couchbase.client.java.env.CouchbaseEnvironment;
 import com.couchbase.client.java.env.DefaultCouchbaseEnvironment;
 
@@ -116,6 +117,11 @@ public abstract class AbstractCouchbaseConfiguration {
     return CouchbaseCluster.create(couchbaseEnvironment(), getBootstrapHosts());
   }
 
+  @Bean(name = BeanNames.COUCHBASE_CLUSTER_INFO)
+  public ClusterInfo couchbaseClusterInfo() throws Exception {
+    return couchbaseCluster().clusterManager(getBucketName(), getBucketPassword()).info();
+  }
+
   /**
    * Return the {@link Bucket} instance to connect to.
    *
@@ -134,7 +140,7 @@ public abstract class AbstractCouchbaseConfiguration {
    */
   @Bean(name = BeanNames.COUCHBASE_TEMPLATE)
   public CouchbaseTemplate couchbaseTemplate() throws Exception {
-    return new CouchbaseTemplate(couchbaseClient(), mappingCouchbaseConverter(), translationService());
+    return new CouchbaseTemplate(couchbaseClusterInfo(), couchbaseClient(), mappingCouchbaseConverter(), translationService());
   }
 
   /**

--- a/src/main/java/org/springframework/data/couchbase/config/BeanNames.java
+++ b/src/main/java/org/springframework/data/couchbase/config/BeanNames.java
@@ -48,4 +48,8 @@ class BeanNames {
    */
   static final String TRANSLATION_SERVICE = "couchbaseTranslationService";
 
+  /**
+   * Refers to the "&lt;couchbase:clusterInfo&gt;" bean
+   */
+  static final String COUCHBASE_CLUSTER_INFO = "couchbaseClusterInfo";
 }

--- a/src/main/java/org/springframework/data/couchbase/config/CouchbaseClusterInfoFactoryBean.java
+++ b/src/main/java/org/springframework/data/couchbase/config/CouchbaseClusterInfoFactoryBean.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2012-2015 the original author or authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.data.couchbase.config;
+
+import com.couchbase.client.java.Cluster;
+import com.couchbase.client.java.cluster.ClusterInfo;
+
+import org.springframework.beans.factory.config.AbstractFactoryBean;
+import org.springframework.dao.DataAccessException;
+import org.springframework.dao.support.PersistenceExceptionTranslator;
+import org.springframework.data.couchbase.core.CouchbaseExceptionTranslator;
+
+/**
+ * The Factory Bean to help {@link CouchbaseClusterInfoParser} constructing a {@link ClusterInfo} from a given
+ * {@link Cluster} reference.
+ *
+ * @author Simon Baslé
+ */
+public class CouchbaseClusterInfoFactoryBean extends AbstractFactoryBean<ClusterInfo> implements PersistenceExceptionTranslator {
+
+  private final Cluster cluster;
+  private final String login;
+  private final String password;
+
+  private final PersistenceExceptionTranslator exceptionTranslator = new CouchbaseExceptionTranslator();
+
+  public CouchbaseClusterInfoFactoryBean(Cluster cluster, String login, String password) {
+    this.cluster = cluster;
+    this.login = login;
+    this.password = password;
+  }
+
+  @Override
+  public Class<?> getObjectType() {
+    return ClusterInfo.class;
+  }
+
+  @Override
+  protected ClusterInfo createInstance() throws Exception {
+    return cluster.clusterManager(login, password).info();
+  }
+
+  @Override
+  public DataAccessException translateExceptionIfPossible(RuntimeException ex) {
+    return exceptionTranslator.translateExceptionIfPossible(ex);
+  }
+}

--- a/src/main/java/org/springframework/data/couchbase/config/CouchbaseNamespaceHandler.java
+++ b/src/main/java/org/springframework/data/couchbase/config/CouchbaseNamespaceHandler.java
@@ -39,6 +39,7 @@ public class CouchbaseNamespaceHandler extends NamespaceHandlerSupport {
     registerBeanDefinitionParser("repositories", new RepositoryBeanDefinitionParser(extension));
     registerBeanDefinitionParser("env", new CouchbaseEnvironmentParser());
     registerBeanDefinitionParser("cluster", new CouchbaseClusterParser());
+    registerBeanDefinitionParser("clusterInfo", new CouchbaseClusterInfoParser());
     registerBeanDefinitionParser("bucket", new CouchbaseBucketParser());
     registerBeanDefinitionParser("jmx", new CouchbaseJmxParser());
     registerBeanDefinitionParser("template", new CouchbaseTemplateParser());

--- a/src/main/java/org/springframework/data/couchbase/core/CouchbaseOperations.java
+++ b/src/main/java/org/springframework/data/couchbase/core/CouchbaseOperations.java
@@ -23,6 +23,7 @@ import java.util.List;
 import com.couchbase.client.java.Bucket;
 import com.couchbase.client.java.PersistTo;
 import com.couchbase.client.java.ReplicateTo;
+import com.couchbase.client.java.cluster.ClusterInfo;
 import com.couchbase.client.java.query.Query;
 import com.couchbase.client.java.query.QueryParams;
 import com.couchbase.client.java.query.QueryResult;
@@ -327,6 +328,13 @@ public interface CouchbaseOperations {
    * @return the client used for the template.
    */
   Bucket getCouchbaseBucket();
+
+  /**
+   * Returns the {@link ClusterInfo} about the cluster linked to this template.
+   *
+   * @return the info about the cluster the template connects to.
+   */
+  ClusterInfo getCouchbaseClusterInfo();
 
   /**
    * Returns the underlying {@link CouchbaseConverter}.

--- a/src/main/java/org/springframework/data/couchbase/core/UnsupportedCouchbaseFeatureException.java
+++ b/src/main/java/org/springframework/data/couchbase/core/UnsupportedCouchbaseFeatureException.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2012-2015 the original author or authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.data.couchbase.core;
+
+import com.couchbase.client.java.util.features.CouchbaseFeature;
+
+import org.springframework.dao.InvalidDataAccessApiUsageException;
+import org.springframework.dao.NonTransientDataAccessException;
+
+/**
+ * A {@link NonTransientDataAccessException} that denotes that a particular feature is expected
+ * on the server side but is not available.
+ */
+public class UnsupportedCouchbaseFeatureException extends InvalidDataAccessApiUsageException {
+
+  private final CouchbaseFeature feature;
+
+  public UnsupportedCouchbaseFeatureException(String msg, CouchbaseFeature feature) {
+    super(msg);
+    this.feature = feature;
+  }
+
+  public UnsupportedCouchbaseFeatureException(String msg, CouchbaseFeature feature, Throwable cause) {
+    super(msg, cause);
+    this.feature = feature;
+  }
+
+  /**
+   * @return the {@link CouchbaseFeature} that was missing (could be null if not
+   * a registered CouchbaseFeature, in which case see {@link #getMessage()}).
+   */
+  public CouchbaseFeature getFeature() {
+    return feature;
+  }
+}

--- a/src/main/java/org/springframework/data/couchbase/repository/query/ViewBasedCouchbaseQuery.java
+++ b/src/main/java/org/springframework/data/couchbase/repository/query/ViewBasedCouchbaseQuery.java
@@ -19,6 +19,7 @@ package org.springframework.data.couchbase.repository.query;
 import java.util.List;
 
 import com.couchbase.client.java.document.json.JsonObject;
+import com.couchbase.client.java.view.Stale;
 import com.couchbase.client.java.view.ViewQuery;
 import com.couchbase.client.java.view.ViewResult;
 import com.couchbase.client.java.view.ViewRow;

--- a/src/main/java/org/springframework/data/couchbase/repository/support/CouchbaseRepositoryFactoryBean.java
+++ b/src/main/java/org/springframework/data/couchbase/repository/support/CouchbaseRepositoryFactoryBean.java
@@ -16,13 +16,13 @@
 
 package org.springframework.data.couchbase.repository.support;
 
+import java.io.Serializable;
+
 import org.springframework.data.couchbase.core.CouchbaseOperations;
 import org.springframework.data.repository.Repository;
 import org.springframework.data.repository.core.support.RepositoryFactoryBeanSupport;
 import org.springframework.data.repository.core.support.RepositoryFactorySupport;
 import org.springframework.util.Assert;
-
-import java.io.Serializable;
 
 /**
  * The factory bean to create repositories.

--- a/src/main/resources/org/springframework/data/couchbase/config/spring-couchbase-2.0.xsd
+++ b/src/main/resources/org/springframework/data/couchbase/config/spring-couchbase-2.0.xsd
@@ -42,12 +42,37 @@
         </xsd:complexType>
     </xsd:element>
 
+    <xsd:element name="clusterInfo">
+        <xsd:complexType>
+            <xsd:complexContent>
+                <xsd:extension base="beans:identifiedType">
+                    <xsd:attribute name="cluster-ref" type="xsd:string" use="optional"/>
+                    <!-- note that login/password can be a bucketName and bucketPassword -->
+                    <xsd:attribute name="login" type="xsd:string" use="optional"/>
+                    <xsd:attribute name="password" type="xsd:string" use="optional"/>
+                </xsd:extension>
+            </xsd:complexContent>
+        </xsd:complexType>
+    </xsd:element>
+
     <xsd:element name="template">
         <xsd:complexType>
             <xsd:attribute name="id" type="xsd:string" use="optional">
                 <xsd:annotation>
                     <xsd:documentation><![CDATA[
 The id of the couchbase definition (by default "couchbaseFactory").]]></xsd:documentation>
+                </xsd:annotation>
+            </xsd:attribute>
+            <xsd:attribute name="clusterInfo-ref" type="xsd:string" use="optional">
+                <xsd:annotation>
+                    <xsd:documentation>
+                        The reference to a ClusterInfo object giving information about the cluster this template connects to.
+                    </xsd:documentation>
+                    <xsd:appinfo>
+                        <tool:annotation kind="ref">
+                            <tool:assignable-to type="com.couchbase.client.java.cluster.ClusterInfo"/>
+                        </tool:annotation>
+                    </xsd:appinfo>
                 </xsd:annotation>
             </xsd:attribute>
             <xsd:attribute name="bucket-ref" type="xsd:string" use="optional">

--- a/src/test/java/org/springframework/data/couchbase/UnitTestApplicationConfig.java
+++ b/src/test/java/org/springframework/data/couchbase/UnitTestApplicationConfig.java
@@ -1,5 +1,7 @@
 package org.springframework.data.couchbase;
 
+import static org.mockito.Mockito.when;
+
 import java.util.Collections;
 import java.util.List;
 
@@ -7,6 +9,10 @@ import com.couchbase.client.java.Bucket;
 import com.couchbase.client.java.Cluster;
 import com.couchbase.client.java.CouchbaseBucket;
 import com.couchbase.client.java.CouchbaseCluster;
+import com.couchbase.client.java.cluster.ClusterInfo;
+import com.couchbase.client.java.cluster.DefaultClusterInfo;
+import com.couchbase.client.java.util.features.CouchbaseFeature;
+import com.couchbase.client.java.util.features.Version;
 import org.mockito.Mockito;
 
 import org.springframework.context.annotation.Bean;
@@ -18,45 +24,53 @@ import org.springframework.data.couchbase.core.WriteResultChecking;
 @Configuration
 public class UnitTestApplicationConfig extends AbstractCouchbaseConfiguration {
 
-	@Bean
-	public String couchbaseAdminUser() {
-		return "someLogin";
-	}
+  @Bean
+  public String couchbaseAdminUser() {
+    return "someLogin";
+  }
 
-	@Bean
-	public String couchbaseAdminPassword() {
-		return "somePassword";
-	}
+  @Bean
+  public String couchbaseAdminPassword() {
+    return "somePassword";
+  }
 
-	@Override
-	protected List<String> getBootstrapHosts() {
-		return Collections.singletonList("192.1.2.3");
-	}
+  @Override
+  protected List<String> getBootstrapHosts() {
+    return Collections.singletonList("192.1.2.3");
+  }
 
-	@Override
-	protected String getBucketName() {
-		return "someBucket";
-	}
+  @Override
+  protected String getBucketName() {
+    return "someBucket";
+  }
 
-	@Override
-	protected String getBucketPassword() {
-		return "someBucketPassword";
-	}
+  @Override
+  protected String getBucketPassword() {
+    return "someBucketPassword";
+  }
 
-	@Override
-	public Cluster couchbaseCluster() throws Exception {
-		return Mockito.mock(CouchbaseCluster.class);
-	}
+  @Override
+  public Cluster couchbaseCluster() throws Exception {
+    return Mockito.mock(CouchbaseCluster.class);
+  }
 
-	@Override
-	public Bucket couchbaseClient() throws Exception {
-		return Mockito.mock(CouchbaseBucket.class);
-	}
+  @Override
+  public ClusterInfo couchbaseClusterInfo() {
+    DefaultClusterInfo mock = Mockito.mock(DefaultClusterInfo.class);
+    when(mock.checkAvailable(CouchbaseFeature.N1QL)).thenReturn(true);
+    when(mock.getMinVersion()).thenReturn(new Version(4, 0, 0));
+    return mock;
+  }
 
-	@Override
-	public CouchbaseTemplate couchbaseTemplate() throws Exception {
-		CouchbaseTemplate template = super.couchbaseTemplate();
-		template.setWriteResultChecking(WriteResultChecking.LOG);
-		return template;
-	}
+  @Override
+  public Bucket couchbaseClient() throws Exception {
+    return Mockito.mock(CouchbaseBucket.class);
+  }
+
+  @Override
+  public CouchbaseTemplate couchbaseTemplate() throws Exception {
+    CouchbaseTemplate template = super.couchbaseTemplate();
+    template.setWriteResultChecking(WriteResultChecking.LOG);
+    return template;
+  }
 }


### PR DESCRIPTION
Detect N1QL is not available at configuration time for the repositories and at runtime for the template. This throws a UnsupportedCouchbaseFeatureException.

The ClusterInfo is captured at bootstrap and used to determine if the feature is available. The xml configuration will need the ClusterInfo-related credentials to be provided explicitly.