### PR TITLE
DATACOUCH-59 | Configuration for updating expire settings for documen…

### DIFF
--- a/src/integration/java/org/springframework/data/couchbase/core/CouchbaseTemplateTests.java
+++ b/src/integration/java/org/springframework/data/couchbase/core/CouchbaseTemplateTests.java
@@ -402,6 +402,19 @@ public class CouchbaseTemplateTests {
 		assertEquals(versionedClass.getVersion(), foundClass.getVersion());
 	}
 
+	@Test
+	public void expiryWhenTouchOnReadDocument() throws InterruptedException {
+		String id = "simple-doc-with-update-expiry-for-read";
+		DocumentWithTouchOnRead doc = new DocumentWithTouchOnRead(id);
+		template.save(doc);
+		Thread.sleep(1500);
+		assertNotNull(template.findById(id, DocumentWithTouchOnRead.class));
+		Thread.sleep(1500);
+		assertNotNull(template.findById(id, DocumentWithTouchOnRead.class));
+		Thread.sleep(3000);
+		assertNull(template.findById(id, DocumentWithTouchOnRead.class));
+	}
+
 	/**
 	 * A sample document with just an id and property.
 	 */
@@ -429,6 +442,20 @@ public class CouchbaseTemplateTests {
 		private final String id;
 
 		public DocumentWithExpiry(String id) {
+			this.id = id;
+		}
+	}
+
+	/**
+	 * A sample document that expires in 2 seconds and touchOnRead set.
+	 */
+	@Document(expiry = 2, touchOnRead = true)
+	static class DocumentWithTouchOnRead {
+
+		@Id
+		private final String id;
+
+		public DocumentWithTouchOnRead(String id) {
 			this.id = id;
 		}
 	}

--- a/src/main/java/org/springframework/data/couchbase/core/CouchbaseTemplate.java
+++ b/src/main/java/org/springframework/data/couchbase/core/CouchbaseTemplate.java
@@ -281,10 +281,15 @@ public class CouchbaseTemplate implements CouchbaseOperations, ApplicationEventP
 
   @Override
   public <T> T findById(final String id, Class<T> entityClass) {
+    final CouchbasePersistentEntity<?> entity = mappingContext.getPersistentEntity(entityClass);
     RawJsonDocument result = execute(new BucketCallback<RawJsonDocument>() {
       @Override
       public RawJsonDocument doInBucket() {
-        return client.get(id, RawJsonDocument.class);
+        if (entity.isTouchOnRead()) {
+          return client.getAndTouch(id, entity.getExpiry(), RawJsonDocument.class);
+        } else {
+          return client.get(id, RawJsonDocument.class);
+        }
       }
     });
 

--- a/src/main/java/org/springframework/data/couchbase/core/mapping/BasicCouchbasePersistentEntity.java
+++ b/src/main/java/org/springframework/data/couchbase/core/mapping/BasicCouchbasePersistentEntity.java
@@ -16,12 +16,7 @@
 
 package org.springframework.data.couchbase.core.mapping;
 
-import java.util.Calendar;
-import java.util.TimeZone;
-import java.util.concurrent.TimeUnit;
-
 import com.couchbase.client.java.repository.annotation.Id;
-
 import org.springframework.beans.BeansException;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
@@ -30,6 +25,10 @@ import org.springframework.context.expression.BeanFactoryResolver;
 import org.springframework.data.mapping.model.BasicPersistentEntity;
 import org.springframework.data.util.TypeInformation;
 import org.springframework.expression.spel.support.StandardEvaluationContext;
+
+import java.util.Calendar;
+import java.util.TimeZone;
+import java.util.concurrent.TimeUnit;
 
 /**
  * The representation of a persistent entity.
@@ -121,6 +120,13 @@ public class BasicCouchbasePersistentEntity<T> extends BasicPersistentEntity<T, 
     } else {
       return (int) secondsShift;
     }
+  }
+
+  @Override
+  public boolean isTouchOnRead() {
+    org.springframework.data.couchbase.core.mapping.Document annotation = getType().getAnnotation(
+        org.springframework.data.couchbase.core.mapping.Document.class);
+    return annotation == null ? false : getExpiry() > 0 && annotation.touchOnRead();
   }
 
 }

--- a/src/main/java/org/springframework/data/couchbase/core/mapping/CouchbasePersistentEntity.java
+++ b/src/main/java/org/springframework/data/couchbase/core/mapping/CouchbasePersistentEntity.java
@@ -42,4 +42,10 @@ public interface CouchbasePersistentEntity<T> extends
    */
   int getExpiry();
 
+  /**
+   * Flag for using getAndTouch operations for reads
+   * @return
+   */
+   boolean isTouchOnRead();
+
 }

