### PR TITLE
DATACOUCH-235 - Fixed multiple Couchbase environments.

### DIFF
--- a/src/main/java/org/springframework/data/couchbase/config/CouchbaseEnvironmentFactoryBean.java
+++ b/src/main/java/org/springframework/data/couchbase/config/CouchbaseEnvironmentFactoryBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2015 the original author or authors
+ * Copyright 2012-2016 the original author or authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import com.couchbase.client.core.retry.FailFastRetryStrategy;
 import com.couchbase.client.core.retry.RetryStrategy;
 import com.couchbase.client.java.env.CouchbaseEnvironment;
 import com.couchbase.client.java.env.DefaultCouchbaseEnvironment;
+import com.couchbase.client.java.env.DefaultCouchbaseEnvironment.Builder;
 
 import org.springframework.beans.factory.config.AbstractFactoryBean;
 
@@ -28,47 +29,14 @@ import org.springframework.beans.factory.config.AbstractFactoryBean;
  * Factory Bean to help create a CouchbaseEnvironment (by offering setters for supported tuning methods).
  *
  * @author Simon Baslé
+ * @author Simon Bland
  */
 /*package*/ class CouchbaseEnvironmentFactoryBean extends AbstractFactoryBean<CouchbaseEnvironment> {
 
-  private static final CouchbaseEnvironment DEFAULT_ENV = DefaultCouchbaseEnvironment.create();
   public static final String RETRYSTRATEGY_FAILFAST = "FailFast";
   public static final String RETRYSTRATEGY_BESTEFFORT = "BestEffort";
-
-  private long managementTimeout = DEFAULT_ENV.managementTimeout();
-  private long queryTimeout = DEFAULT_ENV.queryTimeout();
-  private long viewTimeout = DEFAULT_ENV.viewTimeout();
-  private long kvTimeout = DEFAULT_ENV.kvTimeout();
-  private long connectTimeout = DEFAULT_ENV.connectTimeout();
-  private long disconnectTimeout = DEFAULT_ENV.disconnectTimeout();
-  private boolean dnsSrvEnabled = DEFAULT_ENV.dnsSrvEnabled();
-
-  private boolean dcpEnabled = DEFAULT_ENV.dcpEnabled();
-  private boolean sslEnabled = DEFAULT_ENV.sslEnabled();
-  private String sslKeystoreFile = DEFAULT_ENV.sslKeystoreFile();
-  private String sslKeystorePassword = DEFAULT_ENV.sslKeystorePassword();
-  private boolean queryEnabled = DEFAULT_ENV.queryEnabled();
-  private int queryPort = DEFAULT_ENV.queryPort();
-  private boolean bootstrapHttpEnabled = DEFAULT_ENV.bootstrapHttpEnabled();
-  private boolean bootstrapCarrierEnabled = DEFAULT_ENV.bootstrapCarrierEnabled();
-  private int bootstrapHttpDirectPort = DEFAULT_ENV.bootstrapHttpDirectPort();
-  private int bootstrapHttpSslPort = DEFAULT_ENV.bootstrapHttpSslPort();
-  private int bootstrapCarrierDirectPort = DEFAULT_ENV.bootstrapCarrierDirectPort();
-  private int bootstrapCarrierSslPort = DEFAULT_ENV.bootstrapCarrierSslPort();
-  private int ioPoolSize = DEFAULT_ENV.ioPoolSize();
-  private int computationPoolSize = DEFAULT_ENV.computationPoolSize();
-  private int responseBufferSize = DEFAULT_ENV.responseBufferSize();
-  private int requestBufferSize = DEFAULT_ENV.requestBufferSize();
-  private int kvEndpoints = DEFAULT_ENV.kvEndpoints();
-  private int viewEndpoints = DEFAULT_ENV.viewEndpoints();
-  private int queryEndpoints = DEFAULT_ENV.queryEndpoints();
-  private RetryStrategy retryStrategy = DEFAULT_ENV.retryStrategy();
-  private long maxRequestLifetime = DEFAULT_ENV.maxRequestLifetime();
-  private long keepAliveInterval = DEFAULT_ENV.keepAliveInterval();
-  private long autoreleaseAfter = DEFAULT_ENV.autoreleaseAfter();
-  private boolean bufferPoolingEnabled = DEFAULT_ENV.bufferPoolingEnabled();
-  private boolean tcpNodelayEnabled = DEFAULT_ENV.tcpNodelayEnabled();
-  private boolean mutationTokensEnabled = DEFAULT_ENV.mutationTokensEnabled();
+  
+  private final Builder couchbaseEnvBuilder = DefaultCouchbaseEnvironment.builder();
 
   /*
   These are tunings that are not practical to be exposed in a xml configuration
@@ -92,41 +60,7 @@ import org.springframework.beans.factory.config.AbstractFactoryBean;
 
   @Override
   protected CouchbaseEnvironment createInstance() throws Exception {
-    return DefaultCouchbaseEnvironment.builder()
-        .managementTimeout(managementTimeout)
-        .queryTimeout(queryTimeout)
-        .viewTimeout(viewTimeout)
-        .kvTimeout(kvTimeout)
-        .connectTimeout(connectTimeout)
-        .disconnectTimeout(disconnectTimeout)
-        .dnsSrvEnabled(dnsSrvEnabled)
-        .dcpEnabled(dcpEnabled)
-        .sslEnabled(sslEnabled)
-        .sslKeystoreFile(sslKeystoreFile)
-        .sslKeystorePassword(sslKeystorePassword)
-        .queryEnabled(queryEnabled)
-        .queryPort(queryPort)
-        .bootstrapHttpEnabled(bootstrapHttpEnabled)
-        .bootstrapCarrierEnabled(bootstrapCarrierEnabled)
-        .bootstrapHttpDirectPort(bootstrapHttpDirectPort)
-        .bootstrapHttpSslPort(bootstrapHttpSslPort)
-        .bootstrapCarrierDirectPort(bootstrapCarrierDirectPort)
-        .bootstrapCarrierSslPort(bootstrapCarrierSslPort)
-        .ioPoolSize(ioPoolSize)
-        .computationPoolSize(computationPoolSize)
-        .responseBufferSize(responseBufferSize)
-        .requestBufferSize(requestBufferSize)
-        .kvEndpoints(kvEndpoints)
-        .viewEndpoints(viewEndpoints)
-        .queryEndpoints(queryEndpoints)
-        .retryStrategy(retryStrategy)
-        .maxRequestLifetime(maxRequestLifetime)
-        .keepAliveInterval(keepAliveInterval)
-        .autoreleaseAfter(autoreleaseAfter)
-        .bufferPoolingEnabled(bufferPoolingEnabled)
-        .tcpNodelayEnabled(tcpNodelayEnabled)
-        .mutationTokensEnabled(mutationTokensEnabled)
-        .build();
+    return couchbaseEnvBuilder.build();
   }
 
   /**
@@ -137,139 +71,139 @@ import org.springframework.beans.factory.config.AbstractFactoryBean;
    */
   public void setRetryStrategy(String retryStrategy) {
     if (RETRYSTRATEGY_FAILFAST.equals(retryStrategy)) {
-      this.retryStrategy = FailFastRetryStrategy.INSTANCE;
+      this.couchbaseEnvBuilder.retryStrategy(FailFastRetryStrategy.INSTANCE);
     } else if (RETRYSTRATEGY_BESTEFFORT.equals(retryStrategy)) {
-      this.retryStrategy = BestEffortRetryStrategy.INSTANCE;
+      this.couchbaseEnvBuilder.retryStrategy(BestEffortRetryStrategy.INSTANCE);
     }
   }
 
   //==== SETTERS for the factory bean ====
 
   public void setManagementTimeout(long managementTimeout) {
-    this.managementTimeout = managementTimeout;
+    this.couchbaseEnvBuilder.managementTimeout(managementTimeout);
   }
 
   public void setQueryTimeout(long queryTimeout) {
-    this.queryTimeout = queryTimeout;
+    this.couchbaseEnvBuilder.queryTimeout(queryTimeout);
   }
 
   public void setViewTimeout(long viewTimeout) {
-    this.viewTimeout = viewTimeout;
+    this.couchbaseEnvBuilder.viewTimeout(viewTimeout);
   }
 
   public void setKvTimeout(long kvTimeout) {
-    this.kvTimeout = kvTimeout;
+    this.couchbaseEnvBuilder.kvTimeout(kvTimeout);
   }
 
   public void setConnectTimeout(long connectTimeout) {
-    this.connectTimeout = connectTimeout;
+    this.couchbaseEnvBuilder.connectTimeout(connectTimeout);
   }
 
   public void setDisconnectTimeout(long disconnectTimeout) {
-    this.disconnectTimeout = disconnectTimeout;
+    this.couchbaseEnvBuilder.disconnectTimeout(disconnectTimeout);
   }
 
   public void setDnsSrvEnabled(boolean dnsSrvEnabled) {
-    this.dnsSrvEnabled = dnsSrvEnabled;
+    this.couchbaseEnvBuilder.dnsSrvEnabled(dnsSrvEnabled);
   }
 
   public void setDcpEnabled(boolean dcpEnabled) {
-    this.dcpEnabled = dcpEnabled;
+    this.couchbaseEnvBuilder.dcpEnabled(dcpEnabled);
   }
 
   public void setSslEnabled(boolean sslEnabled) {
-    this.sslEnabled = sslEnabled;
+    this.couchbaseEnvBuilder.sslEnabled(sslEnabled);
   }
 
   public void setSslKeystoreFile(String sslKeystoreFile) {
-    this.sslKeystoreFile = sslKeystoreFile;
+    this.couchbaseEnvBuilder.sslKeystoreFile(sslKeystoreFile);
   }
 
   public void setSslKeystorePassword(String sslKeystorePassword) {
-    this.sslKeystorePassword = sslKeystorePassword;
+    this.couchbaseEnvBuilder.sslKeystorePassword(sslKeystorePassword);
   }
 
   public void setQueryEnabled(boolean queryEnabled) {
-    this.queryEnabled = queryEnabled;
+    this.couchbaseEnvBuilder.queryEnabled(queryEnabled);
   }
 
   public void setQueryPort(int queryPort) {
-    this.queryPort = queryPort;
+    this.couchbaseEnvBuilder.queryPort(queryPort);
   }
 
   public void setBootstrapHttpEnabled(boolean bootstrapHttpEnabled) {
-    this.bootstrapHttpEnabled = bootstrapHttpEnabled;
+    this.couchbaseEnvBuilder.bootstrapHttpEnabled(bootstrapHttpEnabled);
   }
 
   public void setBootstrapCarrierEnabled(boolean bootstrapCarrierEnabled) {
-    this.bootstrapCarrierEnabled = bootstrapCarrierEnabled;
+    this.couchbaseEnvBuilder.bootstrapCarrierEnabled(bootstrapCarrierEnabled);
   }
 
   public void setBootstrapHttpDirectPort(int bootstrapHttpDirectPort) {
-    this.bootstrapHttpDirectPort = bootstrapHttpDirectPort;
+    this.couchbaseEnvBuilder.bootstrapHttpDirectPort(bootstrapHttpDirectPort);
   }
 
   public void setBootstrapHttpSslPort(int bootstrapHttpSslPort) {
-    this.bootstrapHttpSslPort = bootstrapHttpSslPort;
+    this.couchbaseEnvBuilder.bootstrapHttpSslPort(bootstrapHttpSslPort);
   }
 
   public void setBootstrapCarrierDirectPort(int bootstrapCarrierDirectPort) {
-    this.bootstrapCarrierDirectPort = bootstrapCarrierDirectPort;
+    this.couchbaseEnvBuilder.bootstrapCarrierDirectPort(bootstrapCarrierDirectPort);
   }
 
   public void setBootstrapCarrierSslPort(int bootstrapCarrierSslPort) {
-    this.bootstrapCarrierSslPort = bootstrapCarrierSslPort;
+    this.couchbaseEnvBuilder.bootstrapCarrierSslPort(bootstrapCarrierSslPort);
   }
 
   public void setIoPoolSize(int ioPoolSize) {
-    this.ioPoolSize = ioPoolSize;
+    this.couchbaseEnvBuilder.ioPoolSize(ioPoolSize);
   }
 
   public void setComputationPoolSize(int computationPoolSize) {
-    this.computationPoolSize = computationPoolSize;
+    this.couchbaseEnvBuilder.computationPoolSize(computationPoolSize);
   }
 
   public void setResponseBufferSize(int responseBufferSize) {
-    this.responseBufferSize = responseBufferSize;
+    this.couchbaseEnvBuilder.responseBufferSize(responseBufferSize);
   }
 
   public void setRequestBufferSize(int requestBufferSize) {
-    this.requestBufferSize = requestBufferSize;
+    this.couchbaseEnvBuilder.requestBufferSize(requestBufferSize);
   }
 
   public void setKvEndpoints(int kvEndpoints) {
-    this.kvEndpoints = kvEndpoints;
+    this.couchbaseEnvBuilder.kvEndpoints(kvEndpoints);
   }
 
   public void setViewEndpoints(int viewEndpoints) {
-    this.viewEndpoints = viewEndpoints;
+    this.couchbaseEnvBuilder.viewEndpoints(viewEndpoints);
   }
 
   public void setQueryEndpoints(int queryEndpoints) {
-    this.queryEndpoints = queryEndpoints;
+    this.couchbaseEnvBuilder.queryEndpoints(queryEndpoints);
   }
 
   public void setMaxRequestLifetime(long maxRequestLifetime) {
-    this.maxRequestLifetime = maxRequestLifetime;
+    this.couchbaseEnvBuilder.maxRequestLifetime(maxRequestLifetime);
   }
 
   public void setKeepAliveInterval(long keepAliveInterval) {
-    this.keepAliveInterval = keepAliveInterval;
+    this.couchbaseEnvBuilder.keepAliveInterval(keepAliveInterval);
   }
 
   public void setAutoreleaseAfter(long autoreleaseAfter) {
-    this.autoreleaseAfter = autoreleaseAfter;
+    this.couchbaseEnvBuilder.autoreleaseAfter(autoreleaseAfter);
   }
 
   public void setBufferPoolingEnabled(boolean bufferPoolingEnabled) {
-    this.bufferPoolingEnabled = bufferPoolingEnabled;
+    this.couchbaseEnvBuilder.bufferPoolingEnabled(bufferPoolingEnabled);
   }
 
   public void setTcpNodelayEnabled(boolean tcpNodelayEnabled) {
-    this.tcpNodelayEnabled = tcpNodelayEnabled;
+    this.couchbaseEnvBuilder.tcpNodelayEnabled(tcpNodelayEnabled);
   }
 
   public void setMutationTokensEnabled(boolean mutationTokensEnabled) {
-    this.mutationTokensEnabled = mutationTokensEnabled;
+    this.couchbaseEnvBuilder.mutationTokensEnabled(mutationTokensEnabled);
   }
 }

