### PR TITLE
DATACOUCH-314 - Adopt to ReactiveCrudRepository.findById(Publisher) and existsById(Publisher).

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.springframework.data</groupId>
     <artifactId>spring-data-couchbase</artifactId>
-    <version>3.0.0.BUILD-SNAPSHOT</version>
+    <version>3.0.0.DATACOUCH-314-SNAPSHOT</version>
 
     <name>Spring Data Couchbase</name>
     <description>Spring Data integration for Couchbase</description>
@@ -20,7 +20,7 @@
     <properties>
         <couchbase>2.4.6</couchbase>
         <couchbase.osgi>2.4.6</couchbase.osgi>
-        <springdata.commons>2.0.0.BUILD-SNAPSHOT</springdata.commons>
+        <springdata.commons>2.0.0.DATACMNS-1063-SNAPSHOT</springdata.commons>
     </properties>
 
     <dependencies>

--- a/src/main/java/org/springframework/data/couchbase/repository/support/SimpleReactiveCouchbaseRepository.java
+++ b/src/main/java/org/springframework/data/couchbase/repository/support/SimpleReactiveCouchbaseRepository.java
@@ -42,6 +42,7 @@ import reactor.core.publisher.Mono;
  *
  * @author Subhashni Balakrishnan
  * @author Mark Paluch
+ * @author Christoph Strobl
  * @since 3.0
  */
 public class SimpleReactiveCouchbaseRepository<T, ID extends Serializable> implements ReactiveCouchbaseRepository<T, ID> {
@@ -189,6 +190,13 @@ public class SimpleReactiveCouchbaseRepository<T, ID extends Serializable> imple
     public Mono<Void> deleteById(ID id) {
         Assert.notNull(id, "The given id must not be null!");
         return mapMono(operations.remove(id.toString()).map(res -> Observable.<Void>empty()).toSingle());
+    }
+
+    @Override
+    public Mono<Void> deleteById(Publisher<ID> publisher) {
+        Assert.notNull(publisher, "The given id must not be null!");
+        return Mono.from(publisher).flatMap(
+                this::deleteById);
     }
 
     @SuppressWarnings("unchecked")

--- a/src/main/java/org/springframework/data/couchbase/repository/support/SimpleReactiveCouchbaseRepository.java
+++ b/src/main/java/org/springframework/data/couchbase/repository/support/SimpleReactiveCouchbaseRepository.java
@@ -130,9 +130,9 @@ public class SimpleReactiveCouchbaseRepository<T, ID extends Serializable> imple
 
     @SuppressWarnings("unchecked")
     @Override
-    public Mono<T> findById(Mono<ID> mono) {
-        Assert.notNull(mono, "The given mono must not be null!");
-        return mono.flatMap(
+    public Mono<T> findById(Publisher<ID> publisher) {
+        Assert.notNull(publisher, "The given Publisher must not be null!");
+        return Mono.from(publisher).flatMap(
                 this::findById);
     }
 
@@ -145,8 +145,9 @@ public class SimpleReactiveCouchbaseRepository<T, ID extends Serializable> imple
 
     @SuppressWarnings("unchecked")
     @Override
-    public Mono<Boolean> existsById(Mono<ID> mono) {
-        return mono.flatMap(
+    public Mono<Boolean> existsById(Publisher<ID> publisher) {
+        Assert.notNull(publisher, "The given Publisher must not be null!");
+        return Mono.from(publisher).flatMap(
                 this::existsById);
     }
 
@@ -180,7 +181,7 @@ public class SimpleReactiveCouchbaseRepository<T, ID extends Serializable> imple
     public Flux<T> findAllById(Publisher<ID> entityStream) {
         Assert.notNull(entityStream, "The given entityStream must not be null!");
         return Flux.from(entityStream)
-                .flatMap(entity -> findById(entity));
+                .flatMap(this::findById);
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
Depends on: https://github.com/spring-projects/spring-data-commons/pull/226
Related ticket: [DATACOUCH-314](https://jira.spring.io/browse/DATACOUCH-314).