### PR TITLE
DATACOUCH-583 - Nested properties in queries not working.

### DIFF
--- a/src/main/java/org/springframework/data/couchbase/core/query/QueryCriteria.java
+++ b/src/main/java/org/springframework/data/couchbase/core/query/QueryCriteria.java
@@ -343,7 +343,7 @@ public class QueryCriteria implements QueryCriteriaDefinition {
 	 */
 	private StringBuilder exportSingle(StringBuilder sb, int[] paramIndexPtr, JsonValue parameters,
 			CouchbaseConverter converter) {
-		String fieldName = maybeQuote(key);
+		String fieldName = maybeBackTic(key);
 		int valueLen = value == null ? 0 : value.length;
 		Object[] v = new Object[valueLen + 2];
 		v[0] = fieldName;
@@ -445,8 +445,8 @@ public class QueryCriteria implements QueryCriteriaDefinition {
 		posValues.add(ja);
 	}
 
-	private String maybeQuote(String value) {
-		if (value == null || (value.startsWith("\"") && value.endsWith("\""))) {
+	private String maybeBackTic(String value) {
+		if (value == null || (value.startsWith("`") && value.endsWith("`"))) {
 			return value;
 		} else {
 			return "`" + value + "`";

--- a/src/main/java/org/springframework/data/couchbase/repository/query/N1qlQueryCreator.java
+++ b/src/main/java/org/springframework/data/couchbase/repository/query/N1qlQueryCreator.java
@@ -19,6 +19,7 @@ import static org.springframework.data.couchbase.core.query.QueryCriteria.*;
 
 import java.util.Iterator;
 
+import org.springframework.core.convert.converter.Converter;
 import org.springframework.data.couchbase.core.convert.CouchbaseConverter;
 import org.springframework.data.couchbase.core.mapping.CouchbasePersistentProperty;
 import org.springframework.data.couchbase.core.query.Query;
@@ -56,8 +57,12 @@ public class N1qlQueryCreator extends AbstractQueryCreator<Query, QueryCriteria>
 	protected QueryCriteria create(final Part part, final Iterator<Object> iterator) {
 		PersistentPropertyPath<CouchbasePersistentProperty> path = context.getPersistentPropertyPath(part.getProperty());
 		CouchbasePersistentProperty property = path.getLeafProperty();
-		return from(part, property, where(path.toDotPath()), iterator);
+		return from(part, property, where(path.toDotPath(cvtr)), iterator);
 	}
+
+	static Converter<? super CouchbasePersistentProperty, String> cvtr = (
+			source) -> new StringBuilder(source.getName().length() + 2).append('`').append(source.getName()).append('`')
+					.toString();
 
 	@Override
 	protected QueryCriteria and(final Part part, final QueryCriteria base, final Iterator<Object> iterator) {

--- a/src/test/java/org/springframework/data/couchbase/domain/PersonRepository.java
+++ b/src/test/java/org/springframework/data/couchbase/domain/PersonRepository.java
@@ -15,7 +15,9 @@
  */
 package org.springframework.data.couchbase.domain;
 
+import com.couchbase.client.java.query.QueryScanConsistency;
 import org.springframework.data.couchbase.repository.Query;
+import org.springframework.data.couchbase.repository.ScanConsistency;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.query.Param;
 
@@ -105,4 +107,6 @@ public interface PersonRepository extends CrudRepository<Person, String> {
 
 	void deleteAll();
 
+	@ScanConsistency(query=QueryScanConsistency.REQUEST_PLUS)
+	List<Person> findByAddressStreet(String street);
 }

--- a/src/test/java/org/springframework/data/couchbase/repository/CouchbaseRepositoryQueryIntegrationTests.java
+++ b/src/test/java/org/springframework/data/couchbase/repository/CouchbaseRepositoryQueryIntegrationTests.java
@@ -33,8 +33,11 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.couchbase.CouchbaseClientFactory;
 import org.springframework.data.couchbase.config.AbstractCouchbaseConfiguration;
+import org.springframework.data.couchbase.domain.Address;
 import org.springframework.data.couchbase.domain.Airport;
 import org.springframework.data.couchbase.domain.AirportRepository;
+import org.springframework.data.couchbase.domain.Person;
+import org.springframework.data.couchbase.domain.PersonRepository;
 import org.springframework.data.couchbase.repository.config.EnableCouchbaseRepositories;
 import org.springframework.data.couchbase.util.Capabilities;
 import org.springframework.data.couchbase.util.ClusterAwareIntegrationTests;
@@ -79,6 +82,24 @@ public class CouchbaseRepositoryQueryIntegrationTests extends ClusterAwareIntegr
 			assertTrue(all.stream().anyMatch(a -> a.getId().equals("airports::vie")));
 		} finally {
 			airportRepository.delete(vie);
+		}
+	}
+
+	@Autowired PersonRepository personRepository;
+
+	@Test
+	void nestedFind() {
+		Person person = null;
+		try {
+			person = new Person(1, "first", "last");
+			Address address = new Address();
+			address.setStreet("Maple");
+			person.setAddress(address);
+			personRepository.save(person);
+			List<Person> persons = personRepository.findByAddressStreet("Maple");
+			assertEquals(1, persons.size());
+		} finally {
+			personRepository.deleteById(person.getId().toString());
 		}
 	}
 


### PR DESCRIPTION
The complete property path was being quoted instead of the individual
components.  ie.  `address.street` instead of `address`.`street`
Also fixed another issue - changed the maybeQuote() method for
property names to correctly look for back-tics instead of double
quotes and changed the name accordingly.

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATACOUCH).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
