### PR TITLE
Update to client 2.4.1 and fix tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,8 +21,8 @@
 
         <dist.key>DATACOUCH</dist.key>
 
-        <couchbase>2.2.8</couchbase>
-        <couchbase.osgi>2.2.8</couchbase.osgi>
+        <couchbase>2.4.1</couchbase>
+        <couchbase.osgi>2.4.1</couchbase.osgi>
         <springdata.commons>1.14.0.BUILD-SNAPSHOT</springdata.commons>
         <validation>1.0.0.GA</validation>
     </properties>

--- a/src/integration/java/org/springframework/data/couchbase/repository/CouchbaseRepositoryViewTests.java
+++ b/src/integration/java/org/springframework/data/couchbase/repository/CouchbaseRepositoryViewTests.java
@@ -134,9 +134,9 @@ public class CouchbaseRepositoryViewTests {
     String highKey = "uname-11";
     List<String> keys = Arrays.asList(lowKey, middleKey, highKey);
 
-    User u1 = repository.findByUsernameIs(lowKey);
-    User u2 = repository.findByUsernameIs(middleKey);
-    User u3 = repository.findByUsernameIs(highKey);
+    User u1 = repository.findByUsernameIs(lowKey).get(0);
+    User u2 = repository.findByUsernameIs(middleKey).get(0);
+    User u3 = repository.findByUsernameIs(highKey).get(0);
 
 
     List<User> in = repository.findAllByUsernameIn(keys);

--- a/src/integration/java/org/springframework/data/couchbase/repository/CustomUserRepository.java
+++ b/src/integration/java/org/springframework/data/couchbase/repository/CustomUserRepository.java
@@ -46,7 +46,7 @@ public interface CustomUserRepository extends CouchbaseRepository<User, String> 
   long countByUsernameGreaterThanEqualAndUsernameLessThan(String lowBound, String highBound);
 
   @View(viewName = "customFindByNameView")
-  User findByUsernameIs(String lowKey);
+  List<User> findByUsernameIs(String lowKey);
 
   @View(viewName = "customFindByNameView")
   List<User> findAllByUsernameIn(List<String> keys);

--- a/src/integration/java/org/springframework/data/couchbase/repository/index/IndexedRepositoryTestListener.java
+++ b/src/integration/java/org/springframework/data/couchbase/repository/index/IndexedRepositoryTestListener.java
@@ -1,6 +1,7 @@
 package org.springframework.data.couchbase.repository.index;
 
 import com.couchbase.client.java.Bucket;
+import com.couchbase.client.java.error.DesignDocumentDoesNotExistException;
 import com.couchbase.client.java.query.Index;
 import com.couchbase.client.java.query.N1qlQuery;
 
@@ -18,8 +19,12 @@ public class IndexedRepositoryTestListener extends DependencyInjectionTestExecut
   @Override
   public void beforeTestClass(final TestContext testContext) throws Exception {
     Bucket client = (Bucket) testContext.getApplicationContext().getBean(BeanNames.COUCHBASE_BUCKET);
-    client.bucketManager().removeDesignDocument(IndexedRepositoryTests.VIEW_DOC);
-    client.bucketManager().removeDesignDocument("foo");
+    try {
+      client.bucketManager().removeDesignDocument(IndexedRepositoryTests.VIEW_DOC);
+      client.bucketManager().removeDesignDocument("foo");
+    } catch (DesignDocumentDoesNotExistException ex) {
+      //ignore
+    }
     client.query(N1qlQuery.simple(Index.dropPrimaryIndex(client.name())));
     client.query(N1qlQuery.simple(Index.dropIndex(client.name(), IndexedRepositoryTests.SECONDARY)));
   }

--- a/src/main/java/org/springframework/data/couchbase/config/CouchbaseEnvironmentFactoryBean.java
+++ b/src/main/java/org/springframework/data/couchbase/config/CouchbaseEnvironmentFactoryBean.java
@@ -123,14 +123,6 @@ import org.springframework.beans.factory.config.AbstractFactoryBean;
     this.couchbaseEnvBuilder.sslKeystorePassword(sslKeystorePassword);
   }
 
