### PR TITLE
DATACOUCH-287 - Add CAS operations to RxJavaCouchbaseOperations.

### DIFF
--- a/src/integration/java/org/springframework/data/couchbase/core/AsyncUtils.java
+++ b/src/integration/java/org/springframework/data/couchbase/core/AsyncUtils.java
@@ -1,5 +1,7 @@
 package org.springframework.data.couchbase.core;
 
+import rx.observers.TestSubscriber;
+
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -16,5 +18,38 @@ public class AsyncUtils {
         for (Future future : futures) {
             future.get(numThreads, TimeUnit.SECONDS);
         }
+    }
+
+    public static <T> void awaitCompleted(TestSubscriber<T> testSubscriber) {
+        testSubscriber.awaitTerminalEvent();
+        testSubscriber.assertNoErrors();
+        testSubscriber.assertNoValues();
+        testSubscriber.assertCompleted();
+    }
+
+    public static <T> void awaitCompletedWithAnyValue(TestSubscriber<T> testSubscriber) {
+        testSubscriber.awaitTerminalEvent();
+        testSubscriber.assertNoErrors();
+        testSubscriber.assertCompleted();
+    }
+
+    public static <T> void awaitCompletedWithValueCount(TestSubscriber<T> testSubscriber, int count) {
+        testSubscriber.awaitTerminalEvent();
+        testSubscriber.assertNoErrors();
+        testSubscriber.assertValueCount(count);
+        testSubscriber.assertCompleted();
+    }
+
+    public static <T> void awaitError(TestSubscriber<T> testSubscriber, Class<? extends Throwable> throwableClazz) {
+        testSubscriber.awaitTerminalEvent();
+        testSubscriber.assertError(throwableClazz);
+        testSubscriber.assertNoValues();
+    }
+
+    public static <T> void awaitValue(TestSubscriber<T> testSubscriber, T value) {
+        testSubscriber.awaitTerminalEvent();
+        testSubscriber.assertNoErrors();
+        testSubscriber.assertValue(value);
+        testSubscriber.assertCompleted();
     }
 }

--- a/src/main/java/org/springframework/data/couchbase/core/RxJavaCouchbaseOperations.java
+++ b/src/main/java/org/springframework/data/couchbase/core/RxJavaCouchbaseOperations.java
@@ -15,8 +15,6 @@
  */
 package org.springframework.data.couchbase.core;
 
-import java.util.Collection;
-
 import com.couchbase.client.java.Bucket;
 import com.couchbase.client.java.PersistTo;
 import com.couchbase.client.java.ReplicateTo;
@@ -33,6 +31,7 @@ import rx.Observable;
 
 /**
  * @author Subhashni Balakrishnan
+ * @author Alex Derkach
  * @since 3.0
  */
 public interface RxJavaCouchbaseOperations {
@@ -44,6 +43,22 @@ public interface RxJavaCouchbaseOperations {
     <T>Observable<T> save(T objectToSave, PersistTo persistTo, ReplicateTo replicateTo);
 
     <T>Observable<T> save(Iterable<T> batchToSave, PersistTo persistTo, ReplicateTo replicateTo);
+
+    <T>Observable<T> insert(T objectToSave);
+
+    <T>Observable<T> insert(Iterable<T> batchToSave);
+
+    <T>Observable<T> insert(T objectToSave, PersistTo persistTo, ReplicateTo replicateTo);
+
+    <T>Observable<T> insert(Iterable<T> batchToSave, PersistTo persistTo, ReplicateTo replicateTo);
+
+    <T>Observable<T> update(T objectToSave);
+
+    <T>Observable<T> update(Iterable<T> batchToSave);
+
+    <T>Observable<T> update(T objectToSave, PersistTo persistTo, ReplicateTo replicateTo);
+
+    <T>Observable<T> update(Iterable<T> batchToSave, PersistTo persistTo, ReplicateTo replicateTo);
 
     <T>Observable<T> remove(T objectToRemove);
 

--- a/src/test/java/org/springframework/data/couchbase/core/VersionedReactiveBeer.java
+++ b/src/test/java/org/springframework/data/couchbase/core/VersionedReactiveBeer.java
@@ -16,20 +16,19 @@
 
 package org.springframework.data.couchbase.core;
 
+import com.couchbase.client.java.repository.annotation.Field;
 import lombok.EqualsAndHashCode;
 import org.springframework.data.annotation.Id;
-
-import com.couchbase.client.java.repository.annotation.Field;
+import org.springframework.data.annotation.Version;
 
 
 /**
  * Test class for persisting and loading from {@link RxJavaCouchbaseTemplate}.
  *
- * @author Subhashni Balakrishnan
  * @author Alex Derkach
  */
 @EqualsAndHashCode
-public class ReactiveBeer {
+public class VersionedReactiveBeer {
 
 	@Id
 	private final String id;
@@ -42,7 +41,10 @@ public class ReactiveBeer {
 	@Field("desc")
 	private String description;
 
-	public ReactiveBeer(String id, String name, Boolean active, String description) {
+	@Version
+	private long version;
+
+	public VersionedReactiveBeer(String id, String name, Boolean active, String description) {
 		this.id = id;
 		this.name = name;
 		this.active = active;
@@ -54,7 +56,7 @@ public class ReactiveBeer {
 		return "Beer [id=" + id + ", name=" + name + ", active=" + active + ", description=" + description + "]";
 	}
 
-	public ReactiveBeer setName(String name) {
+	public VersionedReactiveBeer setName(String name) {
 		this.name = name;
 		return this;
 	}
@@ -63,7 +65,7 @@ public class ReactiveBeer {
 		return name;
 	}
 
-	public ReactiveBeer setActive(boolean active) {
+	public VersionedReactiveBeer setActive(boolean active) {
 		this.active = active;
 		return this;
 	}
@@ -72,7 +74,7 @@ public class ReactiveBeer {
 		return active;
 	}
 
-	public ReactiveBeer setDescription(String description) {
+	public VersionedReactiveBeer setDescription(String description) {
 		this.description = description;
 		return this;
 	}
@@ -85,4 +87,11 @@ public class ReactiveBeer {
 		return id;
 	}
 
+	public void setVersion(long version) {
+		this.version = version;
+	}
+
+	public long getVersion() {
+		return version;
+	}
 }


### PR DESCRIPTION
Currently, there is only one way to save an entity - upsert.

**RxJavaCouchbaseOperations** is missing important feature of Couchbase 2.x API - cas updates.
The idea is to provide a few methods, which will apply a function to existing/non-existing input document, and perform safe replace/insert.