### PR TITLE
DATACOUCH-176 - Geo false positive autoelimination

### DIFF
--- a/src/integration/java/org/springframework/data/couchbase/repository/Party.java
+++ b/src/integration/java/org/springframework/data/couchbase/repository/Party.java
@@ -82,6 +82,7 @@ public class Party {
     return "Party{" +
         "name='" + name + '\'' +
         ", eventDate=" + eventDate +
+        ", location=" + location +
         '}';
   }
 }

--- a/src/main/asciidoc/repository.adoc
+++ b/src/main/asciidoc/repository.adoc
@@ -350,7 +350,7 @@ Multi-dimensionality concept is interesting, it means you can craft views that a
 
 Couchbase's Spatial View support querying through ranges that represent "lowest" and "highest" values in each dimension, so for 2D it represents a bounding box, with the southwest-most point [x,y] as `startRange` and northeast-most point [x,y] as `endRange`.
 
-WARNING: Some forms of Geographical queries can only be approximated, for instance querying with a `Polygon` or a `Circle` can only be approximated to the containing bounding `Box` (in DEBUG log level this will be made explicit with each such query).
+TIP: Even though Couchbase Spatial View engine only support Bounding Box querying, the Spring Data Couchbase framework will attempt to remove false positives for you when querying with a `Polygon` or a `Circle` (in TRACE log level each false positive elimination will be logged). Note that a point on the edge of a `Polygon` is *not* considered within (whereas it is when dealing with a `Circle`).
 
 The following query derivation keywords and parameters relative to geographical data in Spring Data are supported for Spatial Views:
 
@@ -367,67 +367,7 @@ The following query derivation keywords and parameters relative to geographical 
 
 IMPORTANT: For "within" types of queries, the expected parameters map to geographical 2D data. Classes from the `org.springframework.data.geo` package are usually expected, but Polygon and Boxes can also be expressed as arrays of `Point`s.
 
-TIP: Further dimensions are supported through keywords other than Within and Near and require numerical input.
-
-=== Removing False Positives
-`Circle` and `Polygon` will be approximated to their surrounding bounding `Box`, but we provide `PointInShapeEvaluator` (`AwtPointInShapeEvaluator`) to be used on the results if you want to remove false positives.
-
-Here is an example of a repository using a spatial view with 3 dimensions (x, y and opening hours).
-Second example demonstrates querying it within a `Polygon` then removing false positives in a second pass:
-
-.Example of dimensional repository
-====
-[source,java]
-----
-public interface StoreRepository extends PagingAndSortingRepository<Store, String> {
-
-  @Dimensional(designDocument = "store", spatialViewName = "byLocationOpening", dimensions = 3)
-  public List<Store> findByLocationWithinAndOpenBefore(Polygon zone, Integer minOpeningHourMinute);
-
-}
-----
-====
-
-.Query a spatial view and eliminate false positives on the geo aspect
-====
-[source,java]
-----
-// Load the bean, or @Autowire it
-StoreRepository repo = ctx.getBean(StoreRepository.class);
-
-// Prepare an arbitrary polygon (a triangle)
-Polygon zone = new Polygon(
-  new Point(2.0, 0.0),
-  new Point(4.0, 0.0),
-  new Point(3.0, -5.5),
-  new Point(2.0, 0.0)); //we explicitly closed the polygon
-
-// Find all stores located inside the triangle.
-// Use 3rd dimension to also query on opening hours, making sure one can go there at 8:00am
-List<Store> stores = repo.findByLocationWithinAndOpenBefore(zone, 800);
-
-// The view will return all matching stores that are actually within the enclosing rectangle around the polygon
-// So we remove false positives
-PointInShapeEvaluator evaluator = new AwtPointInShapeEvaluator();
-List<Store> truePositives = new ArrayList<Store>(stores.size());
-for (Store store : stores) {
-  if (evaluator.pointInPolygon(store.getLocation(), zone)) {
-    truePositives.add(store);
-  } //else this is a false positive
-}
-
-// Alternatively, use "removeFalsePositives" to get the list right away.
-truePositives = evaluator.removeFalsePositives(stores,
-  //this method needs a Converter to know where to find the location
-  new Converter<Store, Point>() {
-    @Override
-    public Point convert(Store source) {
-      return source.getLocation();
-    }
-  },
-  zone);
-----
-====
+Further dimensions are supported through keywords other than Within and Near and require numerical input.
 
 [[couchbase.repository.consistency]]
 == Querying with consistency

