### PR TITLE
DATACOUCH 225 - Minimal SDK 2.2.6 support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,8 +21,8 @@
 
         <dist.key>DATACOUCH</dist.key>
 
-        <couchbase>2.2.3</couchbase>
-        <couchbase.osgi>2.2.3</couchbase.osgi>
+        <couchbase>2.2.6</couchbase>
+        <couchbase.osgi>2.2.6</couchbase.osgi>
         <springdata.commons>1.13.0.BUILD-SNAPSHOT</springdata.commons>
         <validation>1.0.0.GA</validation>
     </properties>

--- a/src/main/java/org/springframework/data/couchbase/config/CouchbaseEnvironmentNoShutdownProxy.java
+++ b/src/main/java/org/springframework/data/couchbase/config/CouchbaseEnvironmentNoShutdownProxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2015 the original author or authors
+ * Copyright 2012-2016 the original author or authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,6 +31,7 @@ import rx.Scheduler;
  * to be invoked. Useful when the delegate is not to be lifecycle-managed by Spring.
  *
  * @author Simon Baslé
+ * @author Jonathan Edwards
  */
 public class CouchbaseEnvironmentNoShutdownProxy implements CouchbaseEnvironment {
 
@@ -282,5 +283,45 @@ public class CouchbaseEnvironmentNoShutdownProxy implements CouchbaseEnvironment
   @Override
   public boolean tcpNodelayEnabled() {
     return delegate.tcpNodelayEnabled();
+  }
+
+  @Override
+  public boolean callbacksOnIoPool() {
+    return delegate.callbacksOnIoPool();
+  }
+
+  @Override
+  public String coreBuild() {
+    return delegate.coreBuild();
+  }
+
+  @Override
+  public String coreVersion() {
+    return delegate.coreVersion();
+  }
+
+  @Override
+  public String dcpConnectionName() {
+    return delegate.dcpConnectionName();
+  }
+
+  @Override
+  public int searchEndpoints() {
+    return delegate.searchEndpoints();
+  }
+
+  @Override
+  public String clientBuild() {
+    return delegate.clientBuild();
+  }
+
+  @Override
+  public String clientVersion() {
+    return delegate.clientVersion();
+  }
+
+  @Override
+  public long searchTimeout() {
+    return delegate.searchTimeout();
   }
 }


### PR DESCRIPTION
DATACOUCH-225 - Minimal SDK 2.2.6 support.

org.springframework.data.couchbase.config.CouchbaseEnvironmentNoShutdownProxy is missing new methods required by updated interface com.couchbase.client.core.env.CoreEnvironment (SDK 2.2.4+). Adding new delegate methods resolves this immediate issue, with all tests passing (though the CouchbaseEnvironmentNoShutdownProxy class doesn't appear to be directly or indirectly tested).

Jonathan Edwards, s34gull@gmail.com