### PR TITLE
DATACOUCH-579 - Handle string queries containing ORDERED, LIMIT and O…

### DIFF
--- a/src/main/java/org/springframework/data/couchbase/core/query/Query.java
+++ b/src/main/java/org/springframework/data/couchbase/core/query/Query.java
@@ -48,7 +48,7 @@ public class Query {
 	private int limit;
 	private Sort sort = Sort.unsorted();
 
-	static private final Pattern WHERE_PATTERN = Pattern.compile("\\sWHERE\\s");
+	protected final Pattern WHERE_PATTERN = Pattern.compile("\\sWHERE\\s");
 
 	public Query() {}
 
@@ -220,7 +220,7 @@ public class Query {
 	 * @param querySoFar
 	 * @return true -> not quoted, false -> quoted
 	 */
-	private static boolean notQuoted(int start, int end, String querySoFar) {
+	protected static boolean notQuoted(int start, int end, String querySoFar) {
 		Matcher quoteMatcher = StringBasedN1qlQueryParser.QUOTE_DETECTION_PATTERN.matcher(querySoFar);
 		List<int[]> quotes = new ArrayList<int[]>();
 		while (quoteMatcher.find()) {

--- a/src/main/java/org/springframework/data/couchbase/core/query/StringQuery.java
+++ b/src/main/java/org/springframework/data/couchbase/core/query/StringQuery.java
@@ -20,17 +20,15 @@ import com.couchbase.client.java.json.JsonValue;
 import org.springframework.data.couchbase.core.ReactiveCouchbaseTemplate;
 import org.springframework.data.couchbase.repository.query.StringBasedN1qlQueryParser;
 
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 /**
- * @author Michael Reiche
- *
- * Query created from the string in @Query annotation in the repository interface.
- *
- *      @Query("#{#n1ql.selectEntity} where firstname = $1 and lastname = $2")
- * 	    List<User>  getByFirstnameAndLastname(String firstname, String lastname);
- *
- * It must include the SELECT ... FROM ... preferably via the #n1ql expression
- * In addition to any predicates in the string, a predicate for the domainType (class)
- * will be added.
+ * @author Michael Reiche Query created from the string in @Query annotation in the repository
+ *         interface. @Query("#{#n1ql.selectEntity} where firstname = $1 and lastname = $2") List<User>
+ *         getByFirstnameAndLastname(String firstname, String lastname); It must include the SELECT ... FROM ...
+ *         preferably via the #n1ql expression In addition to any predicates in the string, a predicate for the
+ *         domainType (class) will be added.
  */
 public class StringQuery extends Query {
 
@@ -41,10 +39,10 @@ public class StringQuery extends Query {
 	}
 
 	/**
-	 * inlineN1qlQuery (Query Annotation)
-	 * append the string query to the provided StringBuilder.
-	 * To be used along with the other append*() methods to construct the N1QL statement
-	 * @param	sb - StringBuilder
+	 * inlineN1qlQuery (Query Annotation) append the string query to the provided StringBuilder. To be used along with the
+	 * other append*() methods to construct the N1QL statement
+	 * 
+	 * @param sb - StringBuilder
 	 */
 	private void appendInlineN1qlStatement(final StringBuilder sb) {
 		sb.append(inlineN1qlQuery);
@@ -53,9 +51,9 @@ public class StringQuery extends Query {
 	@Override
 	public String toN1qlString(ReactiveCouchbaseTemplate template, Class domainClass, boolean isCount) {
 		StringBasedN1qlQueryParser.N1qlSpelValues n1ql = getN1qlSpelValues(template, domainClass, isCount);
-		final StringBuilder statement = new StringBuilder();
+		StringBuilder statement = new StringBuilder();
 		appendInlineN1qlStatement(statement); // apply the string statement
-		appendWhereString(statement, n1ql.filter); // typeKey = typeValue
+		statement = insertWherePredOrAndPred(statement, n1ql.filter, n1ql.bucket); // typeKey = typeValue
 
 		// To use generated parameters for literals
 		// we need to figure out if we must use positional or named parameters
@@ -72,5 +70,58 @@ public class StringQuery extends Query {
 		appendSort(statement);
 		appendSkipAndLimit(statement);
 		return statement.toString();
+	}
+
+	/**
+	 * Inserts or appends a predicate to a n1ql string 1) If the n1ql string already contains a WHERE, the predicate will
+	 * be inserted right after the WHERE 2) If the n1ql string doesn't contain a WHERE, either a) if FROM 'bucket' is at
+	 * the end of the n1ql statement, append WHERE <predicate> b) if FROM 'bucket' is not at the of the n1ql statement,
+	 * insert WHERE <predicate> immediately after FROM 'bucket' </predicate>
+	 * 
+	 * @param sb - StringBuilder containing n1ql statement being built
+	 * @param predicate - predicate to add to statement
+	 * @param bucket - to find 'from bucket' in n1ql statement
+	 * @return - StringBuilder containing n1ql statement being built
+	 */
+	private StringBuilder insertWherePredOrAndPred(StringBuilder sb, String predicate, String bucket) {
+		String querySoFar = sb.toString().toUpperCase();
+		Matcher whereMatcher = WHERE_PATTERN.matcher(querySoFar);
+		boolean alreadyWhere = false;
+		while (!alreadyWhere && whereMatcher.find()) {
+			if (notQuoted(whereMatcher.start(), whereMatcher.end(), querySoFar)) {
+				alreadyWhere = true;
+			}
+		}
+		if (alreadyWhere) { // already a 'where', the predicate can go immediately after the 'where'
+			StringBuilder newStringBuilder = new StringBuilder(sb.substring(0, whereMatcher.end()));
+			newStringBuilder.append(predicate);
+			newStringBuilder.append(" AND ");
+			newStringBuilder.append(sb.substring(whereMatcher.end()));
+			return newStringBuilder;
+		} else { // if there isn't a 'where' (select * from bucket LIMIT 10), we need to insert following 'bucket'
+			final Pattern BUCKET_PATTERN = Pattern.compile("\\s(f|F)(r|R)(o|O)(m|M)(\\s)+" + bucket + "(\\s|$)");
+			Matcher fromBucketMatcher = BUCKET_PATTERN.matcher(sb.toString()); // do not change case
+			boolean alreadyFromBucket = false;
+			while (!alreadyFromBucket && fromBucketMatcher.find()) {
+				if (notQuoted(fromBucketMatcher.start(), fromBucketMatcher.end(), querySoFar)) {
+					alreadyFromBucket = true;
+				}
+			}
+			if (!alreadyFromBucket) {
+				throw new RuntimeException("bucket name " + bucket + " not found in query string: " + sb.toString());
+			}
+			if (fromBucketMatcher.end() == sb.toString().length()) { // at the end, just append
+				sb.append(" WHERE ");
+				sb.append(predicate);
+				return sb;
+			} else {
+				StringBuilder newStringBuilder = new StringBuilder(sb.substring(0, fromBucketMatcher.end()));
+				newStringBuilder.append(" WHERE ");
+				newStringBuilder.append(predicate);
+				newStringBuilder.append(" ");
+				newStringBuilder.append(sb.substring(fromBucketMatcher.end()));
+				return newStringBuilder;
+			}
+		}
 	}
 }

--- a/src/test/java/org/springframework/data/couchbase/domain/AirportRepository.java
+++ b/src/test/java/org/springframework/data/couchbase/domain/AirportRepository.java
@@ -41,7 +41,19 @@ public interface AirportRepository extends PagingAndSortingRepository<Airport, S
 	List<Airport> findAllByIata(String iata);
 
 	@Query("#{#n1ql.selectEntity} where iata = $1")
-	List<Airport> getAllByIata(String iata);
+	List<Airport> getByIata(String iata);
+
+	@Query("#{#n1ql.selectEntity} where iata = $1  ORDER BY icao LIMIT 10")
+	List<Airport> getByIataSort(String iata);
+
+	@Query("#{#n1ql.selectEntity} ORDER BY icao LIMIT 10")
+	List<Airport> getAllSort();
+
+	@Query("#{#n1ql.selectEntity}")
+	List<Airport> getAll();
+
+	@Query("select meta(#{#n1ql.bucket}).id as __id, META(#{#n1ql.bucket}).cas as __cas, #{#n1ql.bucket}.* from #{#n1ql.bucket}")
+	List<Airport> getAllExplicitly();
 
 	long countByIataIn(String... iata);
 

--- a/src/test/java/org/springframework/data/couchbase/repository/CouchbaseRepositoryQueryIntegrationTests.java
+++ b/src/test/java/org/springframework/data/couchbase/repository/CouchbaseRepositoryQueryIntegrationTests.java
@@ -122,6 +122,76 @@ public class CouchbaseRepositoryQueryIntegrationTests extends ClusterAwareIntegr
 	}
 
 	@Test
+	void findByStringQuery() {
+		Airport vie = null;
+		try {
+			vie = new Airport("airports::vie", "vie", "loww");
+			airportRepository.save(vie);
+			sleep(1000);
+			List<Airport> airports = airportRepository.getByIata("vie");
+			assertEquals(vie.getId(), airports.get(0).getId());
+		} finally {
+			airportRepository.delete(vie);
+		}
+	}
+
+	@Test
+	void findByStringQuerySort() {
+		Airport vie = null;
+		try {
+			vie = new Airport("airports::vie", "vie", "loww");
+			airportRepository.save(vie);
+			sleep(1000);
+			List<Airport> airports = airportRepository.getByIataSort("vie");
+			assertEquals(vie.getId(), airports.get(0).getId());
+		} finally {
+			airportRepository.delete(vie);
+		}
+	}
+
+	@Test
+	void findByStringQueryNoPredSort() {
+		Airport vie = null;
+		try {
+			vie = new Airport("airports::vie", "vie", "loww");
+			airportRepository.save(vie);
+			sleep(1000);
+			List<Airport> airports = airportRepository.getAllSort();
+			assertEquals(vie.getId(), airports.get(0).getId());
+		} finally {
+			airportRepository.delete(vie);
+		}
+	}
+
+	@Test
+	void findByStringQueryNoPred() {
+		Airport vie = null;
+		try {
+			vie = new Airport("airports::vie", "vie", "loww");
+			airportRepository.save(vie);
+			sleep(1000);
+			List<Airport> airports = airportRepository.getAll();
+			assertEquals(vie.getId(), airports.get(0).getId());
+		} finally {
+			airportRepository.delete(vie);
+		}
+	}
+
+	@Test
+	void findByStringQueryNoPredExplicitly() {
+		Airport vie = null;
+		try {
+			vie = new Airport("airports::vie", "vie", "loww");
+			airportRepository.save(vie);
+			sleep(1000);
+			List<Airport> airports = airportRepository.getAllExplicitly();
+			assertEquals(vie.getId(), airports.get(0).getId());
+		} finally {
+			airportRepository.delete(vie);
+		}
+	}
+
+	@Test
 	void count() {
 		String[] iatas = { "JFK", "IAD", "SFO", "SJC", "SEA", "LAX", "PHX" };
 		Future[] future = new Future[iatas.length];
@@ -219,7 +289,7 @@ public class CouchbaseRepositoryQueryIntegrationTests extends ClusterAwareIntegr
 					final int idx = i;
 					suppliers[i] = () -> {
 						sleep(iatas.length - idx); // so they are executed out-of-order
-						String foundName = airportRepository.getAllByIata(iatas[idx]).get(0).getIata();
+						String foundName = airportRepository.getByIata(iatas[idx]).get(0).getIata();
 						assertEquals(iatas[idx], foundName);
 						return iatas[idx].equals(foundName);
 					};


### PR DESCRIPTION
…FFSET.

Handle string queries containing ORDERED, LIMIT and OFFSET.
The _class = <className> predicate cannot simply be appended to these queries.
It must be inserted after the WHERE and before the ORDERED, LIMIT and OFFSET

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATACOUCH).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