--- a/src/main/java/org/springframework/data/couchbase/repository/query/support/GeoUtils.java
+++ b/src/main/java/org/springframework/data/couchbase/repository/query/support/GeoUtils.java
@@ -34,8 +34,6 @@ import org.springframework.data.geo.Shape;
  */
 public class GeoUtils {
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(GeoUtils.class);
-
   /**
    * Computes the bounding box approximation for a "near" query (max distance from a point of origin).
    *
@@ -46,7 +44,6 @@ public class GeoUtils {
    */
   public static double[] getBoundingBoxForNear(Point origin, Distance distance) {
     if (origin == null || distance == null) throw new NullPointerException("Origin and distance required");
-    warnBoundingBoxApproximation("near a Point (within Distance)");
 
     //since maxDistance COULD be negative, we have to make sure we have correct min/max
     double maxDistance = Math.abs(distance.getNormalizedValue());
@@ -90,7 +87,6 @@ public class GeoUtils {
       endRange.add(points[1].getX()).add(points[1].getY());
     } else {
       //this is like a polygon, find the bounding box
-      warnBoundingBoxApproximation("within a sequence of Points (polygon)");
       //find the lowest and highest X and Y to get the bounding box
       double xMin = Double.POSITIVE_INFINITY;
       double yMin = Double.POSITIVE_INFINITY;
@@ -128,7 +124,6 @@ public class GeoUtils {
           .add(box.getSecond().getX())
           .add(box.getSecond().getY());
     } else if (shape instanceof Polygon) {
-      warnBoundingBoxApproximation("within a Polygon");
       //find the lowest and highest X and Y to get the bounding box
       double xMin = Double.POSITIVE_INFINITY;
       double yMin = Double.POSITIVE_INFINITY;
@@ -146,7 +141,6 @@ public class GeoUtils {
       startRange.add(xMin).add(yMin);
       endRange.add(xMax).add(yMax);
     } else if (shape instanceof Circle) {
-      warnBoundingBoxApproximation("within a Circle");
       //here the bounding box is the box that contains the circle
       Circle circle = (Circle) shape;
       Point center = circle.getCenter();
@@ -161,13 +155,6 @@ public class GeoUtils {
       endRange.add(xMax).add(yMax);
     } else {
       throw new IllegalArgumentException("Unsupported shape " + shape.getClass().getName());
-    }
-  }
-
-  private static void warnBoundingBoxApproximation(String kind) {
-    if (LOGGER.isDebugEnabled()) {
-      LOGGER.debug("Spatial View queries " + kind + " are made using a bounding box approximation," +
-          "you probably want to remove false positives by applying a PointInShapeEvaluator");
     }
   }
 }

--- a/src/test/resources/logback.xml
+++ b/src/test/resources/logback.xml
@@ -17,10 +17,12 @@
 
 	<!-- You can use these logger configurations to log more details:
 	 - log the Couchbase queries produced by the framework
+	 - log details of geo queries and false positive elimination
 	 - log details of the parsing of SpEL in N1QL inline queries
 	 - log additional debug info during automatic index creation
 	-->
 	<logger name="org.springframework.data.couchbase.repository.query" level="debug"/>
+	<logger name="org.springframework.data.couchbase.repository.query.SpatialViewQueryCreator" level="trace"/>
 	<logger name="org.springframework.data.couchbase.repository.query.StringN1qlBasedQuery" level="trace"/>
 	<logger name="org.springframework.data.couchbase.repository.support.IndexManager" level="debug"/>
 


### PR DESCRIPTION
So far with geo queries a bounding box approximation was performed on Circle and Polygon queries (since Couchbase internally only supports Bounding Box queries).

It was confusing since in previous iteration it was up to the user to remove these false positives "after the fact" in code calling the repository.

This change allows for the framework to retain enough information to perform false positives elimination automatically and transparently for the user.