-  public void setQueryEnabled(boolean queryEnabled) {
-    this.couchbaseEnvBuilder.queryEnabled(queryEnabled);
-  }
-
-  public void setQueryPort(int queryPort) {
-    this.couchbaseEnvBuilder.queryPort(queryPort);
-  }
-
   public void setBootstrapHttpEnabled(boolean bootstrapHttpEnabled) {
     this.couchbaseEnvBuilder.bootstrapHttpEnabled(bootstrapHttpEnabled);
   }

--- a/src/main/java/org/springframework/data/couchbase/config/CouchbaseEnvironmentNoShutdownProxy.java
+++ b/src/main/java/org/springframework/data/couchbase/config/CouchbaseEnvironmentNoShutdownProxy.java
@@ -16,9 +16,14 @@
 
 package org.springframework.data.couchbase.config;
 
+import java.security.KeyStore;
+import java.util.concurrent.TimeUnit;
+
+import com.couchbase.client.core.env.WaitStrategyFactory;
 import com.couchbase.client.core.event.EventBus;
 import com.couchbase.client.core.metrics.MetricsCollector;
 import com.couchbase.client.core.metrics.NetworkLatencyMetricsCollector;
+import com.couchbase.client.core.node.MemcachedHashingStrategy;
 import com.couchbase.client.core.retry.RetryStrategy;
 import com.couchbase.client.core.time.Delay;
 import com.couchbase.client.deps.io.netty.channel.EventLoopGroup;
@@ -42,8 +47,8 @@ public class CouchbaseEnvironmentNoShutdownProxy implements CouchbaseEnvironment
   }
 
   @Override
-  public Observable<Boolean> shutdown() {
-    return Observable.just(false);
+  public boolean shutdown() {
+    return false;
   }
 
   //===== DELEGATION METHODS =====
@@ -56,6 +61,11 @@ public class CouchbaseEnvironmentNoShutdownProxy implements CouchbaseEnvironment
   @Override
   public EventLoopGroup ioPool() {
     return delegate.ioPool();
+  }
+
+  @Override
+  public EventLoopGroup kvIoPool() {
+    return delegate.kvIoPool();
   }
 
   @Override
@@ -81,18 +91,6 @@ public class CouchbaseEnvironmentNoShutdownProxy implements CouchbaseEnvironment
   @Override
   public String sslKeystorePassword() {
     return delegate.sslKeystorePassword();
-  }
-
-  @Override
-  @Deprecated
-  public boolean queryEnabled() {
-    return delegate.queryEnabled();
-  }
-
-  @Override
-  @Deprecated
-  public int queryPort() {
-    return delegate.queryPort();
   }
 
   @Override
@@ -323,5 +321,40 @@ public class CouchbaseEnvironmentNoShutdownProxy implements CouchbaseEnvironment
   @Override
   public long searchTimeout() {
     return delegate.searchTimeout();
+  }
+
+  @Override
+  public WaitStrategyFactory requestBufferWaitStrategy() {
+    return delegate.requestBufferWaitStrategy();
+  }
+
+  @Override
+  public EventLoopGroup viewIoPool() {
+    return delegate.viewIoPool();
+  }
+
+  @Override
+  public EventLoopGroup searchIoPool() {
+    return delegate.searchIoPool();
+  }
+
+  @Override
+  public EventLoopGroup queryIoPool() {
+    return delegate.queryIoPool();
+  }
+
+  @Override
+  public KeyStore sslKeystore() {
+    return delegate.sslKeystore();
+  }
+
+  @Override
+  public boolean shutdown(long timeout, TimeUnit timeUnit) {
+    return delegate.shutdown(timeout, timeUnit);
+  }
+
+  @Override
+  public MemcachedHashingStrategy memcachedHashingStrategy() {
+    return delegate.memcachedHashingStrategy();
   }
 }

