### PR TITLE
DATACOUCH-524 - ability to store @Nullable fields as field:null

### DIFF
--- a/src/main/java/org/springframework/data/couchbase/core/convert/translation/JacksonTranslationService.java
+++ b/src/main/java/org/springframework/data/couchbase/core/convert/translation/JacksonTranslationService.java
@@ -21,6 +21,7 @@ import java.io.StringWriter;
 import java.io.Writer;
 import java.util.Map;
 
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.data.couchbase.core.mapping.CouchbaseDocument;
 import org.springframework.data.couchbase.core.mapping.CouchbaseList;
@@ -101,12 +102,15 @@ public class JacksonTranslationService implements TranslationService, Initializi
 				continue;
 			}
 
-			final Class<?> clazz = value.getClass();
-
-			if (simpleTypeHolder.isSimpleType(clazz) && !isEnumOrClass(clazz)) {
-				generator.writeObject(value);
+			if (value != null) {
+				final Class<?> clazz = value.getClass();
+				if (simpleTypeHolder.isSimpleType(clazz) && !isEnumOrClass(clazz)) {
+					generator.writeObject(value);
+				} else {
+					objectMapper.writeValue(generator, value);
+				}
 			} else {
-				objectMapper.writeValue(generator, value);
+				generator.writeObject(null);
 			}
 
 		}
@@ -247,6 +251,7 @@ public class JacksonTranslationService implements TranslationService, Initializi
 			objectMapper = new ObjectMapper();
 		}
 		objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+		objectMapper.registerModule(new Jdk8Module());
 	}
 
 }

--- a/src/main/java/org/springframework/data/couchbase/core/mapping/BasicCouchbasePersistentProperty.java
+++ b/src/main/java/org/springframework/data/couchbase/core/mapping/BasicCouchbasePersistentProperty.java
@@ -24,6 +24,7 @@ import org.springframework.data.mapping.model.FieldNamingStrategy;
 import org.springframework.data.mapping.model.Property;
 import org.springframework.data.mapping.model.PropertyNameFieldNamingStrategy;
 import org.springframework.data.mapping.model.SimpleTypeHolder;
+import org.springframework.lang.Nullable;
 import org.springframework.util.StringUtils;
 
 import com.couchbase.client.core.deps.com.fasterxml.jackson.annotation.JsonProperty;
@@ -93,5 +94,11 @@ public class BasicCouchbasePersistentProperty extends AnnotationBasedPersistentP
 	@Override
 	public boolean isIdProperty() {
 		return isAnnotationPresent(Id.class) || super.isIdProperty();
+	}
+
+	// DATACOUCH-524: allows explicitly storing null field
+	@Override
+	public boolean isNullable() {
+		return isAnnotationPresent(Nullable.class) ;
 	}
 }

--- a/src/main/java/org/springframework/data/couchbase/core/mapping/CouchbasePersistentProperty.java
+++ b/src/main/java/org/springframework/data/couchbase/core/mapping/CouchbasePersistentProperty.java
@@ -31,4 +31,6 @@ public interface CouchbasePersistentProperty extends PersistentProperty<Couchbas
 	 * The field name can be different from the actual property name by using a custom annotation.
 	 */
 	String getFieldName();
+
+	boolean isNullable();
 }

