### PR TITLE
DATACOUCH-187 - Allow counting queries and single projections.

### DIFF
--- a/src/integration/java/org/springframework/data/couchbase/repository/PartyRepository.java
+++ b/src/integration/java/org/springframework/data/couchbase/repository/PartyRepository.java
@@ -3,11 +3,14 @@ package org.springframework.data.couchbase.repository;
 import java.util.Date;
 import java.util.List;
 
+import org.springframework.data.couchbase.core.query.Query;
 import org.springframework.data.couchbase.core.query.View;
+import org.springframework.data.couchbase.core.query.ViewIndexed;
 
 /**
  * @author Simon Baslé
  */
+@ViewIndexed(designDoc = "party", viewName = "all")
 public interface PartyRepository extends CouchbaseRepository<Party, String> {
 
   List<Party> findByAttendeesGreaterThanEqual(int minAttendees);
@@ -19,4 +22,20 @@ public interface PartyRepository extends CouchbaseRepository<Party, String> {
 
   List<Object> findAllByDescriptionNotNull();
 
+  long countAllByDescriptionNotNull();
+
+  @Query("SELECT MAX(attendees) FROM #{#n1ql.bucket} WHERE #{#n1ql.filter}")
+  long findMaxAttendees();
+
+  @Query("SELECT `desc` FROM #{#n1ql.bucket} WHERE #{#n1ql.filter}")
+  String findSomeString();
+
+  @Query("SELECT count(*) + 5 FROM #{#n1ql.bucket} WHERE #{#n1ql.filter}")
+  long countCustomPlusFive();
+
+  @Query("#{#n1ql.selectEntity} WHERE #{#n1ql.filter}")
+  long countCustom();
+
+  @Query("SELECT 1 = 1")
+  boolean justABoolean();
 }

--- a/src/main/asciidoc/repository.adoc
+++ b/src/main/asciidoc/repository.adoc
@@ -143,6 +143,10 @@ A few N1QL-specific values are provided through SpEL:
  - `#n1ql.bucket` will be replaced by the name of the bucket the entity is stored in, escaped in backticks.
  - `#n1ql.fields` will be replaced by the list of fields (eg. for a SELECT clause) necessary to reconstruct the entity.
 
+IMPORTANT: We recommend that you always use the `selectEntity` SpEL and a WHERE clause with a `filter` SpEL (since otherwise your query could be impacted by entities from other repositories).
+
+You can also do single projections in your N1QL queries (provided it selects only one field and returns only one result, usually an aggregation like `COUNT`, `AVG`, `MAX`...). Such projection would have a simple return type like `long`, `boolean` or `String`. This is *NOT* intended for projections to DTOs.
+
 Another example: "`#{#n1ql.selectEntity} WHERE #{#n1ql.filter} AND test = $1`", which is equivalent to
 `SELECT #{#n1ql.fields} FROM #{#n1ql.bucket} WHERE #{#n1ql.filter} AND test = $1`".
 

--- a/src/main/java/org/springframework/data/couchbase/repository/query/CouchbaseQueryMethod.java
+++ b/src/main/java/org/springframework/data/couchbase/repository/query/CouchbaseQueryMethod.java
@@ -154,4 +154,9 @@ public class CouchbaseQueryMethod extends QueryMethod {
     String query = (String) AnnotationUtils.getValue(getN1qlAnnotation());
     return StringUtils.hasText(query) ? query : null;
   }
+
+  @Override
+  public String toString() {
+    return super.toString();
+  }
 }

--- a/src/main/java/org/springframework/data/couchbase/repository/query/PartTreeN1qlBasedQuery.java
+++ b/src/main/java/org/springframework/data/couchbase/repository/query/PartTreeN1qlBasedQuery.java
@@ -91,4 +91,9 @@ public class PartTreeN1qlBasedQuery extends AbstractN1qlBasedQuery {
       return selectFromWhereOrderBy;
     }
   }
+
+  @Override
+  protected boolean useGeneratedCountQuery() {
+    return false; //generated count query is just for Page/Slice, not projections
+  }
 }

