### PR TITLE
DATACOUCH-156 - Make generated N1QL queries filter on the type field.

### DIFF
--- a/src/integration/java/org/springframework/data/couchbase/repository/Item.java
+++ b/src/integration/java/org/springframework/data/couchbase/repository/Item.java
@@ -1,0 +1,38 @@
+package org.springframework.data.couchbase.repository;
+
+import com.couchbase.client.java.repository.annotation.Field;
+
+import org.springframework.data.annotation.Id;
+
+public class Item {
+
+  @Id
+  public String id;
+
+  @Field("desc")
+  public String description;
+
+  public Item(String id, String description) {
+    this.id = id;
+    this.description = description;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+
+    Item item = (Item) o;
+
+    if (!id.equals(item.id)) return false;
+    return !(description != null ? !description.equals(item.description) : item.description != null);
+
+  }
+
+  @Override
+  public int hashCode() {
+    int result = id.hashCode();
+    result = 31 * result + (description != null ? description.hashCode() : 0);
+    return result;
+  }
+}

--- a/src/integration/java/org/springframework/data/couchbase/repository/ItemRepository.java
+++ b/src/integration/java/org/springframework/data/couchbase/repository/ItemRepository.java
@@ -1,0 +1,10 @@
+package org.springframework.data.couchbase.repository;
+
+import java.util.List;
+
+import org.springframework.data.repository.CrudRepository;
+
+public interface ItemRepository extends CrudRepository<Item, String> {
+
+  List<Object> findAllByDescriptionNotNull();
+}

--- a/src/integration/java/org/springframework/data/couchbase/repository/PartyRepository.java
+++ b/src/integration/java/org/springframework/data/couchbase/repository/PartyRepository.java
@@ -17,6 +17,6 @@ public interface PartyRepository extends CouchbaseRepository<Party, String> {
   @View(designDocument = "party", viewName = "byDate")
   List<Party> findFirst3ByEventDateGreaterThanEqual(Date targetDate);
 
-  List<Party> findAllByDescriptionNotNull();
+  List<Object> findAllByDescriptionNotNull();
 
 }

--- a/src/main/asciidoc/repository.adoc
+++ b/src/main/asciidoc/repository.adoc
@@ -112,7 +112,7 @@ Here is an example:
 ----
 public interface UserRepository extends CrudRepository<UserInfo, String> {
 
-    @Query("$SELECT_ENTITY$ WHERE role = 'admin'")
+    @Query("$SELECT_ENTITY$ WHERE role = 'admin' AND $FILTER_TYPE$")
     List<UserInfo> findAllAdmins();
 
     List<UserInfo> findByFirstname(String fname);
@@ -122,9 +122,14 @@ public interface UserRepository extends CrudRepository<UserInfo, String> {
 
 Here we see two N1QL-backed ways of querying.
 
-The first one uses the `Query` annotation to provide a N1QL statement inline. Notice the special placeholder `$SELECT_ENTITY` which allows to easily make sure the statement will select all the fields necessary to build the full entity (including document ID and CAS value).
+The first one uses the `Query` annotation to provide a N1QL statement inline. Notice the special placeholders:
+
+ - `$SELECT_ENTITY` allows to easily make sure the statement will select all the fields necessary to build the full entity (including document ID and CAS value).
+ - `$FILTER_TYPE$` in the WHERE clause adds a criteria matching the entity type with the field that Spring Data uses to store type information.
 
 The second one use Spring-Data's query derivation mechanism to build a N1QL query from the method name and parameters. This will produce a query looking like this: `SELECT ... FROM ... WHERE firstName = "valueOfFnameAtRuntime"`. You can combine these criteria, even do a count with a name like `countByFirstname` or a limit with a name like `findFirst3ByLastname`...
+
+NOTE: Actually the generated N1QL query will also contain an additional N1QL criteria in order to only select documents that match the repository's entity class.
 
 Most Spring-Data keywords are supported:
 .Supported keywords inside @Query (N1QL) method names

--- a/src/main/java/org/springframework/data/couchbase/core/convert/CouchbaseConverter.java
+++ b/src/main/java/org/springframework/data/couchbase/core/convert/CouchbaseConverter.java
@@ -51,4 +51,9 @@ public interface CouchbaseConverter
    * @see #convertForWriteIfNeeded(Object)
    */
   Class<?> getWriteClassFor(Class<?> clazz);
+
+  /**
+   * @return the name of the field that will hold type information.
+   */
+  String getTypeKey();
 }

--- a/src/main/java/org/springframework/data/couchbase/core/convert/MappingCouchbaseConverter.java
+++ b/src/main/java/org/springframework/data/couchbase/core/convert/MappingCouchbaseConverter.java
@@ -130,9 +130,7 @@ public class MappingCouchbaseConverter extends AbstractCouchbaseConverter
     return mappingContext;
   }
 
