### PR TITLE
Introduce CouchbaseConfigurer

### DIFF
--- a/src/main/java/org/springframework/data/couchbase/config/AbstractCouchbaseConfiguration.java
+++ b/src/main/java/org/springframework/data/couchbase/config/AbstractCouchbaseConfiguration.java
@@ -33,9 +33,11 @@ import org.springframework.context.annotation.Configuration;
  *
  * @author Michael Nitschinger
  * @author Simon Baslé
+ * @author Stephane Nicoll
  */
 @Configuration
-public abstract class AbstractCouchbaseConfiguration extends AbstractCouchbaseDataConfiguration {
+public abstract class AbstractCouchbaseConfiguration
+        extends AbstractCouchbaseDataConfiguration implements CouchbaseConfigurer {
 
   /**
    * The list of hostnames (or IP addresses) to bootstrap from.
@@ -77,6 +79,11 @@ public abstract class AbstractCouchbaseConfiguration extends AbstractCouchbaseDa
    */
   protected CouchbaseEnvironment getEnvironment() {
     return DefaultCouchbaseEnvironment.create();
+  }
+
+  @Override
+  protected CouchbaseConfigurer couchbaseConfigurer() {
+    return this;
   }
 
   @Override

--- a/src/main/java/org/springframework/data/couchbase/config/AbstractCouchbaseDataConfiguration.java
+++ b/src/main/java/org/springframework/data/couchbase/config/AbstractCouchbaseDataConfiguration.java
@@ -57,10 +57,7 @@ import org.springframework.util.StringUtils;
 @Configuration
 public abstract class AbstractCouchbaseDataConfiguration {
 
-  public abstract CouchbaseEnvironment couchbaseEnvironment() throws Exception;
-  public abstract Cluster couchbaseCluster() throws Exception;
-  public abstract ClusterInfo couchbaseClusterInfo() throws Exception;
-  public abstract Bucket couchbaseClient() throws Exception;
+  protected abstract CouchbaseConfigurer couchbaseConfigurer();
 
   /**
    * Creates a {@link CouchbaseTemplate}.
@@ -76,7 +73,8 @@ public abstract class AbstractCouchbaseDataConfiguration {
    */
   @Bean(name = BeanNames.COUCHBASE_TEMPLATE)
   public CouchbaseTemplate couchbaseTemplate() throws Exception {
-    CouchbaseTemplate template = new CouchbaseTemplate(couchbaseClusterInfo(), couchbaseClient(), mappingCouchbaseConverter(), translationService());
+    CouchbaseTemplate template = new CouchbaseTemplate(couchbaseConfigurer().couchbaseClusterInfo(),
+            couchbaseConfigurer().couchbaseClient(), mappingCouchbaseConverter(), translationService());
     template.setDefaultConsistency(getDefaultConsistency());
     return template;
   }

--- a/src/main/java/org/springframework/data/couchbase/config/CouchbaseConfigurer.java
+++ b/src/main/java/org/springframework/data/couchbase/config/CouchbaseConfigurer.java
@@ -1,0 +1,24 @@
+package org.springframework.data.couchbase.config;
+
+import com.couchbase.client.java.Bucket;
+import com.couchbase.client.java.Cluster;
+import com.couchbase.client.java.cluster.ClusterInfo;
+import com.couchbase.client.java.env.CouchbaseEnvironment;
+
+/**
+ * Strategy interface for users to provide as a factory for custom components needed
+ * by the Couchbase integration.
+ *
+ * @author Stephane Nicoll
+ */
+public interface CouchbaseConfigurer {
+
+	CouchbaseEnvironment couchbaseEnvironment() throws Exception;
+
+	Cluster couchbaseCluster() throws Exception;
+
+	ClusterInfo couchbaseClusterInfo() throws Exception;
+
+	Bucket couchbaseClient() throws Exception;
+
+}


### PR DESCRIPTION
Rather than having to extend a few methods from the base Configuration
class, this commit introduces a strategy interface to gather them.

`CouchbaseConfigurer` represents all the components that the Spring Data
integration requires.