### PR TITLE
DATACOUCH-226 

### DIFF
--- a/src/main/java/org/springframework/data/couchbase/core/convert/MappingCouchbaseConverter.java
+++ b/src/main/java/org/springframework/data/couchbase/core/convert/MappingCouchbaseConverter.java
@@ -16,6 +16,13 @@
 
 package org.springframework.data.couchbase.core.convert;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
 import org.springframework.core.CollectionFactory;
@@ -45,13 +52,6 @@ import org.springframework.data.util.ClassTypeInformation;
 import org.springframework.data.util.TypeInformation;
 import org.springframework.util.Assert;
 import org.springframework.util.CollectionUtils;
-
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
 
 /**
  * A mapping converter for Couchbase.
@@ -100,11 +100,6 @@ public class MappingCouchbaseConverter extends AbstractCouchbaseConverter
   private final SpELContext spELContext;
 
   /**
-  * Determines whether only properties with @Field annotation will be candidates for mapping
-  */
-  private boolean enableStrictFieldChecking = false;
-
-  /**
    * Create a new {@link MappingCouchbaseConverter}.
    *
    * @param mappingContext the mapping context to use.
@@ -138,10 +133,6 @@ public class MappingCouchbaseConverter extends AbstractCouchbaseConverter
   @Override
   public String getTypeKey() {
     return typeMapper.getTypeKey();
-  }
-
-  public void setEnableStrictFieldChecking(boolean enableStrictFieldChecking){
-      this.enableStrictFieldChecking = enableStrictFieldChecking;
   }
 
   @Override
@@ -443,8 +434,6 @@ public class MappingCouchbaseConverter extends AbstractCouchbaseConverter
       public void doWithPersistentProperty(final CouchbasePersistentProperty prop) {
         if (prop.equals(idProperty) || (versionProperty != null && prop.equals(versionProperty))) {
           return;
-        }else if(enableStrictFieldChecking && !prop.isAnnotationPresent(com.couchbase.client.java.repository.annotation.Field.class)){
-            return;
         }
 
         Object propertyObj = accessor.getProperty(prop, prop.getType());

--- a/src/main/java/org/springframework/data/couchbase/core/convert/MappingCouchbaseConverter.java
+++ b/src/main/java/org/springframework/data/couchbase/core/convert/MappingCouchbaseConverter.java
@@ -16,13 +16,6 @@
 
 package org.springframework.data.couchbase.core.convert;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
 import org.springframework.core.CollectionFactory;
@@ -52,6 +45,13 @@ import org.springframework.data.util.ClassTypeInformation;
 import org.springframework.data.util.TypeInformation;
 import org.springframework.util.Assert;
 import org.springframework.util.CollectionUtils;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
 
 /**
  * A mapping converter for Couchbase.
@@ -100,6 +100,11 @@ public class MappingCouchbaseConverter extends AbstractCouchbaseConverter
   private final SpELContext spELContext;
 
   /**
+  * Determines whether only properties with @Field annotation will be candidates for mapping
+  */
+  private boolean enableStrictFieldChecking = false;
+
+  /**
    * Create a new {@link MappingCouchbaseConverter}.
    *
    * @param mappingContext the mapping context to use.
@@ -133,6 +138,10 @@ public class MappingCouchbaseConverter extends AbstractCouchbaseConverter
   @Override
   public String getTypeKey() {
     return typeMapper.getTypeKey();
+  }
+
+  public void setEnableStrictFieldChecking(boolean enableStrictFieldChecking){
+      this.enableStrictFieldChecking = enableStrictFieldChecking;
   }
 
   @Override
@@ -434,6 +443,8 @@ public class MappingCouchbaseConverter extends AbstractCouchbaseConverter
       public void doWithPersistentProperty(final CouchbasePersistentProperty prop) {
         if (prop.equals(idProperty) || (versionProperty != null && prop.equals(versionProperty))) {
           return;
+        }else if(enableStrictFieldChecking && !prop.isAnnotationPresent(com.couchbase.client.java.repository.annotation.Field.class)){
+            return;
         }
 
         Object propertyObj = accessor.getProperty(prop, prop.getType());

--- a/src/main/java/org/springframework/data/couchbase/core/convert/MappingCouchbaseConverter.java
+++ b/src/main/java/org/springframework/data/couchbase/core/convert/MappingCouchbaseConverter.java
@@ -62,6 +62,7 @@ import com.couchbase.client.java.repository.annotation.Field;
  *
  * @author Michael Nitschinger
  * @author Oliver Gierke
+ * @author Geoffrey Mina
  */
 public class MappingCouchbaseConverter extends AbstractCouchbaseConverter
   implements ApplicationContextAware {

--- a/src/main/java/org/springframework/data/couchbase/core/convert/MappingCouchbaseConverter.java
+++ b/src/main/java/org/springframework/data/couchbase/core/convert/MappingCouchbaseConverter.java
@@ -52,6 +52,7 @@ import org.springframework.data.util.ClassTypeInformation;
 import org.springframework.data.util.TypeInformation;
 import org.springframework.util.Assert;
 import org.springframework.util.CollectionUtils;
+import com.couchbase.client.java.repository.annotation.Field;
 
 /**
  * A mapping converter for Couchbase.
@@ -100,6 +101,11 @@ public class MappingCouchbaseConverter extends AbstractCouchbaseConverter
   private final SpELContext spELContext;
 
   /**
+   * Enable strict @Field checking on mapper
+   */
+  private boolean enableStrictFieldChecking = false;
+
+  /**
    * Create a new {@link MappingCouchbaseConverter}.
    *
    * @param mappingContext the mapping context to use.
@@ -133,6 +139,10 @@ public class MappingCouchbaseConverter extends AbstractCouchbaseConverter
   @Override
   public String getTypeKey() {
     return typeMapper.getTypeKey();
+  }
+
+  public void setEnableStrictFieldChecking(boolean enableStrictFieldChecking){
+    this.enableStrictFieldChecking = enableStrictFieldChecking;
   }
 
   @Override
@@ -433,6 +443,8 @@ public class MappingCouchbaseConverter extends AbstractCouchbaseConverter
       @Override
       public void doWithPersistentProperty(final CouchbasePersistentProperty prop) {
         if (prop.equals(idProperty) || (versionProperty != null && prop.equals(versionProperty))) {
+          return;
+        }else if(enableStrictFieldChecking && !prop.isAnnotationPresent(Field.class)){
           return;
         }
 

--- a/src/test/java/org/springframework/data/couchbase/core/mapping/MappingCouchbaseConverterTests.java
+++ b/src/test/java/org/springframework/data/couchbase/core/mapping/MappingCouchbaseConverterTests.java
@@ -52,6 +52,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 /**
  * @author Michael Nitschinger
+ * @author Geoffrey Mina
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(classes = UnitTestApplicationConfig.class)

--- a/src/test/java/org/springframework/data/couchbase/core/mapping/MappingCouchbaseConverterTests.java
+++ b/src/test/java/org/springframework/data/couchbase/core/mapping/MappingCouchbaseConverterTests.java
@@ -16,21 +16,7 @@
 
 package org.springframework.data.couchbase.core.mapping;
 
-import com.couchbase.client.java.repository.annotation.Field;
-import com.couchbase.client.java.repository.annotation.Id;
-import org.joda.time.LocalDateTime;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.core.convert.converter.Converter;
-import org.springframework.data.convert.ReadingConverter;
-import org.springframework.data.convert.WritingConverter;
-import org.springframework.data.couchbase.UnitTestApplicationConfig;
-import org.springframework.data.couchbase.core.convert.CustomConversions;
-import org.springframework.data.couchbase.core.convert.MappingCouchbaseConverter;
-import org.springframework.data.mapping.model.MappingException;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import static org.junit.Assert.*;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
@@ -47,10 +33,21 @@ import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
+import org.joda.time.LocalDateTime;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.convert.ReadingConverter;
+import org.springframework.data.convert.WritingConverter;
+import org.springframework.data.couchbase.UnitTestApplicationConfig;
+import org.springframework.data.couchbase.core.convert.CustomConversions;
+import org.springframework.data.couchbase.core.convert.MappingCouchbaseConverter;
+import org.springframework.data.mapping.model.MappingException;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 /**
  * @author Michael Nitschinger
@@ -504,38 +501,6 @@ public class MappingCouchbaseConverterTests {
     assertEquals("springId", converted.getId());
   }
 
-  @Test
-  public void testStrictFieldChecking() throws Exception{
-    try {
-      CouchbaseDocument converted;
-      AnnotatedEntity entity;
-      converter.setEnableStrictFieldChecking(true);
-
-      converted = new CouchbaseDocument();
-      entity = new AnnotatedEntity();
-      converter.write(entity,converted);
-
-      assertTrue(converted.getId() != null);
-      assertTrue(converted.getPayload().containsKey("annotatedField"));
-      assertFalse(converted.getPayload().containsKey("nonAnnotatedField"));
-
-      converter.setEnableStrictFieldChecking(false);
-
-      converted = new CouchbaseDocument();
-      entity = new AnnotatedEntity();
-      converter.write(entity,converted);
-
-      assertTrue(converted.getId() != null);
-      assertTrue(converted.getPayload().containsKey("annotatedField"));
-      assertTrue(converted.getPayload().containsKey("nonAnnotatedField"));
-
-    }finally{
-      converter.setEnableStrictFieldChecking(false);
-    }
-
-  }
-
-
 
   static class EntityWithoutID {
     private String attr0;
@@ -682,19 +647,6 @@ public class MappingCouchbaseConverterTests {
       this.weight = weight;
     }
   }
-
-  static class AnnotatedEntity{
-    @Id private String uuid;
-    @Field private String annotatedField;
-    private String nonAnnotatedField;
-
-    public AnnotatedEntity(){
-      this.uuid = java.util.UUID.randomUUID().toString();
-      this.annotatedField = "Annotated Property";
-      this.nonAnnotatedField = "Non Annotated Property";
-    }
-  }
-
 
   @WritingConverter
   public static enum BigDecimalToStringConverter implements Converter<BigDecimal, String> {

--- a/src/test/java/org/springframework/data/couchbase/core/mapping/MappingCouchbaseConverterTests.java
+++ b/src/test/java/org/springframework/data/couchbase/core/mapping/MappingCouchbaseConverterTests.java
@@ -33,6 +33,7 @@ import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
 
+import com.couchbase.client.java.repository.annotation.Field;
 import org.joda.time.LocalDateTime;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -501,6 +502,38 @@ public class MappingCouchbaseConverterTests {
     assertEquals("springId", converted.getId());
   }
 
+  @Test
+  public void testStrictFieldChecking() throws Exception{
+    try {
+      CouchbaseDocument converted;
+      AnnotatedEntity entity;
+      converter.setEnableStrictFieldChecking(true);
+
+      converted = new CouchbaseDocument();
+      entity = new AnnotatedEntity();
+      converter.write(entity,converted);
+
+      assertTrue(converted.getId() != null);
+      assertTrue(converted.getPayload().containsKey("annotatedField"));
+      assertFalse(converted.getPayload().containsKey("nonAnnotatedField"));
+
+      converter.setEnableStrictFieldChecking(false);
+
+      converted = new CouchbaseDocument();
+      entity = new AnnotatedEntity();
+      converter.write(entity,converted);
+
+      assertTrue(converted.getId() != null);
+      assertTrue(converted.getPayload().containsKey("annotatedField"));
+      assertTrue(converted.getPayload().containsKey("nonAnnotatedField"));
+
+    }finally{
+      converter.setEnableStrictFieldChecking(false);
+    }
+
+  }
+
+
 
   static class EntityWithoutID {
     private String attr0;
@@ -647,6 +680,20 @@ public class MappingCouchbaseConverterTests {
       this.weight = weight;
     }
   }
+
+  static class AnnotatedEntity{
+    @Id private String uuid;
+    @Field private String annotatedField;
+    private String nonAnnotatedField;
+
+    public AnnotatedEntity(){
+      this.uuid = java.util.UUID.randomUUID().toString();
+      this.annotatedField = "Annotated Property";
+      this.nonAnnotatedField = "Non Annotated Property";
+    }
+  }
+
+
 
   @WritingConverter
   public static enum BigDecimalToStringConverter implements Converter<BigDecimal, String> {

--- a/src/test/java/org/springframework/data/couchbase/core/mapping/MappingCouchbaseConverterTests.java
+++ b/src/test/java/org/springframework/data/couchbase/core/mapping/MappingCouchbaseConverterTests.java
@@ -16,7 +16,21 @@
 
 package org.springframework.data.couchbase.core.mapping;
 
-import static org.junit.Assert.*;
+import com.couchbase.client.java.repository.annotation.Field;
+import com.couchbase.client.java.repository.annotation.Id;
+import org.joda.time.LocalDateTime;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.data.convert.ReadingConverter;
+import org.springframework.data.convert.WritingConverter;
+import org.springframework.data.couchbase.UnitTestApplicationConfig;
+import org.springframework.data.couchbase.core.convert.CustomConversions;
+import org.springframework.data.couchbase.core.convert.MappingCouchbaseConverter;
+import org.springframework.data.mapping.model.MappingException;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
@@ -33,21 +47,10 @@ import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
 
-import org.joda.time.LocalDateTime;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.core.convert.converter.Converter;
-import org.springframework.data.annotation.Id;
-import org.springframework.data.convert.ReadingConverter;
-import org.springframework.data.convert.WritingConverter;
-import org.springframework.data.couchbase.UnitTestApplicationConfig;
-import org.springframework.data.couchbase.core.convert.CustomConversions;
-import org.springframework.data.couchbase.core.convert.MappingCouchbaseConverter;
-import org.springframework.data.mapping.model.MappingException;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
 
 /**
  * @author Michael Nitschinger
@@ -501,6 +504,38 @@ public class MappingCouchbaseConverterTests {
     assertEquals("springId", converted.getId());
   }
 
+  @Test
+  public void testStrictFieldChecking() throws Exception{
+    try {
+      CouchbaseDocument converted;
+      AnnotatedEntity entity;
+      converter.setEnableStrictFieldChecking(true);
+
+      converted = new CouchbaseDocument();
+      entity = new AnnotatedEntity();
+      converter.write(entity,converted);
+
+      assertTrue(converted.getId() != null);
+      assertTrue(converted.getPayload().containsKey("annotatedField"));
+      assertFalse(converted.getPayload().containsKey("nonAnnotatedField"));
+
+      converter.setEnableStrictFieldChecking(false);
+
+      converted = new CouchbaseDocument();
+      entity = new AnnotatedEntity();
+      converter.write(entity,converted);
+
+      assertTrue(converted.getId() != null);
+      assertTrue(converted.getPayload().containsKey("annotatedField"));
+      assertTrue(converted.getPayload().containsKey("nonAnnotatedField"));
+
+    }finally{
+      converter.setEnableStrictFieldChecking(false);
+    }
+
+  }
+
+
 
   static class EntityWithoutID {
     private String attr0;
@@ -647,6 +682,19 @@ public class MappingCouchbaseConverterTests {
       this.weight = weight;
     }
   }
+
+  static class AnnotatedEntity{
+    @Id private String uuid;
+    @Field private String annotatedField;
+    private String nonAnnotatedField;
+
+    public AnnotatedEntity(){
+      this.uuid = java.util.UUID.randomUUID().toString();
+      this.annotatedField = "Annotated Property";
+      this.nonAnnotatedField = "Non Annotated Property";
+    }
+  }
+
 
   @WritingConverter
   public static enum BigDecimalToStringConverter implements Converter<BigDecimal, String> {


### PR DESCRIPTION
Greetings,
This patch solves a problem I was having with circular references.  Our use case was pulling some complex objects from MySQL via Hibernate that had OneToMany relationships using the "mappedby" which requires circular references.  

This change modifies the MappingCouchbaseConverter to (optionally) be strict about the @Field annotation.  If setEnableStrictFieldChecking(true) is called, the mapper will only process properties that are annotated and ignore non-annotated properties entirely.

I have also submitted test coverage to show that the expected behavior is present with the boolean in both the true and false state.

Thanks for your consideration.
Geoff Mina