-  /**
-   * @return the name of the field that will hold type information.
-   */
+  @Override
   public String getTypeKey() {
     return typeMapper.getTypeKey();
   }

--- a/src/main/java/org/springframework/data/couchbase/repository/query/PartTreeN1qlBasedQuery.java
+++ b/src/main/java/org/springframework/data/couchbase/repository/query/PartTreeN1qlBasedQuery.java
@@ -61,7 +61,8 @@ public class PartTreeN1qlBasedQuery extends AbstractN1qlBasedQuery {
     }
     WherePath selectFrom = select.from(bucket);
 
-    N1qlQueryCreator queryCreator = new N1qlQueryCreator(partTree, accessor, selectFrom, getCouchbaseOperations().getConverter());
+    N1qlQueryCreator queryCreator = new N1qlQueryCreator(partTree, accessor, selectFrom,
+        getCouchbaseOperations().getConverter(), getQueryMethod());
     LimitPath selectFromWhereOrderBy = queryCreator.createQuery();
 
     if (partTree.isLimiting()) {

--- a/src/test/java/org/springframework/data/couchbase/repository/query/StringN1QlBasedQueryTest.java
+++ b/src/test/java/org/springframework/data/couchbase/repository/query/StringN1QlBasedQueryTest.java
@@ -1,9 +1,7 @@
 package org.springframework.data.couchbase.repository.query;
 
 import static org.junit.Assert.*;
-import static org.springframework.data.couchbase.repository.query.StringN1qlBasedQuery.PLACEHOLDER_BUCKET;
-import static org.springframework.data.couchbase.repository.query.StringN1qlBasedQuery.PLACEHOLDER_ENTITY;
-import static org.springframework.data.couchbase.repository.query.StringN1qlBasedQuery.PLACEHOLDER_SELECT_FROM;
+import static org.springframework.data.couchbase.repository.query.StringN1qlBasedQuery.*;
 
 import com.couchbase.client.java.query.Statement;
 import org.junit.Test;
@@ -13,7 +11,7 @@ public class StringN1QlBasedQueryTest {
   @Test
   public void testReplaceFullSelectPlaceholderOnce() throws Exception {
     String statement = PLACEHOLDER_SELECT_FROM + " where " + PLACEHOLDER_SELECT_FROM;
-    Statement parsed = StringN1qlBasedQuery.prepare(statement, "B");
+    Statement parsed = StringN1qlBasedQuery.prepare(statement, "B", "_class", String.class);
 
     assertEquals("SELECT META(`B`).id AS _ID, META(`B`).cas AS _CAS, `B`.* FROM `B` where "
         + PLACEHOLDER_SELECT_FROM, parsed.toString());
@@ -22,7 +20,7 @@ public class StringN1QlBasedQueryTest {
   @Test
   public void testReplaceAllBucketPlaceholder() throws Exception {
     String statement = "SELECT * FROM " + PLACEHOLDER_BUCKET + " WHERE " + PLACEHOLDER_BUCKET + ".test = 1";
-    Statement parsed = StringN1qlBasedQuery.prepare(statement, "B");
+    Statement parsed = StringN1qlBasedQuery.prepare(statement, "B", "_class", String.class);
 
     assertEquals("SELECT * FROM `B` WHERE `B`.test = 1", parsed.toString());
   }
@@ -30,9 +28,18 @@ public class StringN1QlBasedQueryTest {
   @Test
   public void testReplaceFirstEntityPlaceholder() throws Exception {
     String statement = "SELECT " + PLACEHOLDER_ENTITY + " FROM b where b.test = 1 and " + PLACEHOLDER_ENTITY;
-    Statement parsed = StringN1qlBasedQuery.prepare(statement, "A");
+    Statement parsed = StringN1qlBasedQuery.prepare(statement, "A", "_class", String.class);
 
     assertEquals("SELECT META(`A`).id AS _ID, META(`A`).cas AS _CAS FROM b where b.test = 1 and "
         + PLACEHOLDER_ENTITY, parsed.toString());
+  }
+
+  @Test
+  public void testReplaceTypePlaceholder() throws Exception {
+    String statement = "SELECT " + PLACEHOLDER_ENTITY + " FROM b WHERE b.test = 1 AND " + PLACEHOLDER_FILTER_TYPE;
+    Statement parsed = StringN1qlBasedQuery.prepare(statement, "A", "@class", String.class);
+
+    assertEquals("SELECT META(`A`).id AS _ID, META(`A`).cas AS _CAS FROM b WHERE b.test = 1 AND `@class` = "
+        + "\"java.lang.String\"", parsed.toString());
   }
 }


### PR DESCRIPTION
The generated N1QL queries currently don't filter on the type at all.

Add a criteria to the WHERE clause that checks the field holding type information is matching the entity fully qualified class name.

Add a placeholder for inline N1QL queries that can be replaced by the same type information criteria.