### PR TITLE
DATACOUCH-391 - Remove unused imports causing tests build failure

### DIFF
--- a/src/integration/java/org/springframework/data/couchbase/repository/spel/SpelConfig.java
+++ b/src/integration/java/org/springframework/data/couchbase/repository/spel/SpelConfig.java
@@ -7,8 +7,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.couchbase.IntegrationTestApplicationConfig;
 import org.springframework.data.couchbase.repository.config.EnableCouchbaseRepositories;
-import org.springframework.data.repository.query.EvaluationContextProvider;
-import org.springframework.data.repository.query.ExtensionAwareEvaluationContextProvider;
 import org.springframework.data.repository.query.spi.EvaluationContextExtension;
 import org.springframework.data.repository.query.spi.EvaluationContextExtensionSupport;
 


### PR DESCRIPTION
The imported classes have been renamed in commons and they are not
required for these tests.
