### PR TITLE
DATACOUCH-401 Incorrect return type for reactive string based N1ql co…

### DIFF
--- a/src/integration/java/org/springframework/data/couchbase/repository/ReactiveN1qlCouchbaseRepositoryTests.java
+++ b/src/integration/java/org/springframework/data/couchbase/repository/ReactiveN1qlCouchbaseRepositoryTests.java
@@ -111,4 +111,16 @@ public class ReactiveN1qlCouchbaseRepositoryTests {
 		}
 		assertNotNull("Expected to find several parties", previousDesc);
 	}
+
+    @Test
+    public void testCustomSpelCountQuery() {
+        long count = partyRepository.countCustom().block();
+        assertEquals("Test N1QL Spel based query", 15, count);
+    }
+
+    @Test
+    public void testPartTreeQuery() {
+        long count = partyRepository.countAllByDescriptionNotNull().block();
+        assertEquals("Test N1QL part tree based query", 15, count);
+    }
 }

--- a/src/integration/java/org/springframework/data/couchbase/repository/ReactivePartyRepository.java
+++ b/src/integration/java/org/springframework/data/couchbase/repository/ReactivePartyRepository.java
@@ -37,7 +37,7 @@ public interface ReactivePartyRepository extends ReactiveCouchbaseRepository<Par
 	@Query("SELECT count(*) + 5 FROM #{#n1ql.bucket} WHERE #{#n1ql.filter}")
 	Mono<Long> countCustomPlusFive();
 
-	@Query("#{#n1ql.selectEntity} WHERE #{#n1ql.filter}")
+	@Query("SELECT count(*) FROM #{#n1ql.bucket} WHERE #{#n1ql.filter}")
 	Mono<Long> countCustom();
 
 	@Query("SELECT 1 = 1")


### PR DESCRIPTION
…unt query

Motivation
----------
Reactive string based N1QL count query incorrectly returns the map after
the single result projection.

Changes
-------
Map the observable returning from the N1ql query result deserialized to
a map by converting to the correct return type using the conversion
service. Verified by integration tests.

