### PR TITLE
DATACOUCH-605 - Support ScanConsistency in n1ql queries

### DIFF
--- a/src/main/java/org/springframework/data/couchbase/core/ExecutableFindByQueryOperation.java
+++ b/src/main/java/org/springframework/data/couchbase/core/ExecutableFindByQueryOperation.java
@@ -126,7 +126,7 @@ public interface ExecutableFindByQueryOperation {
 		 *
 		 * @param scanConsistency the custom scan consistency to use for this query.
 		 */
-		FindByQueryWithQuery<T> consistentWith(QueryScanConsistency scanConsistency);
+		FindByQueryConsistentWith<T> consistentWith(QueryScanConsistency scanConsistency);
 
 	}
 

--- a/src/main/java/org/springframework/data/couchbase/core/ExecutableFindByQueryOperationSupport.java
+++ b/src/main/java/org/springframework/data/couchbase/core/ExecutableFindByQueryOperationSupport.java
@@ -21,6 +21,7 @@ import java.util.stream.Stream;
 import org.springframework.data.couchbase.core.query.Query;
 
 import com.couchbase.client.java.query.QueryScanConsistency;
+import org.springframework.data.couchbase.core.ReactiveFindByQueryOperationSupport.ReactiveFindByQuerySupport;
 
 public class ExecutableFindByQueryOperationSupport implements ExecutableFindByQueryOperation {
 
@@ -50,8 +51,7 @@ public class ExecutableFindByQueryOperationSupport implements ExecutableFindByQu
 			this.template = template;
 			this.domainType = domainType;
 			this.query = query;
-			this.reactiveSupport = new ReactiveFindByQueryOperationSupport.ReactiveFindByQuerySupport<T>(
-					template.reactive(), domainType, query, scanConsistency);
+			this.reactiveSupport = new ReactiveFindByQuerySupport<T>(template.reactive(), domainType, query, scanConsistency);
 			this.scanConsistency = scanConsistency;
 		}
 
@@ -72,11 +72,17 @@ public class ExecutableFindByQueryOperationSupport implements ExecutableFindByQu
 
 		@Override
 		public TerminatingFindByQuery<T> matching(final Query query) {
-			return new ExecutableFindByQuerySupport<>(template, domainType, query, scanConsistency);
+			QueryScanConsistency scanCons;
+			if (query.getScanConsistency() != null) {
+				scanCons = query.getScanConsistency();
+			} else {
+				scanCons = scanConsistency;
+			}
+			return new ExecutableFindByQuerySupport<>(template, domainType, query, scanCons);
 		}
 
 		@Override