--- a/src/main/java/org/springframework/data/couchbase/core/mapping/Document.java
+++ b/src/main/java/org/springframework/data/couchbase/core/mapping/Document.java
@@ -41,6 +41,8 @@ public @interface Document {
    */
   int expiry() default 0;
 
+  boolean touchOnRead() default false;
+
   /**
    * An optional time unit for the document's {@link #expiry()}, if set. Default is {@link TimeUnit#SECONDS}.
    */

--- a/src/test/java/org/springframework/data/couchbase/core/mapping/BasicCouchbasePersistentEntityTests.java
+++ b/src/test/java/org/springframework/data/couchbase/core/mapping/BasicCouchbasePersistentEntityTests.java
@@ -17,6 +17,8 @@
 package org.springframework.data.couchbase.core.mapping;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import java.util.Calendar;
 import java.util.Date;
@@ -26,6 +28,7 @@ import java.util.concurrent.TimeUnit;
 import org.junit.Test;
 
 import org.springframework.data.util.ClassTypeInformation;
+
 
 /**
  * Verifies the correct behavior of annotation at the class level on persistable objects.
@@ -101,6 +104,42 @@ public class BasicCouchbasePersistentEntityTests {
     assertEquals(expected.get(Calendar.HOUR_OF_DAY), calendar.get(Calendar.HOUR_OF_DAY));
     assertEquals(expected.get(Calendar.MINUTE), calendar.get(Calendar.MINUTE));
     assertEquals(expected.get(Calendar.SECOND), calendar.get(Calendar.SECOND));
+  }
+
+  @Test
+  public void doesNotUseGetExpiry() throws Exception {
+    assertEquals(0, getBasicCouchbasePersistentEntity(SimpleDocument.class).getExpiry());
+  }
+
+  @Test
+  public void usesGetExpiry() throws Exception {
+    assertEquals(10, getBasicCouchbasePersistentEntity(SimpleDocumentWithExpiry.class).getExpiry());
+  }
+
+  @Test
+  public void doesNotUseIsUpdateExpiryForRead() throws Exception {
+    assertFalse(getBasicCouchbasePersistentEntity(SimpleDocument.class).isTouchOnRead());
+    assertFalse(getBasicCouchbasePersistentEntity(SimpleDocumentWithExpiry.class).isTouchOnRead());
+    }
+
+  @Test
+  public void usesTouchOnRead() throws Exception {
+    assertTrue(getBasicCouchbasePersistentEntity(SimpleDocumentWithTouchOnRead.class).isTouchOnRead());
+  }
+
+  private BasicCouchbasePersistentEntity getBasicCouchbasePersistentEntity(Class<?> clazz) {
+    return new BasicCouchbasePersistentEntity(ClassTypeInformation.from(clazz));
+  }
+
+  public static class SimpleDocument {
+  }
+
+  @Document(expiry = 10)
+  public static class SimpleDocumentWithExpiry {
+  }
+
+  @Document(expiry = 10, touchOnRead = true)
+  public static class SimpleDocumentWithTouchOnRead {
   }
 
   /**


### PR DESCRIPTION
…ts when read is made. Configuration is based on Document annotation. When read of document takes place then touch action is executed on document. It is an asynchronous action so it does not block read.

due to @simonbasle request in https://github.com/spring-projects/spring-data-couchbase/pull/96