### PR TITLE
DATACOUCH-209 - Change default Consistency to READ_YOUR_OWN_WRITES

### DIFF
--- a/src/integration/java/org/springframework/data/couchbase/config/CouchbaseTemplateParserIntegrationTests.java
+++ b/src/integration/java/org/springframework/data/couchbase/config/CouchbaseTemplateParserIntegrationTests.java
@@ -111,7 +111,7 @@ public class CouchbaseTemplateParserIntegrationTests {
     reader.loadBeanDefinitions(new ClassPathResource("configurations/couchbase-consistency.xml"));
     CouchbaseTemplate template = factory.getBean("template", CouchbaseTemplate.class);
 
-    assertEquals(Consistency.READ_YOUR_OWN_WRITES, template.getDefaultConsistency());
+    assertEquals(Consistency.EVENTUALLY_CONSISTENT, template.getDefaultConsistency());
     assertNotEquals(Consistency.DEFAULT_CONSISTENCY, template.getDefaultConsistency());
   }
 

--- a/src/integration/resources/configurations/couchbase-consistency.xml
+++ b/src/integration/resources/configurations/couchbase-consistency.xml
@@ -10,7 +10,7 @@
     <couchbase:clusterInfo/>
     <couchbase:bucket/>
 
-    <couchbase:template id="template" consistency="READ_YOUR_OWN_WRITES"/>
+    <couchbase:template id="template" consistency="EVENTUALLY_CONSISTENT"/>
     <couchbase:template id="templateBad" consistency="BadConsistency"/>
 
 </beans>

--- a/src/main/asciidoc/repository.adoc
+++ b/src/main/asciidoc/repository.adoc
@@ -456,7 +456,7 @@ A global consistency can be defined using the `Consistency` enumeration (eg. `Co
  - in xml, this is done via the `consistency` attribute on `<couchbase:template>`.
  - in javaConfig, this is done by overriding the `getDefaultConsistency()` method.
 
-By default it is `Consistency.UPDATE_AFTER` (which means speed is prioritized over consistency, but the view index will be updated after each request).
+By default it is `Consistency.READ_YOUR_OWN_WRITES` (which means consistency is prioritized over speed, especially when a large number of documents has been created recently).
 
 IMPORTANT: This is **only used in repositories**, either for index-backed methods automatically provided by the repository interface (`findAll()`, `findAll(keys)`, `count()`, `deleteAll()`...) or methods you define in your specific interface using query derivation.
 

--- a/src/main/java/org/springframework/data/couchbase/core/query/Consistency.java
+++ b/src/main/java/org/springframework/data/couchbase/core/query/Consistency.java
@@ -40,9 +40,9 @@ public enum Consistency {
   EVENTUALLY_CONSISTENT(Stale.TRUE, ScanConsistency.NOT_BOUNDED);
 
   /**
-   * The static default Consistency ({@link #UPDATE_AFTER}).
+   * The static default Consistency ({@link #READ_YOUR_OWN_WRITES}).
    */
-  public static final Consistency DEFAULT_CONSISTENCY = UPDATE_AFTER;
+  public static final Consistency DEFAULT_CONSISTENCY = READ_YOUR_OWN_WRITES;
 
   private final Stale viewConsistency;
   private final ScanConsistency n1qlConsistency;


### PR DESCRIPTION
Formerly UPDATE_AFTER, but the inconsistent view this would give eg. while writing tests or exploring Spring Data Couchbase was confusing to users.

cc. @snicoll for review, related to spring-projects/spring-boot#5159