### PR TITLE
DATACOUCH-560 - serialize CouchbaseDocument and CouchbaseList

### DIFF
--- a/src/main/java/org/springframework/data/couchbase/config/AbstractCouchbaseConfiguration.java
+++ b/src/main/java/org/springframework/data/couchbase/config/AbstractCouchbaseConfiguration.java
@@ -22,6 +22,10 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
+import com.couchbase.client.java.codec.JacksonJsonSerializer;
+import com.couchbase.client.java.json.JsonValueModule;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.couchbase.client.java.json.RepackagedJsonValueModule;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ClassPathScanningCandidateComponentProvider;
@@ -35,6 +39,7 @@ import org.springframework.data.couchbase.core.CouchbaseTemplate;
 import org.springframework.data.couchbase.core.ReactiveCouchbaseTemplate;
 import org.springframework.data.couchbase.core.convert.CouchbaseCustomConversions;
 import org.springframework.data.couchbase.core.convert.MappingCouchbaseConverter;
+import org.springframework.data.couchbase.core.convert.translation.CouchbaseJacksonModule;
 import org.springframework.data.couchbase.core.convert.translation.JacksonTranslationService;
 import org.springframework.data.couchbase.core.convert.translation.TranslationService;
 import org.springframework.data.couchbase.core.mapping.CouchbaseMappingContext;
@@ -61,6 +66,7 @@ import com.couchbase.client.java.json.JacksonTransformers;
  * @author Simon Baslé
  * @author Stephane Nicoll
  * @author Subhashni Balakrishnan
