### PR TITLE
#DATACOUCH-206 set scan consistency on repository method

### DIFF
--- a/src/main/asciidoc/repository.adoc
+++ b/src/main/asciidoc/repository.adoc
@@ -477,7 +477,7 @@ data, because the latest version hasn't been indexed yet. This gives the best pe
 Note that weaker consistencies can lead to data being returned that doesn't match the criteria of a derived query.
 One trickier case is when documents are deleted from Couchbase but views have not yet caught up to the deletion. With weak consistency this can mean that a view would return IDs that are not in the database anymore, leading to null entities. The `CouchbaseTemplate`s `findByView` and `findBySpatialView` methods will remove such stale deleted entities from their result in order to avoid having nulls in the returned collections. Similarly, `CouchbaseRepository`'s `deleteAll` method will ignore documents that the backing view provided but the SDK remove operation couldn't find.
 
-If one wants to have stronger consistency, there are two possibilities described in the next sections.
+If one wants to have stronger consistency, there are three possibilities described in the next sections.
 
 ==== Configure it on a global level
 A global consistency can be defined using the `Consistency` enumeration (eg. `Consistency.READ_YOUR_OWN_WRITE`):
@@ -488,6 +488,35 @@ A global consistency can be defined using the `Consistency` enumeration (eg. `Co
 By default it is `Consistency.READ_YOUR_OWN_WRITES` (which means consistency is prioritized over speed, especially when a large number of documents has been created recently).
 
 IMPORTANT: This is **only used in repositories**, either for index-backed methods automatically provided by the repository interface (`findAll()`, `findAll(keys)`, `count()`, `deleteAll()`...) or methods you define in your specific interface using query derivation.
+
+==== Set consistency for N1QL queries
+For N1QL queries, the `ScanConsistency` can be set using the `@WithConsistency` annotation.
+This is independent of whether the query is derived from the method name or specified using `@Query`.
+If the annotation is omitted, the global default consistency is used.
+Consider the three queries in the following example:
+
+.Setting the scan consistency on repository methods
+====
+[source,java]
+----
+public interface UserRepository extends CrudRepository<UserInfo, String> {
+
+    List<UserInfo> findByLastname(String name); <1>
+
+    @WithConsistency(ScanConsistency.NOT_BOUNDED)
+    List<UserInfo> findByFirstname(String name); <2>
+
+    @WithConsistency(ScanConsistency.NOT_BOUNDED)
+    @Query("#{#n1ql.selectEntity} WHERE role = 'admin' AND #{#n1ql.filter}")
+    List<UserInfo> findAllAdmins(); <3>
+}
+----
+====
+<1> Since neither `@Query` nor `@WithConsistency` is specified, a N1QL query is derived from the method name and executed with default consistency.
+<2> The N1QL query is derived automatically but executed with the given consistency, i.e. `NOT_BOUNDED`.
+<3> The N1QL query is specified using `@Query` and is being executed with the given consistency.
+
+IMPORTANT: The `@WithConsistency` annotation is currently only evaluated **for N1QL queries**. View queries use the global default consistency.
 
 ==== Provide an implementation
 Provide the implementation and directly use `queryView` and `queryN1QL` methods on the template with a specific consistency

--- a/src/main/java/org/springframework/data/couchbase/core/query/WithConsistency.java
+++ b/src/main/java/org/springframework/data/couchbase/core/query/WithConsistency.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.data.couchbase.core.query;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.springframework.data.annotation.QueryAnnotation;
+
+import com.couchbase.client.java.query.consistency.ScanConsistency;
+
+/**
+ * Annotation to set the scan consistency of N1QL queries with Couchbase.
+ * This controls whether couchbase waits for all changes to be processed by an index
+ * or whether stale results are acceptable.
+ * <p/>
+ * If not set, the {@link Consistency#DEFAULT_CONSISTENCY default consistency} is used.
+ *
+ * @author Johannes Jasper.
+ */
+@Documented
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@QueryAnnotation
+public @interface WithConsistency {
+
+  ScanConsistency value() default ScanConsistency.REQUEST_PLUS;
+
+}

--- a/src/main/java/org/springframework/data/couchbase/core/query/WithConsistency.java
+++ b/src/main/java/org/springframework/data/couchbase/core/query/WithConsistency.java
@@ -16,22 +16,21 @@
 
 package org.springframework.data.couchbase.core.query;
 
+import com.couchbase.client.java.query.consistency.ScanConsistency;
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-
 import org.springframework.data.annotation.QueryAnnotation;
-
-import com.couchbase.client.java.query.consistency.ScanConsistency;
+import org.springframework.data.couchbase.config.AbstractCouchbaseConfiguration;
 
 /**
  * Annotation to set the scan consistency of N1QL queries with Couchbase.
  * This controls whether couchbase waits for all changes to be processed by an index
  * or whether stale results are acceptable.
  * <p/>
- * If not set, the {@link Consistency#DEFAULT_CONSISTENCY default consistency} is used.
+ * If not set, the default consistency set in {@link AbstractCouchbaseConfiguration#getDefaultConsistency()} is used.
  *
  * @author Johannes Jasper.
  */
@@ -41,6 +40,6 @@ import com.couchbase.client.java.query.consistency.ScanConsistency;
 @QueryAnnotation
 public @interface WithConsistency {
 
-  ScanConsistency value() default ScanConsistency.REQUEST_PLUS;
+  ScanConsistency value();
 
 }

--- a/src/main/java/org/springframework/data/couchbase/repository/query/CouchbaseQueryMethod.java
+++ b/src/main/java/org/springframework/data/couchbase/repository/query/CouchbaseQueryMethod.java
@@ -24,6 +24,7 @@ import org.springframework.data.couchbase.core.mapping.CouchbasePersistentProper
 import org.springframework.data.couchbase.core.query.Dimensional;
 import org.springframework.data.couchbase.core.query.Query;
 import org.springframework.data.couchbase.core.query.View;
+import org.springframework.data.couchbase.core.query.WithConsistency;
 import org.springframework.data.mapping.context.MappingContext;
 import org.springframework.data.projection.ProjectionFactory;
 import org.springframework.data.repository.core.RepositoryMetadata;
@@ -142,6 +143,14 @@ public class CouchbaseQueryMethod extends QueryMethod {
    */
   public boolean hasInlineN1qlQuery() {
     return getInlineN1qlQuery() != null;
+  }
+
+  public boolean hasConsistencyAnnotation() {
+    return getConsistencyAnnotation() != null;
+  }
+
+  public WithConsistency getConsistencyAnnotation() {
+    return method.getAnnotation(WithConsistency.class);
   }
 
   /**

--- a/src/test/java/org/springframework/data/couchbase/repository/PartyRepository.java
+++ b/src/test/java/org/springframework/data/couchbase/repository/PartyRepository.java
@@ -16,6 +16,7 @@
 
 package org.springframework.data.couchbase.repository;
 
+import com.couchbase.client.java.query.consistency.ScanConsistency;
 import java.util.Date;
 import java.util.List;
 
@@ -24,6 +25,7 @@ import org.springframework.data.couchbase.core.query.N1qlSecondaryIndexed;
 import org.springframework.data.couchbase.core.query.Query;
 import org.springframework.data.couchbase.core.query.View;
 import org.springframework.data.couchbase.core.query.ViewIndexed;
+import org.springframework.data.couchbase.core.query.WithConsistency;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -49,6 +51,7 @@ public interface PartyRepository extends CouchbaseRepository<Party, String> {
 
   long countAllByDescriptionNotNull();
 
+  @WithConsistency(ScanConsistency.NOT_BOUNDED)
   @Query("SELECT MAX(attendees) FROM #{#n1ql.bucket} WHERE #{#n1ql.filter}")
   long findMaxAttendees();
 

--- a/src/test/java/org/springframework/data/couchbase/repository/ReactiveUserRepository.java
+++ b/src/test/java/org/springframework/data/couchbase/repository/ReactiveUserRepository.java
@@ -16,6 +16,7 @@
 
 package org.springframework.data.couchbase.repository;
 
+import com.couchbase.client.java.query.consistency.ScanConsistency;
 import java.util.List;
 
 import com.couchbase.client.java.view.ViewQuery;
@@ -24,6 +25,7 @@ import org.springframework.data.couchbase.core.query.N1qlSecondaryIndexed;
 import org.springframework.data.couchbase.core.query.Query;
 import org.springframework.data.couchbase.core.query.View;
 import org.springframework.data.couchbase.core.query.ViewIndexed;
+import org.springframework.data.couchbase.core.query.WithConsistency;
 import reactor.core.publisher.Flux;
 
 /**

--- a/src/test/java/org/springframework/data/couchbase/repository/query/ReactiveAbstractN1qlBasedQueryTest.java
+++ b/src/test/java/org/springframework/data/couchbase/repository/query/ReactiveAbstractN1qlBasedQueryTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2015-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.couchbase.repository.query;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+import com.couchbase.client.java.document.json.JsonValue;
+import com.couchbase.client.java.query.Statement;
+import com.couchbase.client.java.query.consistency.ScanConsistency;
+import org.junit.*;
+import org.springframework.data.couchbase.core.RxJavaCouchbaseOperations;
+import org.springframework.data.couchbase.core.RxJavaCouchbaseTemplate;
+import org.springframework.data.couchbase.core.mapping.CouchbaseMappingContext;
+import org.springframework.data.couchbase.core.query.Consistency;
+import org.springframework.data.couchbase.core.query.WithConsistency;
+import org.springframework.data.couchbase.repository.ReactiveCouchbaseRepository;
+import org.springframework.data.projection.ProjectionFactory;
+import org.springframework.data.projection.SpelAwareProxyProjectionFactory;
+import org.springframework.data.repository.core.RepositoryMetadata;
+import org.springframework.data.repository.core.support.DefaultRepositoryMetadata;
+import org.springframework.data.repository.query.ParameterAccessor;
+import org.springframework.data.repository.query.ReturnedType;
+import reactor.core.publisher.Flux;
+
+/**
+ * Unit tests for {@link ReactiveAbstractN1qlBasedQuery}.
+ *
+ * @author Johannes Jasper
+ */
+public class ReactiveAbstractN1qlBasedQueryTest {
+	
+  CouchbaseMappingContext context = new CouchbaseMappingContext();
+  ProjectionFactory projectionFactory = new SpelAwareProxyProjectionFactory();
+  RepositoryMetadata metadata = DefaultRepositoryMetadata.getMetadata(SampleRepository.class);
+
+
+  @Test // DATACOUCH-206
+  public void shouldPickConsistencyFromAnnotation() throws NoSuchMethodException {
+    Class<SampleRepository> repositoryClass = SampleRepository.class;
+
+    CouchbaseQueryMethod defaultQueryMethod = new CouchbaseQueryMethod(repositoryClass.getMethod("findAll"),
+                                                                       metadata,
+                                                                       projectionFactory,
+                                                                       context);
+
+
+    CouchbaseQueryMethod unboundedQueryMethod = new CouchbaseQueryMethod(repositoryClass.getMethod("findByName"),
+                                                                         metadata,
+                                                                         projectionFactory,
+                                                                         context);
+
+    RxJavaCouchbaseTemplate template = mock(RxJavaCouchbaseTemplate.class);
+    when(template.getDefaultConsistency()).thenReturn(Consistency.STRONGLY_CONSISTENT);
+
+    ScanConsistency defaultConsistency = new SampleQuery(defaultQueryMethod, template).getScanConsistency();
+    assertEquals(defaultConsistency, Consistency.STRONGLY_CONSISTENT.n1qlConsistency());
+
+    ScanConsistency unboundedConsistency = new SampleQuery(unboundedQueryMethod, template).getScanConsistency();
+    assertEquals(unboundedConsistency, ScanConsistency.NOT_BOUNDED);
+
+  }
+
+  static class Sample {
+  		Integer name;
+  }
+
+  interface SampleRepository extends ReactiveCouchbaseRepository<Sample, Integer> {
+
+    Flux<Sample> findAll();
+
+    @WithConsistency(ScanConsistency.NOT_BOUNDED)
+    Flux<Sample> findByName();
+  }
+
+  class SampleQuery extends ReactiveAbstractN1qlBasedQuery {
+
+    protected SampleQuery(CouchbaseQueryMethod queryMethod,
+                          RxJavaCouchbaseOperations couchbaseOperations) {
+      super(queryMethod, couchbaseOperations);
+    }
+
+    @Override
+    protected Statement getStatement(ParameterAccessor accessor,
+                                     Object[] runtimeParameters,
+                                     ReturnedType returnedType) {
+      return null;
+    }
+
+    @Override
+    protected JsonValue getPlaceholderValues(ParameterAccessor accessor) {
+      return null;
+    }
+  }
+}


### PR DESCRIPTION
When using N1QL with spring data repositories, there is no way to set the scan consistency individually, only a global default could be set.

This adds a `@WithConsistency` annotation that allows you to set the scan consistency per query.
When building the query parameters in `AbstractN1qlBasedQuery` and `ReactiveAbstractN1qlBasedQuery` this annotation is evaluated, the current behavior (using the global default) is used as fallback in case no annotation was used.

Currently the added methods are duplicated in `AbstractN1qlBasedQuery` and `ReactiveAbstractN1qlBasedQuery` since they don't share a common interface. The same is true for `CouchbaseOperations` and `RxJavaCouchbaseOperations`. I could extract a common interface from each and provide a default implementation.

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATACOUCH).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
