### PR TITLE
DATACOUCH-147 - Allow to convert Date to ISO-8601 compliant strings

### DIFF
--- a/src/main/asciidoc/entity.adoc
+++ b/src/main/asciidoc/entity.adoc
@@ -271,6 +271,7 @@ A populated object can look like:
 ----
 ====
 
+Optionally, Date can be converted to and from ISO-8601 compliant strings by setting system property `org.springframework.data.couchbase.useISOStringConverterForDate` to true.
 If you want to override a converter or implement your own one, this is also possible. The library implements the general Spring Converter pattern. You can plug in custom converters on bean creation time in your configuration. Here's how you can configure it (in your overridden `AbstractCouchbaseConfiguration`):
 
 .Custom Converters

--- a/src/main/java/org/springframework/data/couchbase/repository/query/support/N1qlUtils.java
+++ b/src/main/java/org/springframework/data/couchbase/repository/query/support/N1qlUtils.java
@@ -197,7 +197,16 @@ public class N1qlUtils {
     for (Sort.Order order : sort) {
       String orderProperty = order.getProperty();
       //FIXME the order property should be converted to its corresponding fieldName
-      Expression orderFieldName = i(orderProperty);
+      String[] orderPropertyParts = orderProperty.split("\\.");
+
+      StringBuilder sb = new StringBuilder();
+      for (String part:orderPropertyParts) {
+        if (sb.length() != 0) {
+          sb.append(".");
+        }
+        sb.append(i(part).toString());
+      }
+      Expression orderFieldName = x(sb.toString());
       if (order.isIgnoreCase()) {
         orderFieldName = lower(TypeFunctions.toString(orderFieldName));
       }

--- a/src/test/java/org/springframework/data/couchbase/repository/query/support/N1qlUtilsTest.java
+++ b/src/test/java/org/springframework/data/couchbase/repository/query/support/N1qlUtilsTest.java
@@ -147,4 +147,14 @@ public class N1qlUtilsTest {
 
     assertEquals(expected, real);
   }
+
+  @Test
+  public void testOrderByWithNestedField() throws Exception {
+    CouchbaseConverter converter = mock(CouchbaseConverter.class);
+    com.couchbase.client.java.query.dsl.Sort[] realSort =
+            N1qlUtils.createSort(new Sort("party.attendees"), converter);
+
+    assertEquals("`party`.`attendees` ASC", realSort[0].toString());
+    verifyZeroInteractions(converter);
+  }
 }


### PR DESCRIPTION
Using the system property
org.springframework.data.couchbase.useISOStringConverterForDate the
conversion can be enabled so this doesn't break backward compatibility