--- a/src/test/java/org/springframework/data/couchbase/core/convert/translation/JacksonTranslationServiceTests.java
+++ b/src/test/java/org/springframework/data/couchbase/core/convert/translation/JacksonTranslationServiceTests.java
@@ -21,6 +21,10 @@ import static org.junit.jupiter.api.Assertions.*;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.springframework.data.couchbase.core.mapping.CouchbaseDocument;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import java.lang.reflect.Field;
+import java.util.Optional;
 
 /**
  * Verifies the functionality of a {@link JacksonTranslationService}.
@@ -54,15 +58,165 @@ public class JacksonTranslationServiceTests {
 	}
 
 	@Test
-	void shouldDecodeAdHocFragment() {
+	void shouldEncDecAdHocFragment() {
 		String source = "{\"language\":\"french\"}";
 		LanguageFragment f = service.decodeFragment(source, LanguageFragment.class);
 		assertNotNull(f);
 		assertEquals("french", f.language);
+		CouchbaseDocument doc = docFromEntity(f);
+		assertEquals(source, service.encode(doc));
+	}
+
+	@Test
+	void shouldEncDecAdHocMissingFragment() {
+		String source = "{}";
+		LanguageFragment f = service.decodeFragment(source, LanguageFragment.class);
+		assertNotNull(f);
+		assertEquals(null, f.language);
+		CouchbaseDocument doc = docFromEntity(f);
+		assertEquals(source, service.encode(doc));
+	}
+
+	// for field that is not Optional<>,  missing and null decode to the same document
+	// however, encode will encode both the same ->   field : null
+	@Test
+	void shouldEncDecAdHocNullFragment() {
+		String source = "{\"language\":null}";
+		LanguageFragment f = service.decodeFragment(source, LanguageFragment.class);
+		assertNotNull(f);
+		assertEquals(null, f.language);
+		CouchbaseDocument doc = docFromEntity(f);
+		assertEquals("{}", service.encode(doc));
+	}
+
+	@Test
+	void shouldEncDecAdHocFragmentOptional() {
+		String source = "{\"language\":\"french\"}";
+		LanguageFragmentOptional f = service.decodeFragment(source, LanguageFragmentOptional.class); // needs Jdk8Module()
+		assertNotNull(f);
+		assertEquals(Optional.of("french"), f.language);
+		CouchbaseDocument doc = docFromEntity(f);
+		assertEquals(source, service.encode(doc));
+	}
+
+	// this will also encode to field : null, unless the encoder has _skipNulls == true
+	@Test
+	void shouldEncDecAdHocMissingFragmentOptional() {
+		String source = "{}";
+		LanguageFragmentOptional f = service.decodeFragment(source, LanguageFragmentOptional.class);
+		assertNotNull(f);
+		assertEquals(null, f.language);
+		CouchbaseDocument doc = docFromEntity(f);
+		assertEquals(source, service.encode(doc));
+	}
+
+	@Test
+	void shouldEncDecAdHocNullFragmentOptional() {
+		String source = "{\"language\":null}";
+		// this is going to get  language == null instead of language = Optional.empty();
+		// com.fasterxml.jackson.databind.deser.BeanDeserializer
+		//    public void deserializeAndSet(JsonParser p, DeserializationContext ctxt, Object instance) throws IOException {
+		//        Object value;
+		//        if (p.hasToken(JsonToken.VALUE_NULL)) {
+		//            if (this._skipNulls) {
+		//                return;
+		//            }
+		//			  value = this._nullProvider.getNullValue(ctxt);
+		LanguageFragmentOptional f = service.decodeFragment(source, LanguageFragmentOptional.class);
+		assertNotNull(f);
+		assertEquals(Optional.empty(), f.language);  //needs Jdk8Module() _nullProvider.getNullValue() return Optional.empty()
+		CouchbaseDocument doc = docFromEntity(f);
+		assertEquals(source, service.encode(doc));
+	}
+
+	@Test
+	void shouldEncDecObjectFragmentOptional() {
+		String source = "{\"language\":\"french\"}";
+		CouchbaseDocument target = new CouchbaseDocument();
+		service.decode(source, target);
+		assertEquals("french", target.get("language"));
+		assertEquals(source, service.encode(target));
+	}
+
+	// this will also encode to field : null, unless the encoder has _skipNulls == true
+	@Test
+	void shouldEncDecObjectMissingFragmentOptional() {
+		String source = "{}";
+		CouchbaseDocument target = new CouchbaseDocument();
+		service.decode(source, target);
+		assertEquals(null, target.get("language"));
+		assertEquals(source, service.encode(target));
+	}
+
+	@Test
+	void shouldEncDecObjectNullFragmentOptional() {
+		String source = "{\"language\":null}";
+		// this is going to get  language == null instead of language = Optional.empty();
+		// com.fasterxml.jackson.databind.deser.BeanDeserializer
+		//    public void deserializeAndSet(JsonParser p, DeserializationContext ctxt, Object instance) throws IOException {
+		//        Object value;
+		//        if (p.hasToken(JsonToken.VALUE_NULL)) {
+		//            if (this._skipNulls) {
+		//                return;
+		//            }
+		//			  value = this._nullProvider.getNullValue(ctxt);
+		CouchbaseDocument target = new CouchbaseDocument();
+		service.decode(source, target);
+		assertEquals(null, target.get("language")); // this will be null. Decode treats as regular property
+		// TODO: target gets encoded to { language:null } instead of {}
+		assertEquals(source, service.encode(target));
 	}
 
 	static class LanguageFragment {
 		public String language;
 	}
 
+	@JsonInclude(JsonInclude.Include.NON_NULL)
+	static class LanguageFragmentOptional {
+		@JsonInclude(JsonInclude.Include.NON_NULL)
+		public Optional<String> language;
+	}
+
+	static class NestedLanguageFragment {
+		static class Sublanguage {
+			String country;
+		}
+
+		public String language;
+		public Sublanguage sublanguage;
+	}
+
+	CouchbaseDocument docFromEntity(Object o) {
+		CouchbaseDocument doc = new CouchbaseDocument("key");
+		Field[] fields = o.getClass().getDeclaredFields();
+		for (Field f : fields) {
+			switch (f.getType().getName()) {
+			case "java.lang.String":
+				try {
+					if (f.get(o) != null) {
+						System.out.println("put " + f.getName() + " = " + f.get(o));
+						doc.put(f.getName(), f.get(o));
+					}
+				} catch (IllegalAccessException iae) {
+					throw new RuntimeException(iae);
+				}
+				break;
+			case "java.util.Optional":
+				try {
+					Optional<Object> opt = (Optional<Object>) f.get(o);
+					if (opt != null) {
+						System.out.println("put " + f.getName() + " = " + opt);
+						doc.put(f.getName(), opt.isPresent() ? opt.get() : null);
+					}
+				} catch (IllegalAccessException iae) {
+					throw new RuntimeException(iae);
+				}
+				break;
+			default:
+				throw new RuntimeException("unhandled type " + f.getType().getName());
+			}
+		}
+		return doc;
+
+	}
 }

--- a/src/test/java/org/springframework/data/couchbase/domain/Person.java
+++ b/src/test/java/org/springframework/data/couchbase/domain/Person.java
@@ -18,35 +18,33 @@ package org.springframework.data.couchbase.domain;
 import java.util.Optional;
 import java.util.UUID;
 
+import com.couchbase.client.core.deps.com.fasterxml.jackson.annotation.JsonProperty;
 import org.springframework.data.annotation.CreatedBy;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedBy;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.annotation.Version;
 import org.springframework.data.couchbase.core.mapping.Document;
+import org.springframework.lang.Nullable;
 
 @Document
 public class Person extends AbstractEntity {
 	Optional<String> firstname;
-	Optional<String> lastname;
+	@Nullable Optional<String> lastname;
 
-	@CreatedBy
-	private String creator;
+	@CreatedBy private String creator;
 
-	@LastModifiedBy
-	private String lastModifiedBy;
+	@LastModifiedBy private String lastModifiedBy;
 
-	@LastModifiedDate
-	private long lastModification;
+	@LastModifiedDate private long lastModification;
 
-	@CreatedDate
-	private long creationDate; // =System.currentTimeMillis();
+	@CreatedDate private long creationDate; // =System.currentTimeMillis();
 
-	@Version
-	private long version;
+	@Version private long version;
 
-	public Person() {
-	}
+	@Nullable @JsonProperty("nickname") private String middlename;
+
+	public Person() {}
 
 	public Person(String firstname, String lastname) {
 		this();
@@ -94,6 +92,14 @@ public class Person extends AbstractEntity {
 		this.lastname = lastname;
 	}
 
+	public String getMiddlename() {
+		return middlename;
+	}
+
+	public void setMiddlename(String middlename) {
+		this.middlename = middlename;
+	}
+
 	public long getVersion() {
 		return version;
 	}
@@ -104,6 +110,8 @@ public class Person extends AbstractEntity {
 		sb.append("  id : " + getId());
 		sb.append(optional(", firstname", firstname));
 		sb.append(optional(", lastname", lastname));
+		if (middlename != null)
+			sb.append(", middlename : " + middlename);
 		sb.append(", version : " + version);
 		if (creator != null) {
 			sb.append(", creator : " + creator);

--- a/src/test/java/org/springframework/data/couchbase/repository/ReactiveCouchbaseRepositoryKeyValueIntegrationTests.java
+++ b/src/test/java/org/springframework/data/couchbase/repository/ReactiveCouchbaseRepositoryKeyValueIntegrationTests.java
@@ -52,6 +52,7 @@ public class ReactiveCouchbaseRepositoryKeyValueIntegrationTests extends Cluster
 		found.ifPresent(u -> assertEquals(user, u));
 
 		assertTrue(userRepository.existsById(user.getId()).block());
+		userRepository.delete(user).block();
 	}
 
 	@Configuration


### PR DESCRIPTION
…the field is Optional.empty()

MOTIVATION
==========
This was a customer request.
Store Optional<T> fields as field:null if the field is Optional.empty().
If the field is null, do not emit the field at all (normal handling)

CHANGES
=======
Use the Jdk8Module of the ObjectMapper to handle Optional<T>.
In MappingCouchbaseConverter, recognize Optional<T> fields when reading and writing

<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATACOUCH).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
