### PR TITLE
DATACOUCH-580 - Handle string queries containing ORDERED, LIMIT and O…

### DIFF
--- a/src/main/java/org/springframework/data/couchbase/core/query/StringQuery.java
+++ b/src/main/java/org/springframework/data/couchbase/core/query/StringQuery.java
@@ -21,16 +21,12 @@ import org.springframework.data.couchbase.core.ReactiveCouchbaseTemplate;
 import org.springframework.data.couchbase.repository.query.StringBasedN1qlQueryParser;
 
 /**
+ * Query created from the string in @Query annotation in the repository interface. @Query("#{#n1ql.selectEntity} where
+ * firstname = $1 and lastname = $2") List<User> getByFirstnameAndLastname(String firstname, String lastname); It must
+ * include the SELECT ... FROM ... preferably via the #n1ql expression In addition to any predicates in the string, a
+ * predicate for the domainType (class) will be added
+ *
  * @author Michael Reiche
- *
- * Query created from the string in @Query annotation in the repository interface.
- *
- *      @Query("#{#n1ql.selectEntity} where firstname = $1 and lastname = $2")
- * 	    List<User>  getByFirstnameAndLastname(String firstname, String lastname);
- *
- * It must include the SELECT ... FROM ... preferably via the #n1ql expression
- * In addition to any predicates in the string, a predicate for the domainType (class)
- * will be added.
  */
 public class StringQuery extends Query {
 
@@ -41,10 +37,10 @@ public class StringQuery extends Query {
 	}
 
 	/**
-	 * inlineN1qlQuery (Query Annotation)
-	 * append the string query to the provided StringBuilder.
-	 * To be used along with the other append*() methods to construct the N1QL statement
-	 * @param	sb - StringBuilder
+	 * inlineN1qlQuery (Query Annotation) append the string query to the provided StringBuilder. To be used along with the
+	 * other append*() methods to construct the N1QL statement
+	 * 
+	 * @param sb - StringBuilder
 	 */
 	private void appendInlineN1qlStatement(final StringBuilder sb) {
 		sb.append(inlineN1qlQuery);
@@ -52,11 +48,8 @@ public class StringQuery extends Query {
 
 	@Override
 	public String toN1qlString(ReactiveCouchbaseTemplate template, Class domainClass, boolean isCount) {
-		StringBasedN1qlQueryParser.N1qlSpelValues n1ql = getN1qlSpelValues(template, domainClass, isCount);
 		final StringBuilder statement = new StringBuilder();
 		appendInlineN1qlStatement(statement); // apply the string statement
-		appendWhereString(statement, n1ql.filter); // typeKey = typeValue
-
 		// To use generated parameters for literals
 		// we need to figure out if we must use positional or named parameters
 		// If we are using positional parameters, we need to start where

--- a/src/test/java/org/springframework/data/couchbase/domain/AirlineRepository.java
+++ b/src/test/java/org/springframework/data/couchbase/domain/AirlineRepository.java
@@ -26,7 +26,7 @@ import java.util.List;
 @Repository
 public interface AirlineRepository extends PagingAndSortingRepository<Airline, String> {
 
-	@Query("#{#n1ql.selectEntity} where (name = $1)")
+	@Query("#{#n1ql.selectEntity} where #{#n1ql.filter} and (name = $1)")
 	List<User> getByName(@Param("airline_name")String airlineName);
 
 }

--- a/src/test/java/org/springframework/data/couchbase/domain/UserRepository.java
+++ b/src/test/java/org/springframework/data/couchbase/domain/UserRepository.java
@@ -36,9 +36,9 @@ public interface UserRepository extends PagingAndSortingRepository<User, String>
 
 	List<User> findByFirstnameAndLastname(String firstname, String lastname);
 
-	@Query("#{#n1ql.selectEntity} where firstname = $1 and lastname = $2")
+	@Query("#{#n1ql.selectEntity} where #{#n1ql.filter} and firstname = $1 and lastname = $2")
 	List<User> getByFirstnameAndLastname(String firstname, String lastname);
 
-	@Query("#{#n1ql.selectEntity} where (firstname = $first or lastname = $last)")
-	List<User>  getByFirstnameOrLastname(@Param("first")String firstname, @Param("last")String lastname);
+	@Query("#{#n1ql.selectEntity} where #{#n1ql.filter} and (firstname = $first or lastname = $last)")
+	List<User> getByFirstnameOrLastname(@Param("first") String firstname, @Param("last") String lastname);
 }

--- a/src/test/java/org/springframework/data/couchbase/repository/query/StringN1qlQueryCreatorMockedTests.java
+++ b/src/test/java/org/springframework/data/couchbase/repository/query/StringN1qlQueryCreatorMockedTests.java
@@ -87,7 +87,7 @@ class StringN1qlQueryCreatorMockedTests extends ClusterAwareIntegrationTests {
 
 		Query query = creator.createQuery();
 		assertEquals(
-				"SELECT META(`travel-sample`).id AS __id, META(`travel-sample`).cas AS __cas, `travel-sample`.* FROM `travel-sample` where firstname = $1 and lastname = $2 AND `_class` = \"org.springframework.data.couchbase.domain.User\"",
+				"SELECT META(`travel-sample`).id AS __id, META(`travel-sample`).cas AS __cas, `travel-sample`.* FROM `travel-sample` where `_class` = \"org.springframework.data.couchbase.domain.User\" and firstname = $1 and lastname = $2",
 				query.toN1qlString(couchbaseTemplate.reactive(), User.class, false));
 	}
 
@@ -105,7 +105,7 @@ class StringN1qlQueryCreatorMockedTests extends ClusterAwareIntegrationTests {
 
 		Query query = creator.createQuery();
 		assertEquals(
-				"SELECT META(`travel-sample`).id AS __id, META(`travel-sample`).cas AS __cas, `travel-sample`.* FROM `travel-sample` where (firstname = $first or lastname = $last) AND `_class` = \"org.springframework.data.couchbase.domain.User\"",
+				"SELECT META(`travel-sample`).id AS __id, META(`travel-sample`).cas AS __cas, `travel-sample`.* FROM `travel-sample` where `_class` = \"org.springframework.data.couchbase.domain.User\" and (firstname = $first or lastname = $last)",
 				query.toN1qlString(couchbaseTemplate.reactive(), User.class, false));
 	}
 

--- a/src/test/java/org/springframework/data/couchbase/repository/query/StringN1qlQueryCreatorTests.java
+++ b/src/test/java/org/springframework/data/couchbase/repository/query/StringN1qlQueryCreatorTests.java
@@ -65,7 +65,6 @@ class StringN1qlQueryCreatorTests extends ClusterAwareIntegrationTests {
 	CouchbaseTemplate couchbaseTemplate;
 	static NamedQueries namedQueries = new PropertiesBasedNamedQueries(new Properties());
 
-
 	@BeforeEach
 	public void beforeEach() {
 		context = new CouchbaseMappingContext();
@@ -73,7 +72,6 @@ class StringN1qlQueryCreatorTests extends ClusterAwareIntegrationTests {
 		ApplicationContext ac = new AnnotationConfigApplicationContext(Config.class);
 		couchbaseTemplate = (CouchbaseTemplate) ac.getBean(COUCHBASE_TEMPLATE);
 	}
-
 
 	@Test
 	@IgnoreWhen(missesCapabilities = Capabilities.QUERY, clusterTypes = ClusterType.MOCKED)
@@ -86,24 +84,24 @@ class StringN1qlQueryCreatorTests extends ClusterAwareIntegrationTests {
 			Method method = AirlineRepository.class.getMethod(input, String.class);
 
 			CouchbaseQueryMethod queryMethod = new CouchbaseQueryMethod(method,
-					new DefaultRepositoryMetadata(UserRepository.class), new SpelAwareProxyProjectionFactory(),
+					new DefaultRepositoryMetadata(AirlineRepository.class), new SpelAwareProxyProjectionFactory(),
 					converter.getMappingContext());
 
-
-			StringN1qlQueryCreator creator = new StringN1qlQueryCreator(
-					getAccessor(getParameters(method), "Continental"), queryMethod, converter, config().bucketname(),
-					QueryMethodEvaluationContextProvider.DEFAULT, namedQueries);
+			StringN1qlQueryCreator creator = new StringN1qlQueryCreator(getAccessor(getParameters(method), "Continental"),
+					queryMethod, converter, config().bucketname(), QueryMethodEvaluationContextProvider.DEFAULT, namedQueries);
 
 			Query query = creator.createQuery();
-			System.out.println(query.toN1qlString(couchbaseTemplate.reactive(), User.class, false));
+			System.out.println(query.toN1qlString(couchbaseTemplate.reactive(), Airline.class, false));
 
-			try { Thread.sleep(3000); } catch (Exception e){}
-			ExecutableFindByQueryOperation.ExecutableFindByQuery q = (ExecutableFindByQueryOperation.ExecutableFindByQuery) couchbaseTemplate.findByQuery(
-					Airline.class).matching(query);
+			try {
+				Thread.sleep(3000);
+			} catch (Exception e) {}
+			ExecutableFindByQueryOperation.ExecutableFindByQuery q = (ExecutableFindByQueryOperation.ExecutableFindByQuery) couchbaseTemplate
+					.findByQuery(Airline.class).matching(query);
 
 			Optional<Airline> al = q.one();
 			assertEquals(airline.toString(), al.get().toString());
-		}catch(Exception e){
+		} catch (Exception e) {
 			e.printStackTrace();
 			throw e;
 		} finally {


### PR DESCRIPTION
…FFSET.

Handle string queries containing ORDERED, LIMIT and OFFSET.
The _class = <className> predicate cannot simply be appended to these queries.
It must be inserted after the WHERE and before the ORDERED, LIMIT and OFFSET

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATACOUCH).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
