### PR TITLE
DATACOUCH-168 - Support and document all reduce functions

### DIFF
--- a/src/integration/java/org/springframework/data/couchbase/repository/CouchbaseRepositoryViewListener.java
+++ b/src/integration/java/org/springframework/data/couchbase/repository/CouchbaseRepositoryViewListener.java
@@ -56,9 +56,11 @@ public class CouchbaseRepositoryViewListener extends DependencyInjectionTestExec
   private void createAndWaitForDesignDocs(final Bucket client) {
     String mapFunction = "function (doc, meta) { if(doc._class == \"org.springframework.data.couchbase.repository.User\") { emit(null, null); } }";
     String mapFunctionName = "function (doc, meta) { if(doc._class == \"org.springframework.data.couchbase.repository.User\") { emit(doc.username, null); } }";
+    String mapFunctionAge = "function (doc, meta) { if(doc._class == \"org.springframework.data.couchbase.repository.User\") { emit(doc.age, doc.age); } }";
     View view = DefaultView.create("customFindAllView", mapFunction, "_count");
     View customFindByNameView = DefaultView.create("customFindByNameView", mapFunctionName, "_count");
-    List<View> views = Arrays.asList(view, customFindByNameView);
+    View customFindByAgeStatsView = DefaultView.create("customFindByAgeStatsView", mapFunctionAge, "_stats");
+    List<View> views = Arrays.asList(view, customFindByNameView, customFindByAgeStatsView);
     DesignDocument designDoc = DesignDocument.create("user", views);
     client.bucketManager().upsertDesignDocument(designDoc);
 

--- a/src/integration/java/org/springframework/data/couchbase/repository/CouchbaseRepositoryViewTests.java
+++ b/src/integration/java/org/springframework/data/couchbase/repository/CouchbaseRepositoryViewTests.java
@@ -25,6 +25,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import com.couchbase.client.java.Bucket;
+import com.couchbase.client.java.document.json.JsonObject;
 import com.couchbase.client.java.view.Stale;
 import com.couchbase.client.java.view.ViewQuery;
 import com.couchbase.client.java.view.ViewResult;
@@ -109,6 +110,17 @@ public class CouchbaseRepositoryViewTests {
   public void shouldDeriveViewParametersAndReduce() {
     long count = repository.countByUsernameGreaterThanEqualAndUsernameLessThan("uname-8", "uname-9");
     assertEquals(12, count);
+  }
+
+  @Test
+  public void shouldDeriveViewParametersAndReduceNonNumerical() {
+    JsonObject reduceResult = repository.findByAgeLessThan(50);
+
+    assertNotNull(reduceResult);
+    assertEquals(51, (long) reduceResult.getLong("count"));
+    assertEquals(50, (long) reduceResult.getLong("max"));
+    assertEquals(0, (long) reduceResult.getLong("min"));
+    assertEquals(1275, (long) reduceResult.getLong("sum"));
   }
 
   @Test

--- a/src/integration/java/org/springframework/data/couchbase/repository/CustomUserRepository.java
+++ b/src/integration/java/org/springframework/data/couchbase/repository/CustomUserRepository.java
@@ -18,6 +18,8 @@ package org.springframework.data.couchbase.repository;
 
 import java.util.List;
 
+import com.couchbase.client.java.document.json.JsonObject;
+
 import org.springframework.data.couchbase.core.view.View;
 
 /**
@@ -72,4 +74,7 @@ public interface CustomUserRepository extends CouchbaseRepository<User, String> 
 
   @View
   long countCustomFindInvalid();
+
+  @View(viewName = "customFindByAgeStatsView", reduce = true)
+  JsonObject findByAgeLessThan(int maxAge);
 }

--- a/src/main/asciidoc/migrating.adoc
+++ b/src/main/asciidoc/migrating.adoc
@@ -61,8 +61,15 @@ List<User> findFirst3ByLastnameEquals(String lastName);
 
 [[couchbase.migrating.reduce-in-views]]
 === Reduce in views
-TIP: Reduce is now supported. It will be triggered by prefixing the method name with `count` instead of `find`.
+Reduce is now supported in view-based querying.
+
+It can be triggered by prefixing the method name with `count` instead of `find`.
 For example: `countByLastnameContains(String word)` instead of `findByLastnameContains(String word)`.
 
-WARNING: Don't forget to specify an `int/long` reduce function (not limited to `_count`) in your view if you plan to use that. Similarly, views backing a query derivation should emit a simple key (not `null` nor a compound key).
+Alternatively, it can be explicitly be activated by setting `reduce = true` on the `@View` annotation.
 
+Be sure to construct your view correctly:
+
+ * specify a reduce function that matches the method return type, which can be anything, eg. long or JSON object
+ * emit a simple key (not `null` nor a compound key).
+ * emit a value suitable for the reduce to work (typically `_count` doesn't need any particular value, but `_stats` will need a numerical value, in addition to the key).

--- a/src/main/asciidoc/repository.adoc
+++ b/src/main/asciidoc/repository.adoc
@@ -315,7 +315,9 @@ For view-based query derivation, here are the supported keywords (A and B are me
 |`IsIn,In`|`findByFieldIn`|`keys=[A]` - A should be a `Collection`/`Array` with elements compatible for storage in a `JsonArray` (or a single element to be stored in a `JsonArray`)
 |===============
 
-TIP: Note that the `reduce function` (not always a count) will be activated by prefixing with `count` and that <<repositories.limit-query-result>> is also supported.
+Note that both `reduce functions` and <<repositories.limit-query-result>> are also supported.
+
+TIP: In order to trigger a `reduce`, you can use the `count` prefix instead of `find`. But sometimes is doesn't make much sense (eg. because you actually use the `_stats` built in function, which returns a JSON object). So alternatively you can also explicitly ask for reduce to be executed by setting `reduce = true` in the `@View` annotation. Be sure to specify a return type that make sense for the reduce function of your view.
 
 WARNING: Compound keys are not supported, and neither are Or composition, Ignore Case and Order By. You have to include a valid entity property in the naming of your method.
 

--- a/src/main/java/org/springframework/data/couchbase/core/view/View.java
+++ b/src/main/java/org/springframework/data/couchbase/core/view/View.java
@@ -52,4 +52,6 @@ public @interface View {
    */
   String viewName() default "";
 
+  boolean reduce() default false;
+
 }


### PR DESCRIPTION
Detection whether or not reduce should be activated is now centralized. Triggers are:
  - using the `count` prefix instead of `find` in method name
  - setting `reduce = true` in the `View` annotation explicitly.

The reduce can thus be returning any kind of value (added an integration example with `_stats`), which is now properly documented.