--- a/src/main/java/org/springframework/data/couchbase/repository/query/StringN1qlBasedQuery.java
+++ b/src/main/java/org/springframework/data/couchbase/repository/query/StringN1qlBasedQuery.java
@@ -170,6 +170,11 @@ public class StringN1qlBasedQuery extends AbstractN1qlBasedQuery {
     return N1qlQuery.simple(parsedCountStatement).statement();
   }
 
+  @Override
+  protected boolean useGeneratedCountQuery() {
+    return this.originalStatement.contains(SPEL_SELECT_FROM_CLAUSE);
+  }
+
   /**
    * This class is exposed to SpEL parsing through the variable <code>#{@value StringN1qlBasedQuery#SPEL_PREFIX}</code>.
    * Use the attributes in your SpEL expressions: {@link #selectEntity}, {@link #fields}, {@link #bucket} and {@link #filter}.

--- a/src/test/java/org/springframework/data/couchbase/repository/query/AbstractN1qlBasedQueryTest.java
+++ b/src/test/java/org/springframework/data/couchbase/repository/query/AbstractN1qlBasedQueryTest.java
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.*;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
 
 import com.couchbase.client.java.document.json.JsonArray;
 import com.couchbase.client.java.document.json.JsonObject;
@@ -18,7 +19,9 @@ import com.couchbase.client.java.query.consistency.ScanConsistency;
 import org.junit.Test;
 import org.mockito.Mockito;
 
+import org.springframework.data.couchbase.core.mapping.event.User;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.repository.query.QueryCreationException;
 import org.springframework.data.repository.query.QueryMethod;
 
 public class AbstractN1qlBasedQueryTest {
@@ -90,6 +93,7 @@ public class AbstractN1qlBasedQueryTest {
     verify(mock, never()).executeStream(any(N1qlQuery.class));
     verify(mock, never()).executePaged(any(N1qlQuery.class), any(N1qlQuery.class), any(Pageable.class));
     verify(mock, never()).executeSliced(any(N1qlQuery.class), any(N1qlQuery.class), any(Pageable.class));
+    verify(mock, never()).executeSingleProjection(any(N1qlQuery.class));
   }
 
   @Test
@@ -109,6 +113,7 @@ public class AbstractN1qlBasedQueryTest {
     verify(mock, never()).executeStream(any(N1qlQuery.class));
     verify(mock, never()).executePaged(any(N1qlQuery.class), any(N1qlQuery.class), any(Pageable.class));
     verify(mock, never()).executeSliced(any(N1qlQuery.class), any(N1qlQuery.class), any(Pageable.class));
+    verify(mock, never()).executeSingleProjection(any(N1qlQuery.class));
   }
 
   @Test
@@ -128,6 +133,7 @@ public class AbstractN1qlBasedQueryTest {
     verify(mock).executeStream(any(N1qlQuery.class));
     verify(mock, never()).executePaged(any(N1qlQuery.class), any(N1qlQuery.class), any(Pageable.class));
     verify(mock, never()).executeSliced(any(N1qlQuery.class), any(N1qlQuery.class), any(Pageable.class));
+    verify(mock, never()).executeSingleProjection(any(N1qlQuery.class));
   }
 
   @Test
@@ -146,6 +152,7 @@ public class AbstractN1qlBasedQueryTest {
     verify(mock, never()).executeStream(any(N1qlQuery.class));
     verify(mock).executePaged(any(N1qlQuery.class), any(N1qlQuery.class), any(Pageable.class));
     verify(mock, never()).executeSliced(any(N1qlQuery.class), any(N1qlQuery.class), any(Pageable.class));
+    verify(mock, never()).executeSingleProjection(any(N1qlQuery.class));
   }
 
   @Test
@@ -165,10 +172,11 @@ public class AbstractN1qlBasedQueryTest {
     verify(mock, never()).executeStream(any(N1qlQuery.class));
     verify(mock, never()).executePaged(any(N1qlQuery.class), any(N1qlQuery.class), any(Pageable.class));
     verify(mock).executeSliced(any(N1qlQuery.class), any(N1qlQuery.class), any(Pageable.class));
+    verify(mock, never()).executeSingleProjection(any(N1qlQuery.class));
   }
 
   @Test
-  public void shouldThrowWhenUnsupportedType() throws NoSuchMethodException {
+  public void shouldThrowWhenModifyingType() {
     CouchbaseQueryMethod queryMethod = Mockito.mock(CouchbaseQueryMethod.class);
     N1qlQuery query = Mockito.mock(N1qlQuery.class);
     Pageable pageable = Mockito.mock(Pageable.class);
@@ -183,5 +191,48 @@ public class AbstractN1qlBasedQueryTest {
     verify(mock, never()).executeStream(any(N1qlQuery.class));
     verify(mock, never()).executePaged(any(N1qlQuery.class), any(N1qlQuery.class), any(Pageable.class));
     verify(mock, never()).executeSliced(any(N1qlQuery.class), any(N1qlQuery.class), any(Pageable.class));
+    verify(mock, never()).executeSingleProjection(any(N1qlQuery.class));
+  }
+
+  @Test
+  public void shouldExecuteSingleProjectionWhenRandomObjectReturnType() {
+    CouchbaseQueryMethod queryMethod = Mockito.mock(CouchbaseQueryMethod.class);
+    doReturn(CountDownLatch.class).when(queryMethod).getReturnedObjectType();
+
+    N1qlQuery query = Mockito.mock(N1qlQuery.class);
+    Pageable pageable = Mockito.mock(Pageable.class);
+    AbstractN1qlBasedQuery mock = mock(AbstractN1qlBasedQuery.class);
+    when(mock.executeDependingOnType(any(N1qlQuery.class), any(N1qlQuery.class), any(QueryMethod.class), any(Pageable.class),
+        anyBoolean(), anyBoolean(), anyBoolean()))
+        .thenCallRealMethod();
+
+    mock.executeDependingOnType(query, query, queryMethod, pageable, false, false, false);
+    verify(mock, never()).executeCollection(any(N1qlQuery.class));
+    verify(mock, never()).executeEntity(any(N1qlQuery.class));
+    verify(mock, never()).executeStream(any(N1qlQuery.class));
+    verify(mock, never()).executePaged(any(N1qlQuery.class), any(N1qlQuery.class), any(Pageable.class));
+    verify(mock, never()).executeSliced(any(N1qlQuery.class), any(N1qlQuery.class), any(Pageable.class));
+    verify(mock).executeSingleProjection(any(N1qlQuery.class));
+  }
+
+  @Test
+  public void shouldExecuteSingleProjectionWhenPrimitiveReturnType() {
+    CouchbaseQueryMethod queryMethod = Mockito.mock(CouchbaseQueryMethod.class);
+    doReturn(long.class).when(queryMethod).getReturnedObjectType();
+
+    N1qlQuery query = Mockito.mock(N1qlQuery.class);
+    Pageable pageable = Mockito.mock(Pageable.class);
+    AbstractN1qlBasedQuery mock = mock(AbstractN1qlBasedQuery.class);
+    when(mock.executeDependingOnType(any(N1qlQuery.class), any(N1qlQuery.class), any(QueryMethod.class), any(Pageable.class),
+        anyBoolean(), anyBoolean(), anyBoolean()))
+        .thenCallRealMethod();
+
+    mock.executeDependingOnType(query, query, queryMethod, pageable, false, false, false);
+    verify(mock, never()).executeCollection(any(N1qlQuery.class));
+    verify(mock, never()).executeEntity(any(N1qlQuery.class));
+    verify(mock, never()).executeStream(any(N1qlQuery.class));
+    verify(mock, never()).executePaged(any(N1qlQuery.class), any(N1qlQuery.class), any(Pageable.class));
+    verify(mock, never()).executeSliced(any(N1qlQuery.class), any(N1qlQuery.class), any(Pageable.class));
+    verify(mock).executeSingleProjection(any(N1qlQuery.class));
   }
 }


### PR DESCRIPTION
This change allows simple projections to types long, boolean, String when an inline N1QL query uses an aggregation function like AVG, COUNT.

The projection's result must be a single row with a single key/value pair in the N1QL response. Only the value gets returned.