### PR TITLE
DATACOUCH-479 - Fix issue with testcontainers usage.

### DIFF
--- a/src/test/java/org/springframework/data/couchbase/TestContainerResource.java
+++ b/src/test/java/org/springframework/data/couchbase/TestContainerResource.java
@@ -44,7 +44,7 @@ public class TestContainerResource extends ExternalResource {
                     .withFixedExposedPort(11210, 11210)
                     .withFixedExposedPort(11211, 11211)
                     .withFixedExposedPort(11207, 11207);
-            couchbaseContainer.waitingFor(new CouchbaseWaitStrategy(serverVersion));
+            couchbaseContainer.waitingFor(new CouchbaseWaitStrategy(serverVersion, couchbaseContainer));
             couchbaseContainer.start();
         }
 


### PR DESCRIPTION
After updating the POM to not have a fixed testcontainers version, we
discovered the tests were failing with later versions of testcontainers.  It
seems that they updated how they did WaitStrategy, deprecating the old way, so
our WaitStrategy was not being called.  That means no setup was done to
the cluster (passwords, buckets, etc...).  Simple fix was to move to the
new interface.