### PR TITLE
DATACOUCH-350 - Generate both blocking & reactive implementations

### DIFF
--- a/src/main/java/org/springframework/data/couchbase/repository/config/CouchbaseRepositoryConfigurationExtension.java
+++ b/src/main/java/org/springframework/data/couchbase/repository/config/CouchbaseRepositoryConfigurationExtension.java
@@ -28,6 +28,7 @@ import org.springframework.data.couchbase.repository.support.CouchbaseRepository
 import org.springframework.data.repository.config.AnnotationRepositoryConfigurationSource;
 import org.springframework.data.repository.config.RepositoryConfigurationExtensionSupport;
 import org.springframework.data.repository.config.XmlRepositoryConfigurationSource;
+import org.springframework.data.repository.core.RepositoryMetadata;
 import org.w3c.dom.Element;
 
 /**
@@ -83,5 +84,9 @@ public class CouchbaseRepositoryConfigurationExtension extends RepositoryConfigu
   @Override
   protected Collection<Class<?>> getIdentifyingTypes() {
     return Collections.singleton(CouchbaseRepository.class);
+  }
+
+  protected boolean useRepositoryConfiguration(RepositoryMetadata metadata) {
+    return !metadata.isReactiveRepository();
   }
 }

--- a/src/main/java/org/springframework/data/couchbase/repository/config/ReactiveCouchbaseRepositoryConfigurationExtension.java
+++ b/src/main/java/org/springframework/data/couchbase/repository/config/ReactiveCouchbaseRepositoryConfigurationExtension.java
@@ -15,9 +15,16 @@
  */
 package org.springframework.data.couchbase.repository.config;
 
+import java.lang.annotation.Annotation;
+import java.util.Collection;
+import java.util.Collections;
+
+import org.springframework.data.couchbase.core.mapping.Document;
+import org.springframework.data.couchbase.repository.ReactiveCouchbaseRepository;
 import org.springframework.data.couchbase.repository.support.ReactiveCouchbaseRepositoryFactoryBean;
 import org.springframework.data.repository.config.RepositoryConfigurationExtensionSupport;
 import org.springframework.data.repository.config.XmlRepositoryConfigurationSource;
+import org.springframework.data.repository.core.RepositoryMetadata;
 import org.w3c.dom.Element;
 
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
@@ -62,4 +69,25 @@ public class ReactiveCouchbaseRepositoryConfigurationExtension extends Repositor
 		builder.addPropertyReference("indexManager", BeanNames.COUCHBASE_INDEX_MANAGER);
 	}
 
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.repository.config.RepositoryConfigurationExtensionSupport#getIdentifyingAnnotations()
+	 */
+	@Override
+	protected Collection<Class<? extends Annotation>> getIdentifyingAnnotations() {
+		return Collections.singleton(Document.class);
+	}
+
+	/*
+     * (non-Javadoc)
+     * @see org.springframework.data.repository.config.RepositoryConfigurationExtensionSupport#getIdentifyingTypes()
+     */
+	@Override
+	protected Collection<Class<?>> getIdentifyingTypes() {
+		return Collections.singleton(ReactiveCouchbaseRepository.class);
+	}
+
+	protected boolean useRepositoryConfiguration(RepositoryMetadata metadata) {
+		return metadata.isReactiveRepository();
+	}
 }


### PR DESCRIPTION
Problem arises, when creating bean definitions for Repository, and both ReactiveCouchbaseRepositoryConfigurationExtension & CouchbaseRepositoryConfigurationExtension are used in Spring Boot autoconfiguration.

First, SimpleReactiveCouchbaseRepository is set as bean definition.
Then, SimpleCouchbaseRepository overrides this definition, despite that Repository uses reactive types.

Thus, repository creation fails, e.g.:
org.springframework.core.convert.ConverterNotFoundException: No converter found capable of converting from type [org.springframework.boot.test.autoconfigure.data.couchbase.ExampleDocument] to type [reactor.core.publisher.Mono<?>]