### PR TITLE
DATACOUCH-383 - RxJavaCouchbaseTemplate should return generated id wh…

### DIFF
--- a/src/test/java/org/springframework/data/couchbase/repository/ReactivePlace.java
+++ b/src/test/java/org/springframework/data/couchbase/repository/ReactivePlace.java
@@ -1,0 +1,38 @@
+package org.springframework.data.couchbase.repository;
+
+import com.couchbase.client.java.repository.annotation.Field;
+import com.couchbase.client.java.repository.annotation.Id;
+import org.springframework.data.couchbase.core.mapping.id.GeneratedValue;
+import org.springframework.data.couchbase.core.mapping.id.GenerationStrategy;
+
+/**
+ * @author David Kelly
+ */
+public class ReactivePlace {
+    @Id
+    @GeneratedValue(strategy= GenerationStrategy.UNIQUE)
+    public String id;
+
+    @Field("name")
+    public String name;
+
+    public String getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public ReactivePlace(String name) {
+        this.name = name;
+    }
+}

--- a/src/test/java/org/springframework/data/couchbase/repository/ReactivePlaceRepository.java
+++ b/src/test/java/org/springframework/data/couchbase/repository/ReactivePlaceRepository.java
@@ -1,0 +1,20 @@
+package org.springframework.data.couchbase.repository;
+
+import org.springframework.data.couchbase.core.query.N1qlPrimaryIndexed;
+import org.springframework.data.couchbase.core.query.Query;
+import org.springframework.data.couchbase.core.query.ViewIndexed;
+import reactor.core.publisher.Flux;
+
+import java.util.List;
+
+/**
+ * @author David Kelly
+ */
+@N1qlPrimaryIndexed
+public interface ReactivePlaceRepository extends ReactiveCouchbaseRepository<ReactivePlace, String> {
+
+    @Query("#{#n1ql.selectEntity} WHERE name = $1")
+    Flux<ReactivePlace> findByName(String name);
+
+}
+

--- a/src/test/java/org/springframework/data/couchbase/repository/ReactivePlaceTests.java
+++ b/src/test/java/org/springframework/data/couchbase/repository/ReactivePlaceTests.java
@@ -1,0 +1,57 @@
+package org.springframework.data.couchbase.repository;
+
+import com.couchbase.client.java.Bucket;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.couchbase.ContainerResourceRunner;
+import org.springframework.data.couchbase.ReactiveIntegrationTestApplicationConfig;
+import org.springframework.data.couchbase.repository.config.ReactiveRepositoryOperationsMapping;
+import org.springframework.data.couchbase.repository.support.IndexManager;
+import org.springframework.data.couchbase.repository.support.ReactiveCouchbaseRepositoryFactory;
+import org.springframework.data.repository.core.support.ReactiveRepositoryFactorySupport;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestExecutionListeners;
+
+import static junit.framework.TestCase.assertNull;
+import static org.junit.Assert.assertNotNull;
+import static org.springframework.data.couchbase.CouchbaseTestHelper.getRepositoryWithRetry;
+
+/**
+ * @author David Kelly
+ */
+@RunWith(ContainerResourceRunner.class)
+@ContextConfiguration(classes = ReactiveIntegrationTestApplicationConfig.class)
+@TestExecutionListeners(SimpleReactiveCouchbaseRepositoryListener.class)
+public class ReactivePlaceTests {
+    @Rule
+    public TestName testName = new TestName();
+
+    @Autowired
+    private Bucket client;
+
+    @Autowired
+    private ReactiveRepositoryOperationsMapping operationsMapping;
+
+    @Autowired
+    private IndexManager indexManager;
+
+    private ReactivePlaceRepository repository;
+
+    @Before
+    public void setup() throws Exception {
+        ReactiveRepositoryFactorySupport factory = new ReactiveCouchbaseRepositoryFactory(operationsMapping, indexManager);
+        repository = getRepositoryWithRetry(factory, ReactivePlaceRepository.class);
+    }
+
+    @Test
+    public void shouldReturnGeneratedId() {
+        ReactivePlace place = new ReactivePlace("somePlace");
+        assertNull(place.getId());
+        ReactivePlace returned = repository.save(place).block();
+        assertNotNull(returned.getId());
+    }
+}


### PR DESCRIPTION
…en saving.

Seems we fixed this for the non-Rx version, but not the RxJava version.  Followed
same basic strategy which was used for version, added a simple test.

