### PR TITLE
DATACOUCH-532 - Use parameters in queries instead of literals.

### DIFF
--- a/src/main/java/org/springframework/data/couchbase/core/query/Query.java
+++ b/src/main/java/org/springframework/data/couchbase/core/query/Query.java
@@ -248,7 +248,7 @@ public class Query {
 		final StringBuilder statement = new StringBuilder();
 		appendString(statement, n1ql.selectEntity); // select ...
 		appendWhereString(statement, n1ql.filter); // typeKey = typeValue
-		appendWhere(statement, null); // criteria on this Query
+		appendWhere(statement, new int[] { 0 }); // criteria on this Query
 		appendSort(statement);
 		appendSkipAndLimit(statement);
 		return statement.toString();

--- a/src/test/java/org/springframework/data/couchbase/repository/CouchbaseRepositoryQueryIntegrationTests.java
+++ b/src/test/java/org/springframework/data/couchbase/repository/CouchbaseRepositoryQueryIntegrationTests.java
@@ -83,6 +83,29 @@ public class CouchbaseRepositoryQueryIntegrationTests extends ClusterAwareIntegr
 		}
 	}
 
+	// "1\" or name=name or name=\"1")
+	@Test
+	void findByInjection() {
+		Airport vie = null;
+		Airport xxx = null;
+		try {
+			vie = new Airport("airports::vie", "vie", "loww");
+			airportRepository.save(vie);
+			xxx = new Airport("airports::xxx", "xxx", "xxxx");
+			airportRepository.save(xxx);
+			sleep(1000);
+			List<Airport> airports;
+			airports = airportRepository.findAllByIata("1\" or iata=iata or iata=\"1");
+			assertEquals(0, airports.size());
+			airports = airportRepository.findAllByIata("vie");
+			assertEquals(1, airports.size());
+		} finally {
+			airportRepository.delete(vie);
+			airportRepository.delete(xxx);
+		}
+
+	}
+
 	@Test
 	void findBySimpleProperty() {
 		Airport vie = null;


### PR DESCRIPTION
This will allow query plans to be reused for different parameters.

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATACOUCH).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
