### PR TITLE
DATACOUCH-558 - Write Nested Objects as Map

### DIFF
--- a/src/main/java/org/springframework/data/couchbase/core/convert/MappingCouchbaseConverter.java
+++ b/src/main/java/org/springframework/data/couchbase/core/convert/MappingCouchbaseConverter.java
@@ -39,17 +39,14 @@ import org.springframework.data.couchbase.core.mapping.CouchbaseList;
 import org.springframework.data.couchbase.core.mapping.CouchbaseMappingContext;
 import org.springframework.data.couchbase.core.mapping.CouchbasePersistentEntity;
 import org.springframework.data.couchbase.core.mapping.CouchbasePersistentProperty;
+import org.springframework.data.couchbase.core.mapping.event.AfterConvertCallback;
 import org.springframework.data.couchbase.core.mapping.id.GeneratedValue;
 import org.springframework.data.couchbase.core.mapping.id.IdAttribute;
 import org.springframework.data.couchbase.core.mapping.id.IdPrefix;
 import org.springframework.data.couchbase.core.mapping.id.IdSuffix;
 import org.springframework.data.couchbase.core.query.N1qlJoin;
-import org.springframework.data.mapping.Association;
-import org.springframework.data.mapping.AssociationHandler;
-import org.springframework.data.mapping.MappingException;
-import org.springframework.data.mapping.PersistentPropertyAccessor;
+import org.springframework.data.mapping.*;
 import org.springframework.data.mapping.PreferredConstructor.Parameter;
-import org.springframework.data.mapping.PropertyHandler;
 import org.springframework.data.mapping.callback.EntityCallbacks;
 import org.springframework.data.mapping.context.MappingContext;
 import org.springframework.data.mapping.model.ConvertingPropertyAccessor;
@@ -614,7 +611,7 @@ public class MappingCouchbaseConverter extends AbstractCouchbaseConverter implem
 				? mappingContext.getRequiredPersistentEntity(source.getClass())
 				: mappingContext.getRequiredPersistentEntity(type);
 		writeInternal(source, propertyDoc, entity);
-		target.put(name, propertyDoc);
+		target.put(name, propertyDoc.getContent());
 	}
 
 	/**

--- a/src/main/java/org/springframework/data/couchbase/core/mapping/CouchbaseDocument.java
+++ b/src/main/java/org/springframework/data/couchbase/core/mapping/CouchbaseDocument.java
@@ -283,6 +283,9 @@ public class CouchbaseDocument implements CouchbaseStorable {
 		if (CouchbaseSimpleTypes.DOCUMENT_TYPES.isSimpleType(clazz)) {
 			return;
 		}
+		if (Map.class.isAssignableFrom(clazz)) { // so source.getContent() can be put
+			return;
+		}
 		throw new IllegalArgumentException(
 				"Attribute of type " + clazz.getCanonicalName() + " cannot be stored and must be converted.");
 	}

--- a/src/test/java/org/springframework/data/couchbase/domain/Address.java
+++ b/src/test/java/org/springframework/data/couchbase/domain/Address.java
@@ -1,0 +1,43 @@
+package org.springframework.data.couchbase.domain;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.couchbase.config.AbstractCouchbaseConfiguration;
+import org.springframework.data.couchbase.core.mapping.Document;
+import org.springframework.data.couchbase.core.mapping.id.GeneratedValue;
+import org.springframework.data.couchbase.core.mapping.id.GenerationStrategy;
+
+import java.util.UUID;
+
+@Document
+public class Address extends AbstractEntity {
+
+	// from AbstractEntity @Id @GeneratedValue(strategy = GenerationStrategy.UNIQUE) private UUID id;
+
+	String street; // until MappingCouchbaseConverter.readFromMap handles setter/getter and/or Constructor
+
+	public Address(){	}
+	public String getStreet(){
+		return street;
+	}
+	public void setStreet(String street){
+		this.street = street;
+	}
+
+	/* from AbstractEntity
+	public UUID getId(){
+		return id;
+	}
+
+	public void setId(UUID id){
+		this.id = id;
+	}
+	 */
+
+	public String toString(){
+		StringBuilder sb = new StringBuilder();
+		sb.append("{ street : ");
+		sb.append( getStreet() );
+		sb.append(" }");
+		return sb.toString();
+	}
+}

--- a/src/test/java/org/springframework/data/couchbase/domain/Person.java
+++ b/src/test/java/org/springframework/data/couchbase/domain/Person.java
@@ -18,17 +18,20 @@ package org.springframework.data.couchbase.domain;
 import java.util.Optional;
 import java.util.UUID;
 
+import com.couchbase.client.core.deps.com.fasterxml.jackson.annotation.JsonProperty;
 import org.springframework.data.annotation.CreatedBy;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedBy;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.annotation.Version;
 import org.springframework.data.couchbase.core.mapping.Document;
+import org.springframework.data.couchbase.core.mapping.Field;
+import org.springframework.lang.Nullable;
 
 @Document
 public class Person extends AbstractEntity {
 	Optional<String> firstname;
-	Optional<String> lastname;
+	@Nullable Optional<String> lastname;
 
 	@CreatedBy
 	private String creator;
@@ -44,6 +47,12 @@ public class Person extends AbstractEntity {
 
 	@Version
 	private long version;
+
+	@Nullable
+	@Field("nickname")
+	private String middlename;
+
+	private Address address;
 
 	public Person() {
 	}
@@ -94,16 +103,31 @@ public class Person extends AbstractEntity {
 		this.lastname = lastname;
 	}
 
+	public String getMiddlename() {
+		return middlename;
+	}
+	public void setMiddlename(String middlename) {
+		this.middlename = middlename;
+	}
+
 	public long getVersion() {
 		return version;
 	}
 
+	public Address getAddress(){
+		return address;
+	}
+
+	public void setAddress(Address address){
+		this.address = address;
+	}
 	public String toString() {
 		StringBuilder sb = new StringBuilder();
 		sb.append("Person : {\n");
 		sb.append("  id : " + getId());
 		sb.append(optional(", firstname", firstname));
 		sb.append(optional(", lastname", lastname));
+		if(middlename!=null) sb.append(", middlename : "+middlename);
 		sb.append(", version : " + version);
 		if (creator != null) {
 			sb.append(", creator : " + creator);
@@ -116,6 +140,9 @@ public class Person extends AbstractEntity {
 		}
 		if (lastModification != 0) {
 			sb.append(", lastModification : " + lastModification);
+		}
+		if( getAddress() != null) {
+			sb.append(", address : "+ getAddress().toString() );
 		}
 		sb.append("}");
 		return sb.toString();


### PR DESCRIPTION
This is to fix an issue where nested objects were written as a
nested CouchbaseDocument - complete with id, expiration and
content containing the actual data. Aside from not being properly
stored, the documents could not be read back to construct a
domain object.