--- a/src/main/java/org/springframework/data/couchbase/config/CouchbaseEnvironmentParser.java
+++ b/src/main/java/org/springframework/data/couchbase/config/CouchbaseEnvironmentParser.java
@@ -117,8 +117,6 @@ public class CouchbaseEnvironmentParser extends AbstractSingleBeanDefinitionPars
 		setPropertyValue(envDefinitionBuilder, envElement, "sslEnabled", "sslEnabled");
 		setPropertyValue(envDefinitionBuilder, envElement, "sslKeystoreFile", "sslKeystoreFile");
 		setPropertyValue(envDefinitionBuilder, envElement, "sslKeystorePassword", "sslKeystorePassword");
-		setPropertyValue(envDefinitionBuilder, envElement, "queryEnabled", "queryEnabled");
-		setPropertyValue(envDefinitionBuilder, envElement, "queryPort", "queryPort");
 		setPropertyValue(envDefinitionBuilder, envElement, "bootstrapHttpEnabled", "bootstrapHttpEnabled");
 		setPropertyValue(envDefinitionBuilder, envElement, "bootstrapCarrierEnabled", "bootstrapCarrierEnabled");
 		setPropertyValue(envDefinitionBuilder, envElement, "bootstrapHttpDirectPort", "bootstrapHttpDirectPort");

--- a/src/main/java/org/springframework/data/couchbase/repository/support/IndexManager.java
+++ b/src/main/java/org/springframework/data/couchbase/repository/support/IndexManager.java
@@ -23,6 +23,7 @@ import java.util.Collections;
 
 import com.couchbase.client.java.bucket.BucketManager;
 import com.couchbase.client.java.document.json.JsonObject;
+import com.couchbase.client.java.error.DesignDocumentDoesNotExistException;
 import com.couchbase.client.java.query.AsyncN1qlQueryResult;
 import com.couchbase.client.java.query.Index;
 import com.couchbase.client.java.query.Statement;
@@ -241,7 +242,12 @@ public class IndexManager {
     }
 
     com.couchbase.client.java.view.View view = DefaultView.create(viewName, mapFunction, reduceFunction);