--- a/src/test/java/org/springframework/data/couchbase/config/CouchbaseSingleEnvironmentParserTest.java
+++ b/src/test/java/org/springframework/data/couchbase/config/CouchbaseSingleEnvironmentParserTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2012-2016 the original author or authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.data.couchbase.config;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+import org.springframework.beans.factory.support.BeanDefinitionReader;
+import org.springframework.beans.factory.support.DefaultListableBeanFactory;
+import org.springframework.beans.factory.xml.XmlBeanDefinitionReader;
+import org.springframework.context.support.GenericApplicationContext;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.couchbase.client.core.env.DefaultCoreEnvironment;
+import com.couchbase.client.java.env.CouchbaseEnvironment;
+import com.couchbase.client.java.env.DefaultCouchbaseEnvironment;
+
+/**
+ * @author Simon Bland
+ */
+public class CouchbaseSingleEnvironmentParserTest {
+  
+  /**
+   * @see DATACOUCH-235
+   */
+  @Test
+  public void testSingleCouchbaseEnvironment() throws Exception {
+    
+    Integer instanceCounterBefore = (Integer) ReflectionTestUtils.getField(DefaultCoreEnvironment.class, "instanceCounter");
+    
+    DefaultListableBeanFactory factory = new DefaultListableBeanFactory();
+    BeanDefinitionReader reader = new XmlBeanDefinitionReader(factory);
+    reader.loadBeanDefinitions(new ClassPathResource("configurations/couchbaseSingleEnv-bean.xml"));
+    GenericApplicationContext context = new GenericApplicationContext(factory);
+    context.refresh();
+    CouchbaseEnvironment env = context.getBean("singleEnv", CouchbaseEnvironment.class);
+    context.close();
+    
+    Integer instanceCounterAfter = (Integer) ReflectionTestUtils.getField(DefaultCoreEnvironment.class, "instanceCounter");
+    
+    assertThat(env, is(instanceOf(DefaultCouchbaseEnvironment.class)));
+    assertThat(instanceCounterAfter, is(instanceCounterBefore + 1));
+  }
+}

--- a/src/test/resources/configurations/couchbaseSingleEnv-bean.xml
+++ b/src/test/resources/configurations/couchbaseSingleEnv-bean.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:couchbase="http://www.springframework.org/schema/data/couchbase"
+       xsi:schemaLocation="http://www.springframework.org/schema/data/couchbase http://www.springframework.org/schema/data/couchbase/spring-couchbase.xsd
+                           http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+                           http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
+
+    <couchbase:env id="singleEnv"/>
+
+</beans>


### PR DESCRIPTION
Defining `<couchbase:env/>` in [XML configuration](http://docs.spring.io/spring-data/couchbase/docs/2.0.0.RELEASE/reference/html/#configuration-xml) was causing a double
instantiation of DefaultCoreEnvironment, with subsequent warning in
logs:

```
[main] WARN c.c.client.core.env.CoreEnvironment - More than 1 Couchbase
Environments found (2), this can have severe impact on performance and
stability. Reuse environments!
```