### PR TITLE
DATACOUCH-265: Support pageable and sort for String based SpEL queries

### DIFF
--- a/src/integration/java/org/springframework/data/couchbase/repository/N1qlCouchbaseRepositoryTests.java
+++ b/src/integration/java/org/springframework/data/couchbase/repository/N1qlCouchbaseRepositoryTests.java
@@ -33,6 +33,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
+import org.springframework.data.mapping.model.MappingInstantiationException;
 import org.springframework.data.repository.core.support.RepositoryFactorySupport;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestExecutionListeners;
@@ -176,5 +177,12 @@ public class N1qlCouchbaseRepositoryTests {
       }
       previousAttendees = party.getAttendees();
     }
+  }
+
+  //Fails on deserialization as a different entity item is also present
+  @Test(expected = MappingInstantiationException.class)
+  public void shouldFailWithMissingFilterStringBasedQuery() {
+    Sort sort = new Sort(Sort.Direction.DESC, "attendees");
+    List<Party> parties = partyRepository.findParties(sort);
   }
 }

--- a/src/integration/java/org/springframework/data/couchbase/repository/PartyRepository.java
+++ b/src/integration/java/org/springframework/data/couchbase/repository/PartyRepository.java
@@ -9,6 +9,7 @@ import org.springframework.data.couchbase.core.query.View;
 import org.springframework.data.couchbase.core.query.ViewIndexed;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.repository.query.Param;
 
 /**
@@ -46,6 +47,9 @@ public interface PartyRepository extends CouchbaseRepository<Party, String> {
 
   @Query("#{#n1ql.selectEntity} WHERE #{#n1ql.filter} AND `attendees` >= $1")
   Page<Party> findPartiesWithAttendee(int count, Pageable pageable);
+
+  @Query("#{#n1ql.selectEntity}")
+  List<Party> findParties(Sort sort);
 
   @Query("#{#n1ql.selectEntity} WHERE #{#n1ql.filter} AND `desc` LIKE '%' || $included ||  '%' AND attendees >= $min" +
       " AND `desc` NOT LIKE '%' || $excluded || '%'")

--- a/src/integration/java/org/springframework/data/couchbase/repository/PartyRepository.java
+++ b/src/integration/java/org/springframework/data/couchbase/repository/PartyRepository.java
@@ -7,6 +7,8 @@ import org.springframework.data.couchbase.core.query.N1qlSecondaryIndexed;
 import org.springframework.data.couchbase.core.query.Query;
 import org.springframework.data.couchbase.core.query.View;
 import org.springframework.data.couchbase.core.query.ViewIndexed;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.repository.query.Param;
 
 /**
@@ -41,6 +43,9 @@ public interface PartyRepository extends CouchbaseRepository<Party, String> {
 
   @Query("SELECT 1 = 1")
   boolean justABoolean();
+
+  @Query("#{#n1ql.selectEntity} WHERE #{#n1ql.filter} AND `attendees` >= $1")
+  Page<Party> findPartiesWithAttendee(int count, Pageable pageable);
 
   @Query("#{#n1ql.selectEntity} WHERE #{#n1ql.filter} AND `desc` LIKE '%' || $included ||  '%' AND attendees >= $min" +
       " AND `desc` NOT LIKE '%' || $excluded || '%'")

--- a/src/main/asciidoc/repository.adoc
+++ b/src/main/asciidoc/repository.adoc
@@ -263,6 +263,8 @@ It adds two methods:
 
 TIP: You can also use `Page` and `Slice` as method return types as well with a N1QL backed repository.
 
+NOTE: If pageable and sort parameters are used with inline queries, there should not be any order by, limit or offset clause in the inline query itself otherwise the server would reject the query as malformed.
+
 The second way of querying, supported also in older versions of Couchbase Server, is the View-backed one that we'll see in the next section.
 
 [[couchbase.repository.views]]

--- a/src/test/java/org/springframework/data/couchbase/repository/query/PartTreeN1qBasedQueryTest.java
+++ b/src/test/java/org/springframework/data/couchbase/repository/query/PartTreeN1qBasedQueryTest.java
@@ -76,7 +76,7 @@ public class PartTreeN1qBasedQueryTest {
 		PartTreeN1qlBasedQuery query = new PartTreeN1qlBasedQuery(queryMethod, couchbaseOperations);
 		Statement statement = query.getCount(accessor, new Object[] { "value", pr });
 
-		assertEquals("SELECT COUNT(*) AS count FROM `default` WHERE name = \"value\" "
+		assertEquals("SELECT COUNT(*) AS count FROM `default` WHERE (name = \"value\") "
 				+ "AND `_class` = \"org.springframework.data.couchbase.core.Beer\"", statement.toString());
 
 	}
@@ -119,7 +119,7 @@ public class PartTreeN1qBasedQueryTest {
 		PartTreeN1qlBasedQuery query = new PartTreeN1qlBasedQuery(queryMethod, couchbaseOperations);
 		Statement statement = query.getCount(accessor, new Object[] { "value", pr });
 
-		assertEquals("SELECT COUNT(*) AS count FROM `default` WHERE name = \"value\" "
+		assertEquals("SELECT COUNT(*) AS count FROM `default` WHERE (name = \"value\") "
 				+ "AND `_class` = \"org.springframework.data.couchbase.core.Beer\"", statement.toString());
 
 	}


### PR DESCRIPTION
Pageable and sort parameters were ignored before. This should fix it.