### PR TITLE
DATACOUCH-207 - Makes all BeanNames constants public

### DIFF
--- a/src/integration/java/org/springframework/data/couchbase/config/CouchbaseTemplateParserIntegrationTests.java
+++ b/src/integration/java/org/springframework/data/couchbase/config/CouchbaseTemplateParserIntegrationTests.java
@@ -52,20 +52,20 @@ public class CouchbaseTemplateParserIntegrationTests {
   public void readsCouchbaseTemplateAttributesCorrectly() {
     reader.loadBeanDefinitions(new ClassPathResource("configurations/couchbase-template-bean.xml"));
 
-    BeanDefinition definition = factory.getBeanDefinition("couchbaseTemplate");
+    BeanDefinition definition = factory.getBeanDefinition(BeanNames.COUCHBASE_TEMPLATE);
     assertEquals(2, definition.getConstructorArgumentValues().getArgumentCount());
 
-    factory.getBean("couchbaseTemplate");
+    factory.getBean(BeanNames.COUCHBASE_TEMPLATE);
   }
 
   @Test
   public void readsCouchbaseTemplateWithTranslationServiceAttributesCorrectly() {
     reader.loadBeanDefinitions(new ClassPathResource("configurations/couchbase-template-with-translation-service-bean.xml"));
 
-    BeanDefinition definition = factory.getBeanDefinition("couchbaseTemplate");
+    BeanDefinition definition = factory.getBeanDefinition(BeanNames.COUCHBASE_TEMPLATE);
     assertEquals(3, definition.getConstructorArgumentValues().getArgumentCount());
 
-    factory.getBean("couchbaseTemplate");
+    factory.getBean(BeanNames.COUCHBASE_TEMPLATE);
   }
 
   /**
@@ -85,7 +85,7 @@ public class CouchbaseTemplateParserIntegrationTests {
   @Test
   public void testTypeFieldCanBeChosen() {
     reader.loadBeanDefinitions(new ClassPathResource("configurations/couchbase-typekey.xml"));
-    CouchbaseTemplate template = factory.getBean("couchbaseTemplate", CouchbaseTemplate.class);
+    CouchbaseTemplate template = factory.getBean(BeanNames.COUCHBASE_TEMPLATE, CouchbaseTemplate.class);
 
     assertTrue(template.getConverter() instanceof MappingCouchbaseConverter);
     MappingCouchbaseConverter converter = ((MappingCouchbaseConverter) template.getConverter());
@@ -130,7 +130,7 @@ public class CouchbaseTemplateParserIntegrationTests {
   public void shouldHaveDefaultsForStaleness() {
     //use another resource where staleness isn't customized
     reader.loadBeanDefinitions(new ClassPathResource("configurations/couchbase-template-with-translation-service-bean.xml"));
-    CouchbaseTemplate template = factory.getBean("couchbaseTemplate", CouchbaseTemplate.class);
+    CouchbaseTemplate template = factory.getBean(BeanNames.COUCHBASE_TEMPLATE, CouchbaseTemplate.class);
 
     assertEquals(Consistency.DEFAULT_CONSISTENCY, template.getDefaultConsistency());
   }

--- a/src/integration/java/org/springframework/data/couchbase/core/CouchbaseTemplateViewListener.java
+++ b/src/integration/java/org/springframework/data/couchbase/core/CouchbaseTemplateViewListener.java
@@ -24,6 +24,7 @@ import com.couchbase.client.java.view.DefaultView;
 import com.couchbase.client.java.view.DesignDocument;
 import com.couchbase.client.java.view.View;
 
+import org.springframework.data.couchbase.config.BeanNames;
 import org.springframework.test.context.TestContext;
 import org.springframework.test.context.support.DependencyInjectionTestExecutionListener;
 
@@ -34,8 +35,8 @@ public class CouchbaseTemplateViewListener extends DependencyInjectionTestExecut
 
   @Override
   public void beforeTestClass(final TestContext testContext) throws Exception {
-    Bucket client = (Bucket) testContext.getApplicationContext().getBean("couchbaseBucket");
-    ClusterInfo clusterInfo = (ClusterInfo) testContext.getApplicationContext().getBean("couchbaseClusterInfo");
+    Bucket client = (Bucket) testContext.getApplicationContext().getBean(BeanNames.COUCHBASE_CLUSTER);
+    ClusterInfo clusterInfo = (ClusterInfo) testContext.getApplicationContext().getBean(BeanNames.COUCHBASE_CLUSTER_INFO);
     populateTestData(client, clusterInfo);
     createAndWaitForDesignDocs(client);
   }

--- a/src/integration/java/org/springframework/data/couchbase/repository/CouchbaseRepositoryViewListener.java
+++ b/src/integration/java/org/springframework/data/couchbase/repository/CouchbaseRepositoryViewListener.java
@@ -28,6 +28,7 @@ import com.couchbase.client.java.view.DefaultView;
 import com.couchbase.client.java.view.DesignDocument;
 import com.couchbase.client.java.view.View;
 
+import org.springframework.data.couchbase.config.BeanNames;
 import org.springframework.data.couchbase.core.CouchbaseTemplate;
 import org.springframework.test.context.TestContext;
 import org.springframework.test.context.support.DependencyInjectionTestExecutionListener;
@@ -40,8 +41,8 @@ public class CouchbaseRepositoryViewListener extends DependencyInjectionTestExec
 
   @Override
   public void beforeTestClass(final TestContext testContext) throws Exception {
-    Bucket client = (Bucket) testContext.getApplicationContext().getBean("couchbaseBucket");
-    ClusterInfo clusterInfo = (ClusterInfo) testContext.getApplicationContext().getBean("couchbaseClusterInfo");
+    Bucket client = (Bucket) testContext.getApplicationContext().getBean(BeanNames.COUCHBASE_BUCKET);
+    ClusterInfo clusterInfo = (ClusterInfo) testContext.getApplicationContext().getBean(BeanNames.COUCHBASE_CLUSTER_INFO);
     populateTestData(client, clusterInfo);
     createAndWaitForDesignDocs(client);
   }

--- a/src/integration/java/org/springframework/data/couchbase/repository/PartyPopulatorListener.java
+++ b/src/integration/java/org/springframework/data/couchbase/repository/PartyPopulatorListener.java
@@ -14,6 +14,7 @@ import com.couchbase.client.java.view.DesignDocument;
 import com.couchbase.client.java.view.SpatialView;
 import com.couchbase.client.java.view.View;
 
+import org.springframework.data.couchbase.config.BeanNames;
 import org.springframework.data.couchbase.core.CouchbaseTemplate;
 import org.springframework.data.geo.Point;
 import org.springframework.test.context.TestContext;
@@ -26,8 +27,8 @@ public class PartyPopulatorListener extends DependencyInjectionTestExecutionList
 
   @Override
   public void beforeTestClass(final TestContext testContext) throws Exception {
-    Bucket client = (Bucket) testContext.getApplicationContext().getBean("couchbaseBucket");
-    ClusterInfo clusterInfo = (ClusterInfo) testContext.getApplicationContext().getBean("couchbaseClusterInfo");
+    Bucket client = (Bucket) testContext.getApplicationContext().getBean(BeanNames.COUCHBASE_BUCKET);
+    ClusterInfo clusterInfo = (ClusterInfo) testContext.getApplicationContext().getBean(BeanNames.COUCHBASE_CLUSTER_INFO);
     populateTestData(client, clusterInfo);
     createAndWaitForDesignDocs(client);
   }

--- a/src/integration/java/org/springframework/data/couchbase/repository/SimpleCouchbaseRepositoryListener.java
+++ b/src/integration/java/org/springframework/data/couchbase/repository/SimpleCouchbaseRepositoryListener.java
@@ -27,6 +27,7 @@ import com.couchbase.client.java.view.DefaultView;
 import com.couchbase.client.java.view.DesignDocument;
 import com.couchbase.client.java.view.View;
 
+import org.springframework.data.couchbase.config.BeanNames;
 import org.springframework.data.couchbase.core.CouchbaseTemplate;
 import org.springframework.test.context.TestContext;
 import org.springframework.test.context.support.DependencyInjectionTestExecutionListener;
@@ -38,8 +39,8 @@ public class SimpleCouchbaseRepositoryListener extends DependencyInjectionTestEx
 
   @Override
   public void beforeTestClass(final TestContext testContext) throws Exception {
-    Bucket client = (Bucket) testContext.getApplicationContext().getBean("couchbaseBucket");
-    ClusterInfo clusterInfo = (ClusterInfo) testContext.getApplicationContext().getBean("couchbaseClusterInfo");
+    Bucket client = (Bucket) testContext.getApplicationContext().getBean(BeanNames.COUCHBASE_BUCKET);
+    ClusterInfo clusterInfo = (ClusterInfo) testContext.getApplicationContext().getBean(BeanNames.COUCHBASE_CLUSTER_INFO);
     populateTestData(client, clusterInfo);
     createAndWaitForDesignDocs(client);
   }

--- a/src/integration/java/org/springframework/data/couchbase/repository/index/IndexedRepositoryTestListener.java
+++ b/src/integration/java/org/springframework/data/couchbase/repository/index/IndexedRepositoryTestListener.java
@@ -4,6 +4,7 @@ import com.couchbase.client.java.Bucket;
 import com.couchbase.client.java.query.Index;
 import com.couchbase.client.java.query.N1qlQuery;
 
+import org.springframework.data.couchbase.config.BeanNames;
 import org.springframework.test.context.TestContext;
 import org.springframework.test.context.support.DependencyInjectionTestExecutionListener;
 
@@ -16,7 +17,7 @@ public class IndexedRepositoryTestListener extends DependencyInjectionTestExecut
 
   @Override
   public void beforeTestClass(final TestContext testContext) throws Exception {
-    Bucket client = (Bucket) testContext.getApplicationContext().getBean("couchbaseBucket");
+    Bucket client = (Bucket) testContext.getApplicationContext().getBean(BeanNames.COUCHBASE_BUCKET);
     client.bucketManager().removeDesignDocument(IndexedRepositoryTests.VIEW_DOC);
     client.bucketManager().removeDesignDocument("foo");
     client.query(N1qlQuery.simple(Index.dropPrimaryIndex(client.name())));

--- a/src/main/java/org/springframework/data/couchbase/config/BeanNames.java
+++ b/src/main/java/org/springframework/data/couchbase/config/BeanNames.java
@@ -16,10 +16,20 @@
 
 package org.springframework.data.couchbase.config;
 
+import com.couchbase.client.java.Bucket;
+import com.couchbase.client.java.Cluster;
+import com.couchbase.client.java.cluster.ClusterInfo;
+import com.couchbase.client.java.env.CouchbaseEnvironment;
+
 import org.springframework.core.convert.converter.Converter;
+import org.springframework.data.couchbase.core.CouchbaseOperations;
+import org.springframework.data.couchbase.core.convert.translation.TranslationService;
 
 /**
- * Contains default bean names that will be used when no "id" is supplied to the beans.
+ * Contains default bean names for Couchbase beans.
+ *
+ * These are the names of the beans used by Spring Data Couchbase, unless an explicit id is given to the bean
+ * either in the xml configuration or the {@link AbstractCouchbaseConfiguration java configuration}.
  *
  * @author Michael Nitschinger
  * @author Simon Baslé
@@ -27,56 +37,75 @@ import org.springframework.core.convert.converter.Converter;
 public class BeanNames {
 
   /**
-   * Refers to the "&lt;couchbase:env /&gt;" bean.
+   * The name for the default {@link CouchbaseEnvironment} bean.
+   *
+   * See {@link AbstractCouchbaseConfiguration#couchbaseEnvironment()} for java config, and
+   * the "&lt;couchbase:env /&gt;" element for xml config.
    */
-  static final String COUCHBASE_ENV = "couchbaseEnv";
-  /**
-   * Refers to the "&lt;couchbase:cluster /&gt;" bean.
-   */
-  static final String COUCHBASE_CLUSTER = "couchbaseCluster";
+  public static final String COUCHBASE_ENV = "couchbaseEnv";
 
   /**
-   * Refers to the "&lt;couchbase:bucket /&gt;" bean.
+   * The name for the default {@link Cluster} bean.
+   *
+   * See {@link AbstractCouchbaseConfiguration#couchbaseCluster()} for java config, and
+   * the "&lt;couchbase:cluster /&gt;" element for xml config.
    */
-  static final String COUCHBASE_BUCKET = "couchbaseBucket";
+  public static final String COUCHBASE_CLUSTER = "couchbaseCluster";
 
   /**
-   * Refers to the "&lt;couchbase:template /&gt;" bean.
+   * The name for the default {@link Bucket} bean.
+   *
+   * See {@link AbstractCouchbaseConfiguration#couchbaseClient()} for java config, and
+   * the "&lt;couchbase:bucket /&gt;" element for xml config.
    */
-  static final String COUCHBASE_TEMPLATE = "couchbaseTemplate";
+  public static final String COUCHBASE_BUCKET = "couchbaseBucket";
 
   /**
-   * Refers to the "&lt;couchbase:translation-service /&gt;" bean
+   * The name for the default {@link CouchbaseOperations} bean.
+   *
+   * See {@link AbstractCouchbaseConfiguration#couchbaseTemplate()} for java config, and
+   * the "&lt;couchbase:template /&gt;" element for xml config.
    */
-  static final String COUCHBASE_TRANSLATION_SERVICE = "couchbaseTranslationService";
+  public static final String COUCHBASE_TEMPLATE = "couchbaseTemplate";
 
   /**
-   * Refers to the "&lt;couchbase:clusterInfo&gt;" bean
+   * The name for the default {@link TranslationService} bean.
+   *
+   * See {@link AbstractCouchbaseConfiguration#translationService()} for java config, and
+   * the "&lt;couchbase:translation-service /&gt;" element for xml config.
    */
-  static final String COUCHBASE_CLUSTER_INFO = "couchbaseClusterInfo";
+  public static final String COUCHBASE_TRANSLATION_SERVICE = "couchbaseTranslationService";
 
   /**
-   * The bean that stores custom mapping between repositories and their backing couchbaseOperations.
+   * The name for the default {@link ClusterInfo} bean.
+   *
+   * See {@link AbstractCouchbaseConfiguration#couchbaseClusterInfo()} for java config, and
+   * the "&lt;couchbase:clusterInfo /&gt;" element for xml config.
+   */
+  public static final String COUCHBASE_CLUSTER_INFO = "couchbaseClusterInfo";
+
+  /**
+   * The name for the bean that stores custom mapping between repositories and their backing couchbaseOperations.
    */
   public static final String COUCHBASE_OPERATIONS_MAPPING = "couchbaseRepositoryOperationsMapping";
 
   /**
-   * The bean that drives how some indexes are automatically created.
+   * The name for the  bean that drives how some indexes are automatically created.
    */
   public static final String COUCHBASE_INDEX_MANAGER = "couchbaseIndexManager";
 
   /**
-   * The bean that performs conversion to/from representation suitable for storage in couchbase.
+   * The name for the  bean that performs conversion to/from representation suitable for storage in couchbase.
    */
   public static final String COUCHBASE_MAPPING_CONVERTER = "couchbaseMappingConverter";
 
   /**
-   * The bean that stores mapping metadata for entities stored in couchbase.
+   * The name for the  bean that stores mapping metadata for entities stored in couchbase.
    */
   public static final String COUCHBASE_MAPPING_CONTEXT = "couchbaseMappingContext";
 
   /**
-   * The bean that registers custom {@link Converter Converters} to encode/decode entity members.
+   * The name for the  bean that registers custom {@link Converter Converters} to encode/decode entity members.
    */
   public static final String COUCHBASE_CUSTOM_CONVERSIONS = "couchbaseCustomConversions";
 }

--- a/src/main/java/org/springframework/data/couchbase/repository/config/EnableCouchbaseRepositories.java
+++ b/src/main/java/org/springframework/data/couchbase/repository/config/EnableCouchbaseRepositories.java
@@ -19,6 +19,7 @@ package org.springframework.data.couchbase.repository.config;
 import org.springframework.beans.factory.FactoryBean;
 import org.springframework.context.annotation.ComponentScan.Filter;
 import org.springframework.context.annotation.Import;
+import org.springframework.data.couchbase.config.BeanNames;
 import org.springframework.data.couchbase.core.CouchbaseTemplate;
 import org.springframework.data.couchbase.repository.support.CouchbaseRepositoryFactoryBean;
 import org.springframework.data.repository.config.DefaultRepositoryBaseClass;
@@ -112,6 +113,6 @@ public @interface EnableCouchbaseRepositories {
    *
    * @return
    */
-  String couchbaseTemplateRef() default "couchbaseTemplate";
+  String couchbaseTemplateRef() default BeanNames.COUCHBASE_TEMPLATE;
 
 }


### PR DESCRIPTION
This makes all bean names public constants, which can be used in Conditional annotation in Spring Boot for instance (cc @snicoll).