### PR TITLE
URL Cleanup

### DIFF
--- a/CODE_OF_CONDUCT.adoc
+++ b/CODE_OF_CONDUCT.adoc
@@ -24,4 +24,4 @@ Instances of abusive, harassing, or otherwise unacceptable behavior may be repor
 All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances.
 Maintainers are obligated to maintain confidentiality with regard to the reporter of an incident.
 
-This Code of Conduct is adapted from the http://contributor-covenant.org[Contributor Covenant], version 1.3.0, available at http://contributor-covenant.org/version/1/3/0/[contributor-covenant.org/version/1/3/0/].
+This Code of Conduct is adapted from the https://contributor-covenant.org[Contributor Covenant], version 1.3.0, available at https://contributor-covenant.org/version/1/3/0/[contributor-covenant.org/version/1/3/0/].

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-[![Spring Data Couchbase](https://spring.io/badges/spring-data-couchbase/ga.svg)](http://projects.spring.io/spring-data-couchbase#quick-start)
-[![Spring Data Couchbase](https://spring.io/badges/spring-data-couchbase/snapshot.svg)](http://projects.spring.io/spring-data-couchbase#quick-start)
+[![Spring Data Couchbase](https://spring.io/badges/spring-data-couchbase/ga.svg)](https://projects.spring.io/spring-data-couchbase#quick-start)
+[![Spring Data Couchbase](https://spring.io/badges/spring-data-couchbase/snapshot.svg)](https://projects.spring.io/spring-data-couchbase#quick-start)
 
 # Spring Data Couchbase 3.0.x
 `Spring-Data Couchbase 3.0.x` is the Spring Data connector for the `Couchbase Java SDK 2.x` generation.
@@ -11,7 +11,7 @@ Notably, this version is compatible with `Couchbase Server 4.0`, bringing suppor
 
 # Spring Data Couchbase
 
-The primary goal of the [Spring Data](http://www.springsource.org/spring-data) project is to make it easier to build
+The primary goal of the [Spring Data](https://www.springsource.org/spring-data) project is to make it easier to build
 Spring-powered applications that use new data access technologies such as non-relational databases, map-reduce
 frameworks, and cloud based data services.
 
@@ -28,14 +28,14 @@ The recommended way to run tests is to install docker and use container in serve
 
 For a comprehensive treatment of all the Spring Data Couchbase features, please refer to:
 
-* the [User Guide](http://docs.spring.io/spring-data/couchbase/docs/current/reference/html/) for the current GA version.
-* the [JavaDocs](http://docs.spring.io/spring-data/couchbase/docs/current/api/) have extensive comments
+* the [User Guide](https://docs.spring.io/spring-data/couchbase/docs/current/reference/html/) for the current GA version.
+* the [JavaDocs](https://docs.spring.io/spring-data/couchbase/docs/current/api/) have extensive comments
   in them as well.
-* for more detailed questions, use the [StackOverflow `spring-data-couchbase` tag](http://stackoverflow.com/questions/tagged/spring-data-couchbase)
+* for more detailed questions, use the [StackOverflow `spring-data-couchbase` tag](https://stackoverflow.com/questions/tagged/spring-data-couchbase)
 or Couchbase's own [forums](https://forums.couchbase.com/c/java-sdk).
 
 If you are new to Spring as well as to Spring Data, look for information about
-[Spring projects](http://www.springsource.org/projects).
+[Spring projects](https://www.springsource.org/projects).
 
 
 ## Quick Start
@@ -65,7 +65,7 @@ the appropriate dependency version.
 <repository>
   <id>spring-libs-snapshot</id>
   <name>Spring Snapshot Repository</name>
-  <url>http://repo.spring.io/libs-snapshot</url>
+  <url>https://repo.spring.io/libs-snapshot</url>
 </repository>
 ```
 
@@ -75,7 +75,7 @@ CouchbaseTemplate is the central support class for Couchbase database operations
 
 * Basic POJO mapping support to and from JSON (by default through Jackson)
 * Convenience methods to interact with the store (insert object, update objects) and Couchbase specific ones
-* Exception translation into Spring's [technology agnostic DAO exception hierarchy](http://docs.spring.io/spring/docs/current/spring-framework-reference/html/dao.html#dao-exceptions).
+* Exception translation into Spring's [technology agnostic DAO exception hierarchy](https://docs.spring.io/spring/docs/current/spring-framework-reference/html/dao.html#dao-exceptions).
 
 ### Spring Data Repositories
 
@@ -266,15 +266,15 @@ public class MyService {
 Here are some ways for you to get involved in the community:
 
 * Get involved with the Spring community on Stack Overflow.  Please help out on the
-  [`spring-data`](http://stackoverflow.com/questions/tagged/spring-data) and
-  [`spring-data-couchbase`](http://stackoverflow.com/questions/tagged/spring-data-couchbase) tags by responding to
+  [`spring-data`](https://stackoverflow.com/questions/tagged/spring-data) and
+  [`spring-data-couchbase`](https://stackoverflow.com/questions/tagged/spring-data-couchbase) tags by responding to
   questions.
 * Create [JIRA](jira.spring.io/browse/DATACOUCH) `DATACOUCH` tickets for bugs and new features and comment and
   vote on the ones that you are interested in.
 * Github is for social coding: if you want to write code, we encourage contributions through pull requests from
-  [forks of this repository](http://help.github.com/forking/). If you want to contribute code this way, please reference
+  [forks of this repository](https://help.github.com/forking/). If you want to contribute code this way, please reference
   a JIRA ticket as well covering the specific issue you are addressing.
-* Watch for upcoming articles on Spring by [subscribing](http://assets.spring.io/drupal/node/feed.xml) to spring.io RSS feed.
+* Watch for upcoming articles on Spring by [subscribing](https://assets.spring.io/drupal/node/feed.xml) to spring.io RSS feed.
 
 BBefore we accept a non-trivial patch or pull request we will need you to [sign the Contributor License Agreement](https://cla.pivotal.io/sign/spring). Signing the contributor’s agreement does not grant anyone commit rights to the main repository, but it does mean that we can accept your contributions, and you will get an author credit if we do. If you forget to do so, you'll be reminded when you submit a pull request. Active contributors might be asked to join the core team, and given the ability
 to merge pull requests.

--- a/src/main/asciidoc/configuration.adoc
+++ b/src/main/asciidoc/configuration.adoc
@@ -22,7 +22,7 @@ All versions intended for production use are distributed across Maven Central an
 
 This will pull in several dependencies, including the underlying Couchbase Java SDK, common Spring dependencies and also Jackson as the JSON mapping infrastructure.
 
-You can also grab snapshots from the http://repo.spring.io/libs-snapshot[spring snapshot repository] and milestone releases from the http://repo.spring.io/libs-milestone[milestone repository]. Here is an example on how to use the current SNAPSHOT dependency:
+You can also grab snapshots from the https://repo.spring.io/libs-snapshot[spring snapshot repository] and milestone releases from the https://repo.spring.io/libs-milestone[milestone repository]. Here is an example on how to use the current SNAPSHOT dependency:
 
 .Using a snapshot version
 ====
@@ -105,9 +105,9 @@ The library provides a custom namespace that you can use in your XML configurati
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xmlns="http://www.springframework.org/schema/data/couchbase
   xsi:schemaLocation="http://www.springframework.org/schema/beans
-    http://www.springframework.org/schema/beans/spring-beans.xsd
+    https://www.springframework.org/schema/beans/spring-beans.xsd
     http://www.springframework.org/schema/data/couchbase
-    http://www.springframework.org/schema/data/couchbase/spring-couchbase.xsd">
+    https://www.springframework.org/schema/data/couchbase/spring-couchbase.xsd">
 
     <couchbase:cluster>
       <couchbase:node>127.0.0.1</couchbase:node>

--- a/src/main/asciidoc/template.adoc
+++ b/src/main/asciidoc/template.adoc
@@ -32,8 +32,8 @@ The template can be configured via xml, including setting a custom `TranslationS
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:couchbase="http://www.springframework.org/schema/data/couchbase"
-       xsi:schemaLocation="http://www.springframework.org/schema/data/couchbase http://www.springframework.org/schema/data/couchbase/spring-couchbase.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/data/couchbase https://www.springframework.org/schema/data/couchbase/spring-couchbase.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
     <couchbase:env/>
     <couchbase:cluster/>

--- a/src/main/resources/license.txt
+++ b/src/main/resources/license.txt
@@ -207,7 +207,7 @@ similar licenses that require the source code and/or modifications to
 source code to be made available (as would be noted above), you may obtain a 
 copy of the source code corresponding to the binaries for such open source 
 components and modifications thereto, if any, (the "Source Files"), by 
-downloading the Source Files from http://www.springsource.org/download, 
+downloading the Source Files from https://www.springsource.org/download, 
 or by sending a request, with your name and address to: VMware, Inc., 3401 Hillview 
 Avenue, Palo Alto, CA 94304, United States of America or email info@vmware.com.  All 
 such requests should clearly specify:  OPEN SOURCE FILES REQUEST, Attention General 

--- a/src/main/resources/org/springframework/data/couchbase/config/spring-couchbase-1.0.xsd
+++ b/src/main/resources/org/springframework/data/couchbase/config/spring-couchbase-1.0.xsd
@@ -9,7 +9,7 @@
     <xsd:import namespace="http://www.springframework.org/schema/beans"/>
     <xsd:import namespace="http://www.springframework.org/schema/tool"/>
     <xsd:import namespace="http://www.springframework.org/schema/context"/>
-    <xsd:import namespace="http://www.springframework.org/schema/data/repository" schemaLocation="http://www.springframework.org/schema/data/repository/spring-repository-1.0.xsd"/>
+    <xsd:import namespace="http://www.springframework.org/schema/data/repository" schemaLocation="https://www.springframework.org/schema/data/repository/spring-repository-1.0.xsd"/>
 
     <xsd:element name="couchbase" type="couchbaseType">
         <xsd:annotation>

--- a/src/main/resources/org/springframework/data/couchbase/config/spring-couchbase-2.0.xsd
+++ b/src/main/resources/org/springframework/data/couchbase/config/spring-couchbase-2.0.xsd
@@ -10,7 +10,7 @@
     <xsd:import namespace="http://www.springframework.org/schema/beans"/>
     <xsd:import namespace="http://www.springframework.org/schema/tool"/>
     <xsd:import namespace="http://www.springframework.org/schema/context"/>
-    <xsd:import namespace="http://www.springframework.org/schema/data/repository" schemaLocation="http://www.springframework.org/schema/data/repository/spring-repository-1.0.xsd"/>
+    <xsd:import namespace="http://www.springframework.org/schema/data/repository" schemaLocation="https://www.springframework.org/schema/data/repository/spring-repository-1.0.xsd"/>
 
     <xsd:include schemaLocation="spring-couchbase-env-2.0.xsd"/>
 


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://assets.spring.io/drupal/node/feed.xml with 1 occurrences migrated to:  
  https://assets.spring.io/drupal/node/feed.xml ([https](https://assets.spring.io/drupal/node/feed.xml) result 200).
* [ ] http://stackoverflow.com/questions/tagged/spring-data with 1 occurrences migrated to:  
  https://stackoverflow.com/questions/tagged/spring-data ([https](https://stackoverflow.com/questions/tagged/spring-data) result 200).
* [ ] http://stackoverflow.com/questions/tagged/spring-data-couchbase with 2 occurrences migrated to:  
  https://stackoverflow.com/questions/tagged/spring-data-couchbase ([https](https://stackoverflow.com/questions/tagged/spring-data-couchbase) result 200).
* [ ] http://www.springframework.org/schema/beans/spring-beans.xsd with 2 occurrences migrated to:  
  https://www.springframework.org/schema/beans/spring-beans.xsd ([https](https://www.springframework.org/schema/beans/spring-beans.xsd) result 200).
* [ ] http://contributor-covenant.org with 1 occurrences migrated to:  
  https://contributor-covenant.org ([https](https://contributor-covenant.org) result 301).
* [ ] http://contributor-covenant.org/version/1/3/0/ with 1 occurrences migrated to:  
  https://contributor-covenant.org/version/1/3/0/ ([https](https://contributor-covenant.org/version/1/3/0/) result 301).
* [ ] http://docs.spring.io/spring-data/couchbase/docs/current/api/ with 1 occurrences migrated to:  
  https://docs.spring.io/spring-data/couchbase/docs/current/api/ ([https](https://docs.spring.io/spring-data/couchbase/docs/current/api/) result 301).
* [ ] http://docs.spring.io/spring-data/couchbase/docs/current/reference/html/ with 1 occurrences migrated to:  
  https://docs.spring.io/spring-data/couchbase/docs/current/reference/html/ ([https](https://docs.spring.io/spring-data/couchbase/docs/current/reference/html/) result 301).
* [ ] http://docs.spring.io/spring/docs/current/spring-framework-reference/html/dao.html with 1 occurrences migrated to:  
  https://docs.spring.io/spring/docs/current/spring-framework-reference/html/dao.html ([https](https://docs.spring.io/spring/docs/current/spring-framework-reference/html/dao.html) result 301).
* [ ] http://help.github.com/forking/ with 1 occurrences migrated to:  
  https://help.github.com/forking/ ([https](https://help.github.com/forking/) result 301).
* [ ] http://projects.spring.io/spring-data-couchbase with 2 occurrences migrated to:  
  https://projects.spring.io/spring-data-couchbase ([https](https://projects.spring.io/spring-data-couchbase) result 301).
* [ ] http://www.springframework.org/schema/data/couchbase/spring-couchbase.xsd with 2 occurrences migrated to:  
  https://www.springframework.org/schema/data/couchbase/spring-couchbase.xsd ([https](https://www.springframework.org/schema/data/couchbase/spring-couchbase.xsd) result 301).
* [ ] http://www.springframework.org/schema/data/repository/spring-repository-1.0.xsd with 2 occurrences migrated to:  
  https://www.springframework.org/schema/data/repository/spring-repository-1.0.xsd ([https](https://www.springframework.org/schema/data/repository/spring-repository-1.0.xsd) result 301).
* [ ] http://www.springsource.org/projects with 1 occurrences migrated to:  
  https://www.springsource.org/projects ([https](https://www.springsource.org/projects) result 301).
* [ ] http://www.springsource.org/spring-data with 1 occurrences migrated to:  
  https://www.springsource.org/spring-data ([https](https://www.springsource.org/spring-data) result 301).
* [ ] http://repo.spring.io/libs-milestone with 1 occurrences migrated to:  
  https://repo.spring.io/libs-milestone ([https](https://repo.spring.io/libs-milestone) result 302).
* [ ] http://repo.spring.io/libs-snapshot with 2 occurrences migrated to:  
  https://repo.spring.io/libs-snapshot ([https](https://repo.spring.io/libs-snapshot) result 302).
* [ ] http://www.springsource.org/download with 1 occurrences migrated to:  
  https://www.springsource.org/download ([https](https://www.springsource.org/download) result 302).

# Ignored
These URLs were intentionally ignored.

* http://www.springframework.org/schema/beans with 9 occurrences
* http://www.springframework.org/schema/context with 3 occurrences
* http://www.springframework.org/schema/data/couchbase with 10 occurrences
* http://www.springframework.org/schema/data/repository with 4 occurrences
* http://www.springframework.org/schema/tool with 4 occurrences
* http://www.w3.org/2001/XMLSchema with 3 occurrences
* http://www.w3.org/2001/XMLSchema-instance with 2 occurrences