### PR TITLE
Adding example of how to run an adhoc query using SPC4.x

### DIFF
--- a/src/main/asciidoc/migrating.adoc
+++ b/src/main/asciidoc/migrating.adoc
@@ -154,6 +154,58 @@ public class MyService {
 See <<couchbase.repository>> for more information.
 
 
+== Ad Hoc Queries
+
+The syntax for Ad Hoc queries has changed as well to be consistent with the Fluent API design. On Spring Data Couchbase 3.x the syntax for a dynamic query would look like the following:
+
+====
+[source,java]
+----
+    //Your custom repositoru
+    @Autowired
+    private MyRepository myRepository;
+
+    public List<User> getUsers() {
+    
+        //A very complex/dynamic query here
+        String queryString = "Select meta(u).id as id, u.* from myUsersBucket";
+        N1qlParams params = N1qlParams.build().consistency(ScanConsistency.STATEMENT_PLUS).adhoc(true);
+        ParameterizedN1qlQuery query = N1qlQuery.parameterized(queryString, JsonObject.create(), params);
+
+        return repository.getCouchbaseOperations().findByN1QLProjection(query, User.class);
+    }
+----
+====
+
+On Spring Data Couchbase 4.x, the same method will look like the following:
+
+
+====
+[source,java]
+----
+    //Cluster is a Couchbase object that you can inject
+    @Autowired
+    private Cluster cluster;
+
+    public List<User> getUsers() {
+        //A very complex/dynamic query here
+        String queryString = "Select meta(u).id as id, u.* from myUsersBucket";
+        
+        QueryOptions options = QueryOptions.queryOptions()
+            .scanConsistency(QueryScanConsistency.REQUEST_PLUS)
+            .adhoc(true);
+            
+        return cluster.query("Select * from myBucket", options)
+            .rowsAs(User.class);
+    }
+----
+====
+
+As you can see in the example above, ad hoc queries are now executed on the cluster level.
+
+See <<couchbase.repository>> for more information.
+
+
 == Full Text Search (FTS)
 
 The FTS API has been simplified and now can be accessed via the `Cluster` class:


### PR DESCRIPTION
Ad hoc Queries are not executed on the Cluster, I updated the migration guide to add a quick example of how it was in SPC3.x and how the new syntax looks like on SPC4.x. 

A proper session for the Cluster object will be added in the future

- [X] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