-    DesignDocument doc = manager.getDesignDocument(config.designDoc());
+    DesignDocument doc = null;
+    try {
+      doc = manager.getDesignDocument(config.designDoc());
+    } catch(DesignDocumentDoesNotExistException ex) {
+      //ignore
+    }
     if (doc != null) {
       for (com.couchbase.client.java.view.View existingView : doc.views()) {
         if (existingView.name().equals(viewName)) {

--- a/src/test/java/org/springframework/data/couchbase/config/CouchbaseEnvironmentParserTest.java
+++ b/src/test/java/org/springframework/data/couchbase/config/CouchbaseEnvironmentParserTest.java
@@ -79,8 +79,6 @@ public class CouchbaseEnvironmentParserTest {
     assertThat(env.sslEnabled(), allOf(equalTo(true), not(defaultEnv.sslEnabled())));
     assertThat(env.sslKeystoreFile(), is(equalTo("test")));
     assertThat(env.sslKeystorePassword(), is(equalTo("test")));
-    assertThat(env.queryEnabled(), allOf(equalTo(true), not(defaultEnv.queryEnabled())));
-    assertThat(env.queryPort(), is(equalTo(7)));
     assertThat(env.bootstrapHttpEnabled(), allOf(equalTo(false), not(defaultEnv.bootstrapHttpEnabled())));
     assertThat(env.bootstrapCarrierEnabled(), allOf(equalTo(false), not(defaultEnv.bootstrapCarrierEnabled())));
     assertThat(env.bootstrapHttpDirectPort(), is(equalTo(8)));

--- a/src/test/java/org/springframework/data/couchbase/repository/RepositoryIndexUsageTest.java
+++ b/src/test/java/org/springframework/data/couchbase/repository/RepositoryIndexUsageTest.java
@@ -75,7 +75,7 @@ public class RepositoryIndexUsageTest {
 
   @Test
   public void testFindAllUsesViewWithConfiguredConsistency() {
-    String expectedQueryParams = "reduce=false&stale=false";
+    String expectedQueryParams = "ViewQuery(string/all){params=\"reduce=false&stale=false\"}";
     repository.findAll();
 
     verify(couchbaseOperations, never()).queryView(any(ViewQuery.class));
@@ -89,7 +89,7 @@ public class RepositoryIndexUsageTest {
 
   @Test
   public void testFindAllKeysUsesViewWithConfiguredConsistency() {
-    String expectedQueryParams = "reduce=false&stale=false";
+    String expectedQueryParams = "ViewQuery(string/all){params=\"reduce=false&stale=false\", keys=\"[\"someKey\"]\"}";
     repository.findAll(Collections.singleton("someKey"));
 
     verify(couchbaseOperations, never()).queryView(any(ViewQuery.class));
@@ -103,7 +103,7 @@ public class RepositoryIndexUsageTest {
 
   @Test
   public void testCountUsesViewWithConfiguredConsistencyAndReduces() {
-    String expectedQueryParams = "reduce=true&stale=false";
+    String expectedQueryParams = "ViewQuery(string/all){params=\"reduce=true&stale=false\"}";
     repository.count();
 
     verify(couchbaseOperations, never()).findByView(any(ViewQuery.class), any(Class.class));
@@ -123,7 +123,7 @@ public class RepositoryIndexUsageTest {
 
   @Test
   public void testDeleteAllUsesViewWithConfiguredConsistency() {
-    String expectedQueryParams = "reduce=false&stale=false";
+    String expectedQueryParams = "ViewQuery(string/all){params=\"reduce=false&stale=false\"}";
     repository.deleteAll();
 
     verify(couchbaseOperations, never()).findByView(any(ViewQuery.class), any(Class.class));

--- a/src/test/java/org/springframework/data/couchbase/repository/query/PartTreeN1qBasedQueryTest.java
+++ b/src/test/java/org/springframework/data/couchbase/repository/query/PartTreeN1qBasedQueryTest.java
@@ -76,7 +76,7 @@ public class PartTreeN1qBasedQueryTest {
 		PartTreeN1qlBasedQuery query = new PartTreeN1qlBasedQuery(queryMethod, couchbaseOperations);
 		Statement statement = query.getCount(accessor, new Object[] { "value", pr });
 
-		assertEquals("SELECT COUNT(*) AS count FROM `default` WHERE name = \"value\" "
+		assertEquals("SELECT COUNT(*) AS count FROM `default` WHERE (name = \"value\") "
 				+ "AND `_class` = \"org.springframework.data.couchbase.core.Beer\"", statement.toString());
 
 	}
@@ -119,7 +119,7 @@ public class PartTreeN1qBasedQueryTest {
 		PartTreeN1qlBasedQuery query = new PartTreeN1qlBasedQuery(queryMethod, couchbaseOperations);
 		Statement statement = query.getCount(accessor, new Object[] { "value", pr });
 
-		assertEquals("SELECT COUNT(*) AS count FROM `default` WHERE name = \"value\" "
+		assertEquals("SELECT COUNT(*) AS count FROM `default` WHERE (name = \"value\") "
 				+ "AND `_class` = \"org.springframework.data.couchbase.core.Beer\"", statement.toString());
 
 	}

--- a/src/test/resources/configurations/couchbaseEnv-bean.xml
+++ b/src/test/resources/configurations/couchbaseEnv-bean.xml
@@ -23,8 +23,6 @@
                    sslEnabled="true"
                    sslKeystoreFile="test"
                    sslKeystorePassword="test"
-                   queryEnabled="true"
-                   queryPort="7"
                    bootstrapHttpEnabled="false"
                    bootstrapCarrierEnabled="false"
                    bootstrapHttpDirectPort="8"


### PR DESCRIPTION
Motivation
----------
Fix failing integration tests due to query pipelinging, class cast
exception. Fix unit tests.

Changes
-------
Updating to newer client fixes pipelining issue

Update to newer client changes
-----------------------------
The update removes query enabled and query port properties from couchbase
environment bean as the query engine has been fully integrated and adds some
new properties like memcached hashing strategy, ssl key store which are not
yet exposed in this patch. There will be a follow patch which does that.

Fix tests
---------
use a simple select use index query to verify index existence versus using
system:indexes which require admin credentials. Fix view test where the view
query returns a list. Add other misc small fixes in integration and unit
tests.

Results
-------
All tests pass consistently