+ * @author Michael Reiche
  */
 @Configuration
 public abstract class AbstractCouchbaseConfiguration {
@@ -140,7 +146,10 @@ public abstract class AbstractCouchbaseConfiguration {
 	 * @param builder the builder that can be customized.
 	 */
 	protected void configureEnvironment(final ClusterEnvironment.Builder builder) {
-
+		ObjectMapper objectMapper = new ObjectMapper();
+		objectMapper.registerModule(new CouchbaseJacksonModule());
+		objectMapper.registerModule(new JsonValueModule());
+		builder.jsonSerializer(JacksonJsonSerializer.create(objectMapper));
 	}
 
 	@Bean(name = BeanNames.COUCHBASE_TEMPLATE)

--- a/src/main/java/org/springframework/data/couchbase/core/convert/MappingCouchbaseConverter.java
+++ b/src/main/java/org/springframework/data/couchbase/core/convert/MappingCouchbaseConverter.java
@@ -39,17 +39,14 @@ import org.springframework.data.couchbase.core.mapping.CouchbaseList;
 import org.springframework.data.couchbase.core.mapping.CouchbaseMappingContext;
 import org.springframework.data.couchbase.core.mapping.CouchbasePersistentEntity;
 import org.springframework.data.couchbase.core.mapping.CouchbasePersistentProperty;
+import org.springframework.data.couchbase.core.mapping.event.AfterConvertCallback;
 import org.springframework.data.couchbase.core.mapping.id.GeneratedValue;
 import org.springframework.data.couchbase.core.mapping.id.IdAttribute;
 import org.springframework.data.couchbase.core.mapping.id.IdPrefix;
 import org.springframework.data.couchbase.core.mapping.id.IdSuffix;
 import org.springframework.data.couchbase.core.query.N1qlJoin;
-import org.springframework.data.mapping.Association;
-import org.springframework.data.mapping.AssociationHandler;
-import org.springframework.data.mapping.MappingException;
-import org.springframework.data.mapping.PersistentPropertyAccessor;
+import org.springframework.data.mapping.*;
 import org.springframework.data.mapping.PreferredConstructor.Parameter;
-import org.springframework.data.mapping.PropertyHandler;
 import org.springframework.data.mapping.callback.EntityCallbacks;
 import org.springframework.data.mapping.context.MappingContext;
 import org.springframework.data.mapping.model.ConvertingPropertyAccessor;
@@ -614,7 +611,7 @@ public class MappingCouchbaseConverter extends AbstractCouchbaseConverter implem
 				? mappingContext.getRequiredPersistentEntity(source.getClass())
 				: mappingContext.getRequiredPersistentEntity(type);
 		writeInternal(source, propertyDoc, entity);
-		target.put(name, propertyDoc);
+		target.put(name, propertyDoc /*.getContent() */);
 	}
 
 	/**

--- a/src/main/java/org/springframework/data/couchbase/core/convert/translation/CouchbaseJacksonModule.java
+++ b/src/main/java/org/springframework/data/couchbase/core/convert/translation/CouchbaseJacksonModule.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2020 the original author or authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.couchbase.core.convert.translation;
+
+import com.fasterxml.jackson.core.Version;
+import com.fasterxml.jackson.databind.*;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.databind.ser.ContextualSerializer;
+import com.fasterxml.jackson.databind.ser.ResolvableSerializer;
+import com.fasterxml.jackson.databind.ser.std.StdDelegatingSerializer;
+import com.fasterxml.jackson.databind.type.TypeFactory;
+import com.fasterxml.jackson.databind.util.Converter;
+import org.springframework.data.couchbase.core.mapping.CouchbaseDocument;
+import org.springframework.data.couchbase.core.mapping.CouchbaseList;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * CouchbaseJacksonModule was provided by spac-valentin to handle nested List (CouchbaseList)
+ * and Map (CouchbaseDocument).
+ * The CouchbaseListSerializer and CouchbaseDocumentSerializer classes have been modified to extend the
+ * {@link StdDelegatingSerializer}
+ *
+ * @author spac-valentin
+ * @author Michael Reiche
+ */
+public class CouchbaseJacksonModule extends SimpleModule {
+
+	public CouchbaseJacksonModule() {
+		super(new Version(1, 0, 0, null, "com.couchbase", "CouchbaseDocumentAndList"));
+		addSerializer(CouchbaseDocument.class, new CouchbaseDocumentSerializer(new CouchbaseDocumentConverter()));
+		addSerializer(CouchbaseList.class, new CouchbaseListSerializer(new CouchbaseListConverter()));
+	}
+
+	public static class CouchbaseDocumentSerializer extends StdDelegatingSerializer implements ResolvableSerializer,
+			ContextualSerializer {
+
+		public CouchbaseDocumentSerializer(Converter<?, ?> converter) {
+			super(converter);
+		}
+
+		@Override
+		protected StdDelegatingSerializer withDelegate(Converter<Object, ?> converter, JavaType delegateType, JsonSerializer<?> delegateSerializer) {
+			return new StdDelegatingSerializer(converter, delegateType, delegateSerializer);
+		}
+
+	}
+
+	public static class CouchbaseListSerializer extends StdDelegatingSerializer implements ResolvableSerializer,
+			ContextualSerializer {
+
+		public CouchbaseListSerializer(Converter<?, ?> converter) {
+			super(converter);
+		}
+
+		@Override
+		protected StdDelegatingSerializer withDelegate(Converter<Object, ?> converter, JavaType delegateType, JsonSerializer<?> delegateSerializer) {
+			return new StdDelegatingSerializer(converter, delegateType, delegateSerializer);
+		}
+	}
+
+	public static class CouchbaseListConverter implements Converter<Object,Object>{
+
+		@Override public Object convert(Object o) {
+			return ((CouchbaseList)o).export();
+		}
+
+		@Override public JavaType getInputType(TypeFactory typeFactory) {
+			return typeFactory.constructType(CouchbaseList.class);
+		}
+
+		@Override public JavaType getOutputType(TypeFactory typeFactory) {
+			return typeFactory.constructType(List.class);
+		}
+	}
+
+	public static class CouchbaseDocumentConverter implements Converter<Object,Object>{
+
+		@Override public Object convert(Object o) {
+			return ((CouchbaseDocument)o).export();
+		}
+
+		@Override public JavaType getInputType(TypeFactory typeFactory) {
+			return typeFactory.constructType(CouchbaseDocument.class);
+		}
+
+		@Override public JavaType getOutputType(TypeFactory typeFactory) {
+			return typeFactory.constructType(Map.class);
+		}
+	}
+}

--- a/src/main/java/org/springframework/data/couchbase/core/mapping/CouchbaseDocument.java
+++ b/src/main/java/org/springframework/data/couchbase/core/mapping/CouchbaseDocument.java
@@ -283,6 +283,9 @@ public class CouchbaseDocument implements CouchbaseStorable {
 		if (CouchbaseSimpleTypes.DOCUMENT_TYPES.isSimpleType(clazz)) {
 			return;
 		}
+		if (Map.class.isAssignableFrom(clazz)) { // so source.getContent() can be put
+			return;
+		}
 		throw new IllegalArgumentException(
 				"Attribute of type " + clazz.getCanonicalName() + " cannot be stored and must be converted.");
 	}

--- a/src/main/java/org/springframework/data/couchbase/core/mapping/CouchbaseList.java
+++ b/src/main/java/org/springframework/data/couchbase/core/mapping/CouchbaseList.java
@@ -156,11 +156,9 @@ public class CouchbaseList implements CouchbaseStorable {
 		int elem = 0;
 		for (Object entry : payload) {
 			if (entry instanceof CouchbaseDocument) {
-				toExport.remove(elem);
-				toExport.add(elem, ((CouchbaseDocument) entry).export());
+				toExport.set(elem, ((CouchbaseDocument) entry).export());
 			} else if (entry instanceof CouchbaseList) {
-				toExport.remove(elem);
-				toExport.add(elem, ((CouchbaseList) entry).export());
+				toExport.set(elem, ((CouchbaseList) entry).export());
 			}
 			elem++;
 		}

--- a/src/test/java/org/springframework/data/couchbase/domain/Address.java
+++ b/src/test/java/org/springframework/data/couchbase/domain/Address.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2020 the original author or authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.couchbase.domain;
+
+import org.springframework.data.couchbase.core.mapping.Document;
+
+/**
+ * nested domain object for manual testing
+ * 
+ * @author Michael Reiche
+ */
+@Document
+public class Address extends AbstractEntity {
+
+	String street;
+
+	public Address() {}
+
+	public String getStreet() {
+		return street;
+	}
+
+	public void setStreet(String street) {
+		this.street = street;
+	}
+
+	public String toString() {
+		StringBuilder sb = new StringBuilder();
+		sb.append("{ street : ");
+		sb.append(getStreet());
+		sb.append(" }");
+		return sb.toString();
+	}
+}

--- a/src/test/java/org/springframework/data/couchbase/domain/Config.java
+++ b/src/test/java/org/springframework/data/couchbase/domain/Config.java
@@ -44,8 +44,7 @@ public class Config extends AbstractCouchbaseConfiguration {
 	static {
 		try {
 			clusterAware = Class.forName("org.springframework.data.couchbase.util.ClusterAwareIntegrationTests");
-		} catch (ClassNotFoundException cnfe) {
-		}
+		} catch (ClassNotFoundException cnfe) {}
 	}
 
 	@Override

--- a/src/test/java/org/springframework/data/couchbase/domain/MyClass.java
+++ b/src/test/java/org/springframework/data/couchbase/domain/MyClass.java
@@ -1,0 +1,50 @@
+package org.springframework.data.couchbase.domain;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.couchbase.core.mapping.Document;
+import org.springframework.data.couchbase.core.mapping.Field;
+
+import java.util.List;
+import java.util.Map;
+
+@Document
+public class MyClass {
+
+	public MyClass() {}
+
+	public void setId(String id) {
+		this.id = id;
+	}
+
+	public String getId() {
+		return id;
+	}
+
+	public List<Map<String, Object>> getFields() {
+		return fields;
+	}
+
+	public void setFields(List<Map<String, Object>> fields) {
+		this.fields = fields;
+	}
+
+	public List<Map<String, Object>> getConfiguration() {
+		return configuration;
+	}
+
+	public void setConfiguration(List<Map<String, Object>> configuration) {
+		this.configuration = configuration;
+	}
+
+	@Id private String id;
+	@Field public List<Map<String, Object>> fields;
+	@Field public List<Map<String, Object>> configuration;
+
+	public String toString() {
+		StringBuilder sb = new StringBuilder();
+		sb.append("{ fields : ");
+		sb.append(getFields().toString());
+		sb.append(" }");
+		return sb.toString();
+	}
+}

--- a/src/test/java/org/springframework/data/couchbase/domain/Person.java
+++ b/src/test/java/org/springframework/data/couchbase/domain/Person.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2020 the original author or authors
+ * Copyright 2020 the original author or authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,29 +24,34 @@ import org.springframework.data.annotation.LastModifiedBy;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.annotation.Version;
 import org.springframework.data.couchbase.core.mapping.Document;
+import org.springframework.data.couchbase.core.mapping.Field;
+import org.springframework.lang.Nullable;
 
+/**
+ * domain object for manual testing
+ * 
+ * @author Michael Reiche
+ */
 @Document
 public class Person extends AbstractEntity {
 	Optional<String> firstname;
-	Optional<String> lastname;
+	@Nullable Optional<String> lastname;
 
-	@CreatedBy
-	private String creator;
+	@CreatedBy private String creator;
 
-	@LastModifiedBy
-	private String lastModifiedBy;
+	@LastModifiedBy private String lastModifiedBy;
 
-	@LastModifiedDate
-	private long lastModification;
+	@LastModifiedDate private long lastModification;
 
-	@CreatedDate
-	private long creationDate; // =System.currentTimeMillis();
+	@CreatedDate private long creationDate; // =System.currentTimeMillis();
 
-	@Version
-	private long version;
+	@Version private long version;
 
-	public Person() {
-	}
+	@Nullable @Field("nickname") private String middlename;
+
+	private Address address;
+
+	public Person() {}
 
 	public Person(String firstname, String lastname) {
 		this();
@@ -94,8 +99,24 @@ public class Person extends AbstractEntity {
 		this.lastname = lastname;
 	}
 
+	public String getMiddlename() {
+		return middlename;
+	}
+
+	public void setMiddlename(String middlename) {
+		this.middlename = middlename;
+	}
+
 	public long getVersion() {
 		return version;
+	}
+
+	public Address getAddress() {
+		return address;
+	}
+
+	public void setAddress(Address address) {
+		this.address = address;
 	}
 
 	public String toString() {
@@ -104,6 +125,8 @@ public class Person extends AbstractEntity {
 		sb.append("  id : " + getId());
 		sb.append(optional(", firstname", firstname));
 		sb.append(optional(", lastname", lastname));
+		if (middlename != null)
+			sb.append(", middlename : " + middlename);
 		sb.append(", version : " + version);
 		if (creator != null) {
 			sb.append(", creator : " + creator);
@@ -116,6 +139,9 @@ public class Person extends AbstractEntity {
 		}
 		if (lastModification != 0) {
 			sb.append(", lastModification : " + lastModification);
+		}
+		if (getAddress() != null) {
+			sb.append(", address : " + getAddress().toString());
 		}
 		sb.append("}");
 		return sb.toString();


### PR DESCRIPTION
MOTIVATION
==========
Without this change, List<> and Map<> are just serialized as beans
A non-empty list ends up being { empty : false }
Also included are MappingCouchbaseConverter and CouchbaseDocument
from DATACOUCH-558 as they are needed for the manual testing of
Person.Address.
