### PR TITLE
DATACOUCH-459: Fix test issue which only shows up in java 11

### DIFF
--- a/src/test/java/org/springframework/data/couchbase/core/mapping/MappingCouchbaseConverterTests.java
+++ b/src/test/java/org/springframework/data/couchbase/core/mapping/MappingCouchbaseConverterTests.java
@@ -19,6 +19,7 @@ package org.springframework.data.couchbase.core.mapping;
 import static org.junit.Assert.*;
 
 import java.math.BigDecimal;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Collection;
@@ -490,7 +491,7 @@ public class MappingCouchbaseConverterTests {
     DateEntity read = converter.read(DateEntity.class, converted);
     assertEquals(created.getTime(), read.created.getTime());
     assertEquals(modified.getTimeInMillis() / 1000, read.modified.getTimeInMillis() / 1000);
-    assertTrue(deleted.isEqual(read.deleted));
+    assertEquals(deleted.truncatedTo(ChronoUnit.MILLIS), read.deleted.truncatedTo(ChronoUnit.MILLIS));
   }
 
   @Test


### PR DESCRIPTION
Seems that LocalDateTime now has microseconds, so the comparison of the unconverted
and converted LocalDateTime will fail, since the conversion/mapping only retains
millisecond precision.
