### PR TITLE
DATACOUCH-475 Couchbase builds failing.

### DIFF
--- a/src/test/java/org/springframework/data/couchbase/repository/ReactivePlaceIntegrationTests.java
+++ b/src/test/java/org/springframework/data/couchbase/repository/ReactivePlaceIntegrationTests.java
@@ -26,7 +26,7 @@ import static org.springframework.data.couchbase.CouchbaseTestHelper.getReposito
 @RunWith(ContainerResourceRunner.class)
 @ContextConfiguration(classes = ReactiveIntegrationTestApplicationConfig.class)
 @TestExecutionListeners(SimpleReactiveCouchbaseRepositoryListener.class)
-public class ReactivePlaceTests {
+public class ReactivePlaceIntegrationTests {
     @Rule
     public TestName testName = new TestName();
 


### PR DESCRIPTION
There was an integration test which wasn't named properly, and
so it was running with regular tests.  This left the container
around, and all subsequent integration tests failed.  Simple
fix.
