### PR TITLE
DATACOUCH-186 - Index-backed methods safe from deleted stales

### DIFF
--- a/src/main/asciidoc/repository.adoc
+++ b/src/main/asciidoc/repository.adoc
@@ -379,6 +379,7 @@ One aspect that is often needed and doesn't have a direct equivalent in the Spri
 data, because the latest version hasn't been indexed yet. This gives the best performance at the expense of consistency.
 
 Note that weaker consistencies can lead to data being returned that doesn't match the criteria of a derived query.
+One trickier case is when documents are deleted from Couchbase but views have not yet caught up to the deletion. With weak consistency this can mean that a view would return IDs that are not in the database anymore, leading to null entities. The `CouchbaseTemplate`s `findByView` and `findBySpatialView` methods will remove such stale deleted entities from their result in order to avoid having nulls in the returned collections. Similarly, `CouchbaseRepository`'s `deleteAll` method will ignore documents that the backing view provided but the SDK remove operation couldn't find.
 
 If one wants to have stronger consistency, there are two possibilities described in the next sections.
 

--- a/src/main/java/org/springframework/data/couchbase/core/CouchbaseExceptionTranslator.java
+++ b/src/main/java/org/springframework/data/couchbase/core/CouchbaseExceptionTranslator.java
@@ -33,6 +33,7 @@ import com.couchbase.client.java.error.BucketDoesNotExistException;
 import com.couchbase.client.java.error.CASMismatchException;
 import com.couchbase.client.java.error.DesignDocumentException;
 import com.couchbase.client.java.error.DocumentAlreadyExistsException;
+import com.couchbase.client.java.error.DocumentDoesNotExistException;
 import com.couchbase.client.java.error.DurabilityException;
 import com.couchbase.client.java.error.InvalidPasswordException;
 import com.couchbase.client.java.error.RequestTooBigException;
@@ -88,6 +89,10 @@ public class CouchbaseExceptionTranslator implements PersistenceExceptionTransla
 
     if (ex instanceof DocumentAlreadyExistsException) {
       return new DuplicateKeyException(ex.getMessage(), ex);
+    }
+
+    if (ex instanceof DocumentDoesNotExistException) {
+      return new DataRetrievalFailureException(ex.getMessage(), ex);
     }
 
     if (ex instanceof CASMismatchException

--- a/src/main/java/org/springframework/data/couchbase/core/CouchbaseOperations.java
+++ b/src/main/java/org/springframework/data/couchbase/core/CouchbaseOperations.java
@@ -190,9 +190,13 @@ public interface CouchbaseOperations {
   /**
    * Query a View for a list of documents of type T.
    * <p/>
-   * <p>There is no need to {@link ViewQuery#includeDocs(boolean) set includeDocs} explicitly, because it will be set to
-   * true all the time. It is valid to pass in a empty constructed {@link ViewQuery} object.</p>
+   * <p>There is no need to {@link ViewQuery#includeDocs(boolean) set includeDocs} explicitly, since this method will
+   * manage the retrieval of documents internally. It is valid to pass in a empty constructed {@link ViewQuery} object.</p>
    * <p/>
+   * <p>Weak consistency in the query (<code>stale(Stale.TRUE)</code>) can lead to some documents being unreachable due
+   * to their deletion not having been indexed. These deleted null documents are eliminated from the result of this
+   * method.</p>
+   * </p>
    * <p>This method does not work with reduced views, because they by design do not contain references to original
    * objects. Use the provided {@link #queryView} method for more flexibility and direct access.</p>
    *
@@ -217,9 +221,13 @@ public interface CouchbaseOperations {
 
   /**
    * Query a Spatial View for a list of documents of type T.
+   * </p>
+   * <p>There is no need to {@link SpatialViewQuery#includeDocs(boolean) set includeDocs} explicitly, since this method
+   * will manage the retrieval of documents internally. It is valid to pass in a empty constructed {@link SpatialViewQuery} object.</p>
    * <p/>
-   * <p>It is valid to pass in a empty constructed {@link SpatialViewQuery} object.</p>
-   * <p/>
+   * <p>Weak consistency in the query (<code>stale(Stale.TRUE)</code>) can lead to some documents being unreachable due
+   * to their deletion not having been indexed. These deleted null documents are eliminated from the result of this
+   * method.</p>
    *
    * @param query the SpatialViewQuery object (also specifying view design document and view name).
    * @param entityClass the entity to map to.
@@ -248,6 +256,10 @@ public interface CouchbaseOperations {
    * statement contains placeholders.
    * <br/>
    * Use {@link N1qlQuery}'s factory methods to construct such a Query.</p>
+   * <p/>
+   * <p>Weak consistency in the query (eg. <code>ScanConsistency.NOT_BOUND</code>) can lead to some documents being
+   * unreachable due to their deletion not having been indexed. These deleted null documents are eliminated from the
+   * result of this method.</p>
    *
    * @param n1ql the N1QL query.
    * @param entityClass the target class for the returned entities.
@@ -266,6 +278,10 @@ public interface CouchbaseOperations {
    * statement contains placeholders.
    * <br/>
    * Use {@link N1qlQuery}'s factory methods to construct such a Query.</p>
+   * <p/>
+   * <p>Weak consistency in the query (eg. <code>ScanConsistency.NOT_BOUND</code>) can lead to some documents being
+   * unreachable due to their deletion not having been indexed. These deleted null documents are eliminated from the
+   * result of this method.</p>
    *
    * @param n1ql the N1QL query.
    * @param fragmentClass the target class for the returned fragments.


### PR DESCRIPTION
This commit ensures that methods in the template and the repository base classes are correctly ignoring documents that have been deleted but are still identified by the view due to using weak consistency (Stale.TRUE).

FindByView in template now ignores null rows in its result list. It also correctly forces the includeDocs parameter in order not to risk a bad transcoding of the document (javadoc clarified).

DeleteAll in the repository CRUD implementation will correctly detect attempts at deleting a non-existing document (DocumentDoesNotExistException is also correctly mapped to a Spring Data exception now).

DeleteAll behavior with DataRetrievalFailureException is tested in RepositoryIndexUsageTest.