-		public FindByQueryWithQuery<T> consistentWith(final QueryScanConsistency scanConsistency) {
+		public FindByQueryConsistentWith<T> consistentWith(final QueryScanConsistency scanConsistency) {
 			return new ExecutableFindByQuerySupport<>(template, domainType, query, scanConsistency);
 		}
 

--- a/src/main/java/org/springframework/data/couchbase/core/ReactiveFindByQueryOperation.java
+++ b/src/main/java/org/springframework/data/couchbase/core/ReactiveFindByQueryOperation.java
@@ -100,7 +100,7 @@ public interface ReactiveFindByQueryOperation {
 		 *
 		 * @param scanConsistency the custom scan consistency to use for this query.
 		 */
-		FindByQueryWithQuery<T> consistentWith(QueryScanConsistency scanConsistency);
+		FindByQueryConsistentWith<T> consistentWith(QueryScanConsistency scanConsistency);
 
 	}
 

--- a/src/main/java/org/springframework/data/couchbase/core/ReactiveFindByQueryOperationSupport.java
+++ b/src/main/java/org/springframework/data/couchbase/core/ReactiveFindByQueryOperationSupport.java
@@ -60,11 +60,17 @@ public class ReactiveFindByQueryOperationSupport implements ReactiveFindByQueryO
 
 		@Override
 		public TerminatingFindByQuery<T> matching(Query query) {
-			return new ReactiveFindByQuerySupport<>(template, domainType, query, scanConsistency);
+			QueryScanConsistency scanCons;
+			if (query.getScanConsistency() != null) {
+				scanCons = query.getScanConsistency();
+			} else {
+				scanCons = scanConsistency;
+			}
+			return new ReactiveFindByQuerySupport<>(template, domainType, query, scanCons);
 		}
 
 		@Override
-		public FindByQueryWithQuery<T> consistentWith(QueryScanConsistency scanConsistency) {
+		public FindByQueryConsistentWith<T> consistentWith(QueryScanConsistency scanConsistency) {
 			return new ReactiveFindByQuerySupport<>(template, domainType, query, scanConsistency);
 		}
 

--- a/src/main/java/org/springframework/data/couchbase/core/ReactiveInsertByIdOperationSupport.java
+++ b/src/main/java/org/springframework/data/couchbase/core/ReactiveInsertByIdOperationSupport.java
@@ -15,7 +15,6 @@
  */
 package org.springframework.data.couchbase.core;
 
-import com.couchbase.client.java.kv.UpsertOptions;
 import org.springframework.data.couchbase.core.mapping.Document;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -98,7 +97,7 @@ public class ReactiveInsertByIdOperationSupport implements ReactiveInsertByIdOpe
 			} else if (durabilityLevel != DurabilityLevel.NONE) {
 				options.durability(durabilityLevel);
 			}
-			if (expiry != null) {
+			if (expiry != null && ! expiry.isZero()) {
 				options.expiry(expiry);
 			} else if (domainType.isAnnotationPresent(Document.class)) {
 				Document documentAnn = domainType.getAnnotation(Document.class);

--- a/src/main/java/org/springframework/data/couchbase/core/ReactiveUpsertByIdOperationSupport.java
+++ b/src/main/java/org/springframework/data/couchbase/core/ReactiveUpsertByIdOperationSupport.java
@@ -15,7 +15,6 @@
  */
 package org.springframework.data.couchbase.core;
 
-import com.couchbase.client.java.kv.Expiry;
 import org.springframework.data.couchbase.core.mapping.Document;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -98,7 +97,7 @@ public class ReactiveUpsertByIdOperationSupport implements ReactiveUpsertByIdOpe
 			} else if (durabilityLevel != DurabilityLevel.NONE) {
 				options.durability(durabilityLevel);
 			}
-			if (expiry != null) {
+			if (expiry != null && !expiry.isZero()) {
 				options.expiry(expiry);
 			} else if (domainType.isAnnotationPresent(Document.class)) {
 				Document documentAnn = domainType.getAnnotation(Document.class);

--- a/src/main/java/org/springframework/data/couchbase/core/query/Query.java
+++ b/src/main/java/org/springframework/data/couchbase/core/query/Query.java
@@ -47,6 +47,7 @@ public class Query {
 	private long skip;
 	private int limit;
 	private Sort sort = Sort.unsorted();
+	private QueryScanConsistency queryScanConsistency;
 
 	static private final Pattern WHERE_PATTERN = Pattern.compile("\\sWHERE\\s");
 
@@ -125,6 +126,27 @@ public class Query {
 		this.limit = pageable.getPageSize();
 		this.skip = pageable.getOffset();
 		return with(pageable.getSort());
+	}
+
+	/**
+	 * queryScanConsistency
+	 *
+	 * @return queryScanConsistency
+	 */
+	public QueryScanConsistency getScanConsistency() {
+		return queryScanConsistency;
+	}
+
+
+	/**
+	 * Sets the given scan consistency on the {@link Query} instance.
+	 *
+	 * @param queryScanConsistency
+	 * @return this
+	 */
+	public Query scanConsistency(final QueryScanConsistency queryScanConsistency) {
+		this.queryScanConsistency = queryScanConsistency;
+		return this;
 	}
 
 	/**
@@ -270,7 +292,7 @@ public class Query {
 	}
 
 	/**
-	 * build QueryOptions forom parameters and scanConsistency
+	 * build QueryOptions from parameters and scanConsistency
 	 *
 	 * @param scanConsistency
 	 * @return QueryOptions

--- a/src/main/java/org/springframework/data/couchbase/repository/CouchbaseRepository.java
+++ b/src/main/java/org/springframework/data/couchbase/repository/CouchbaseRepository.java
@@ -18,6 +18,7 @@ package org.springframework.data.couchbase.repository;
 
 import java.util.List;
 
+import com.couchbase.client.java.query.QueryScanConsistency;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.repository.NoRepositoryBean;
 import org.springframework.data.repository.PagingAndSortingRepository;
@@ -33,6 +34,8 @@ public interface CouchbaseRepository<T, ID> extends PagingAndSortingRepository<T
 
 	@Override
 	List<T> findAll(Sort sort);
+
+	List<T> findAll(QueryScanConsistency queryScanConsistency);
 
 	@Override
 	List<T> findAll();

--- a/src/main/java/org/springframework/data/couchbase/repository/query/CouchbaseQueryMethod.java
+++ b/src/main/java/org/springframework/data/couchbase/repository/query/CouchbaseQueryMethod.java
@@ -25,6 +25,7 @@ import org.springframework.data.couchbase.core.query.Dimensional;
 import org.springframework.data.couchbase.core.query.View;
 import org.springframework.data.couchbase.core.query.WithConsistency;
 import org.springframework.data.couchbase.repository.Query;
+import org.springframework.data.couchbase.repository.ScanConsistency;
 import org.springframework.data.mapping.context.MappingContext;
 import org.springframework.data.projection.ProjectionFactory;
 import org.springframework.data.repository.core.RepositoryMetadata;
@@ -150,6 +151,24 @@ public class CouchbaseQueryMethod extends QueryMethod {
 
 	public WithConsistency getConsistencyAnnotation() {
 		return method.getAnnotation(WithConsistency.class);
+	}
+
+	/**
+	 * If the method has a @ScanConsistency annotation
+	 *
+	 * @return true if this has the @ScanConsistency annotation
+	 */
+	public boolean hasScanConsistencyAnnotation() {
+		return getScanConsistencyAnnotation() != null;
+	}
+
+	/**
+	 * ScanConsistency annotation
+	 *
+	 * @return the @ScanConsistency annotation
+	 */
+	public ScanConsistency getScanConsistencyAnnotation() {
+		return method.getAnnotation(ScanConsistency.class);
 	}
 
 	/**

--- a/src/main/java/org/springframework/data/couchbase/repository/query/N1qlRepositoryQueryExecutor.java
+++ b/src/main/java/org/springframework/data/couchbase/repository/query/N1qlRepositoryQueryExecutor.java
@@ -15,9 +15,7 @@
  */
 package org.springframework.data.couchbase.repository.query;
 
-import java.util.ArrayList;
-import java.util.List;
-
+import com.couchbase.client.java.query.QueryScanConsistency;
 import org.springframework.data.couchbase.core.CouchbaseOperations;
 import org.springframework.data.couchbase.core.ExecutableFindByQueryOperation;
 import org.springframework.data.couchbase.core.query.Query;
@@ -65,7 +63,8 @@ public class N1qlRepositoryQueryExecutor {
 			final PartTree tree = new PartTree(queryMethod.getName(), domainClass);
 			query = new N1qlQueryCreator(tree, accessor, queryMethod, operations.getConverter()).createQuery();
 		}
-		q = (ExecutableFindByQueryOperation.ExecutableFindByQuery) operations.findByQuery(domainClass).matching(query);
+		q = (ExecutableFindByQueryOperation.ExecutableFindByQuery) operations.findByQuery(domainClass)
+				.consistentWith(buildQueryScanConsistency()).matching(query);
 		if (queryMethod.isCountQuery()) {
 			return q.count();
 		} else if (queryMethod.isCollectionQuery()) {
@@ -74,6 +73,16 @@ public class N1qlRepositoryQueryExecutor {
 			return q.oneValue();
 		}
 
+	}
+
+	private QueryScanConsistency buildQueryScanConsistency() {
+		QueryScanConsistency scanConsistency = QueryScanConsistency.NOT_BOUNDED;
+		if (queryMethod.hasConsistencyAnnotation()) {
+			scanConsistency = queryMethod.getConsistencyAnnotation().value();
+		} else if (queryMethod.hasScanConsistencyAnnotation()) {
+			scanConsistency = queryMethod.getScanConsistencyAnnotation().query();
+		}
+		return scanConsistency;
 	}
 
 }

--- a/src/main/java/org/springframework/data/couchbase/repository/support/SimpleCouchbaseRepository.java
+++ b/src/main/java/org/springframework/data/couchbase/repository/support/SimpleCouchbaseRepository.java
@@ -148,6 +148,11 @@ public class SimpleCouchbaseRepository<T, ID> implements CouchbaseRepository<T, 
 	}
 
 	@Override
+	public List<T> findAll(final QueryScanConsistency queryScanConsistency) {
+		return findAll(new Query().scanConsistency(queryScanConsistency));
+	}
+
+	@Override
 	public Page<T> findAll(final Pageable pageable) {
 		List<T> results = findAll(new Query().with(pageable));
 		return new PageImpl<>(results, pageable, count());

--- a/src/test/java/org/springframework/data/couchbase/core/CouchbaseTemplateKeyValueIntegrationTests.java
+++ b/src/test/java/org/springframework/data/couchbase/core/CouchbaseTemplateKeyValueIntegrationTests.java
@@ -55,6 +55,7 @@ class CouchbaseTemplateKeyValueIntegrationTests extends ClusterAwareIntegrationT
 
 	private static CouchbaseClientFactory couchbaseClientFactory;
 	private CouchbaseTemplate couchbaseTemplate;
+	private ReactiveCouchbaseTemplate reactiveCouchbaseTemplate;
 
 	@BeforeAll
 	static void beforeAll() {
@@ -71,6 +72,7 @@ class CouchbaseTemplateKeyValueIntegrationTests extends ClusterAwareIntegrationT
 	void beforeEach() {
 		ApplicationContext ac = new AnnotationConfigApplicationContext(Config.class);
 		couchbaseTemplate = (CouchbaseTemplate) ac.getBean(COUCHBASE_TEMPLATE);
+		reactiveCouchbaseTemplate = (ReactiveCouchbaseTemplate) ac.getBean(REACTIVE_COUCHBASE_TEMPLATE);
 	}
 
 	@Test
@@ -89,6 +91,7 @@ class CouchbaseTemplateKeyValueIntegrationTests extends ClusterAwareIntegrationT
 		assertEquals(user, found);
 
 		couchbaseTemplate.removeById().one(user.getId());
+		reactiveCouchbaseTemplate.replaceById(User.class).withDurability(PersistTo.ACTIVE, ReplicateTo.THREE).one(user);
 	}
 
 	@Test

--- a/src/test/java/org/springframework/data/couchbase/domain/AirportRepository.java
+++ b/src/test/java/org/springframework/data/couchbase/domain/AirportRepository.java
@@ -40,15 +40,19 @@ public interface AirportRepository extends PagingAndSortingRepository<Airport, S
 	Iterable<Airport> findAll();
 
 	@Override
-	@ScanConsistency(query = QueryScanConsistency.REQUEST_PLUS)
 	Airport save(Airport airport);
 
 	@ScanConsistency(query = QueryScanConsistency.REQUEST_PLUS)
 	List<Airport> findAllByIata(String iata);
 
+	@ScanConsistency(query = QueryScanConsistency.REQUEST_PLUS)
+	Airport findByIata(String iata);
+
 	@Query("#{#n1ql.selectEntity} where iata = $1")
+	@ScanConsistency(query = QueryScanConsistency.REQUEST_PLUS)
 	List<Airport> getAllByIata(String iata);
 
+	@ScanConsistency(query = QueryScanConsistency.REQUEST_PLUS)
 	long countByIataIn(String... iata);
 
 	@ScanConsistency(query = QueryScanConsistency.REQUEST_PLUS)

--- a/src/test/java/org/springframework/data/couchbase/domain/ReactiveAirportRepository.java
+++ b/src/test/java/org/springframework/data/couchbase/domain/ReactiveAirportRepository.java
@@ -16,6 +16,7 @@
 
 package org.springframework.data.couchbase.domain;
 
+import org.springframework.data.couchbase.repository.Query;
 import reactor.core.publisher.Flux;
 
 import org.springframework.data.couchbase.repository.ScanConsistency;
@@ -43,6 +44,10 @@ public interface ReactiveAirportRepository extends ReactiveSortingRepository<Air
 
 	@ScanConsistency(query = QueryScanConsistency.REQUEST_PLUS)
 	Flux<Airport> findAllByIata(String iata);
+
+	@Query("#{#n1ql.selectEntity} where iata = $1")
+	@ScanConsistency(query = QueryScanConsistency.REQUEST_PLUS)
+	Flux<Airport> getAllByIata(String iata);
 
 	@ScanConsistency(query = QueryScanConsistency.REQUEST_PLUS)
 	Mono<Long> countByIataIn(String... iatas);

--- a/src/test/java/org/springframework/data/couchbase/repository/CouchbaseRepositoryQueryIntegrationTests.java
+++ b/src/test/java/org/springframework/data/couchbase/repository/CouchbaseRepositoryQueryIntegrationTests.java
@@ -25,8 +25,6 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
-import java.util.stream.Collectors;
-import java.util.stream.StreamSupport;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -93,7 +91,6 @@ public class CouchbaseRepositoryQueryIntegrationTests extends ClusterAwareIntegr
 			airportRepository.save(vie);
 			xxx = new Airport("airports::xxx", "xxx", "xxxx");
 			airportRepository.save(xxx);
-			sleep(1000);
 			List<Airport> airports;
 			airports = airportRepository.findAllByIata("1\" or iata=iata or iata=\"1");
 			assertEquals(0, airports.size());
@@ -112,7 +109,6 @@ public class CouchbaseRepositoryQueryIntegrationTests extends ClusterAwareIntegr
 		try {
 			vie = new Airport("airports::vie", "vie", "loww");
 			airportRepository.save(vie);
-			sleep(1000);
 			List<Airport> airports = airportRepository.findAllByIata("vie");
 			assertEquals(vie.getId(), airports.get(0).getId());
 		} finally {
@@ -170,7 +166,7 @@ public class CouchbaseRepositoryQueryIntegrationTests extends ClusterAwareIntegr
 						iatas[i].toLowerCase(Locale.ROOT) /* lcao */);
 				airportRepository.save(airport);
 			}
-			sleep(1000);
+
 			for (int k = 0; k < 50; k++) {
 				Callable<Boolean>[] suppliers = new Callable[iatas.length];
 				for (int i = 0; i < iatas.length; i++) {
@@ -211,7 +207,7 @@ public class CouchbaseRepositoryQueryIntegrationTests extends ClusterAwareIntegr
 				Airport airport = new Airport("airports::" + iatas[i], iatas[i] /*iata*/, iatas[i].toLowerCase() /* lcao */);
 				airportRepository.save(airport);
 			}
-			sleep(1000);
+
 			for (int k = 0; k < 100; k++) {
 				Callable<Boolean>[] suppliers = new Callable[iatas.length];
 				for (int i = 0; i < iatas.length; i++) {

--- a/src/test/java/org/springframework/data/couchbase/repository/ReactiveCouchbaseRepositoryQueryIntegrationTests.java
+++ b/src/test/java/org/springframework/data/couchbase/repository/ReactiveCouchbaseRepositoryQueryIntegrationTests.java
@@ -88,9 +88,10 @@ public class ReactiveCouchbaseRepositoryQueryIntegrationTests extends ClusterAwa
 		try {
 			vie = new Airport("airports::vie", "vie", "loww");
 			airportRepository.save(vie).block();
-			List<Airport> airports = airportRepository.findAllByIata("vie").collectList().block();
-			// TODO
-			System.err.println(airports);
+			List<Airport> airports1 = airportRepository.findAllByIata("vie").collectList().block();
+			assertEquals(1,airports1.size());
+			List<Airport> airports2 = airportRepository.findAllByIata("vie").collectList().block();
+			assertEquals(1,airports2.size());
 		} finally {
 			airportRepository.delete(vie).block();
 		}


### PR DESCRIPTION

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATACOUCH).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
