### PR TITLE
DATACOUCH-626 - Handle reading into entity with only all-args constru…

### DIFF
--- a/src/main/java/org/springframework/data/couchbase/core/CouchbaseTemplateSupport.java
+++ b/src/main/java/org/springframework/data/couchbase/core/CouchbaseTemplateSupport.java
@@ -75,10 +75,13 @@ class CouchbaseTemplateSupport implements ApplicationContextAware {
 	public <T> T decodeEntity(String id, String source, long cas, Class<T> entityClass) {
 		final CouchbaseDocument converted = new CouchbaseDocument(id);
 		converted.setId(id);
+		CouchbasePersistentEntity<?> persistentEntity = mappingContext.getRequiredPersistentEntity(entityClass);
+		if (cas != 0 && persistentEntity.getVersionProperty() != null) {
+			converted.put(persistentEntity.getVersionProperty().getName(), cas);
+		}
 
 		T readEntity = converter.read(entityClass, (CouchbaseDocument) translationService.decode(source, converted));
 		final ConvertingPropertyAccessor<T> accessor = getPropertyAccessor(readEntity);
-		CouchbasePersistentEntity<?> persistentEntity = mappingContext.getRequiredPersistentEntity(readEntity.getClass());
 
 		if (persistentEntity.getVersionProperty() != null) {
 			accessor.setProperty(persistentEntity.getVersionProperty(), cas);

--- a/src/main/java/org/springframework/data/couchbase/repository/support/Util.java
+++ b/src/main/java/org/springframework/data/couchbase/repository/support/Util.java
@@ -1,9 +1,30 @@
+/*
+ * Copyright 2020 the original author or authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.data.couchbase.repository.support;
 
 import org.springframework.data.couchbase.core.convert.CouchbaseConverter;
 import org.springframework.data.couchbase.core.mapping.CouchbasePersistentEntity;
 import org.springframework.data.couchbase.core.mapping.CouchbasePersistentProperty;
 
+/**
+ * Utility class for Couchbase Repository
+ *
+ * @author Michael Reiche
+ */
 public class Util {
 
 	public static boolean hasNonZeroVersionProperty(Object entity, CouchbaseConverter converter) {

--- a/src/test/java/org/springframework/data/couchbase/domain/SubscriptionToken.java
+++ b/src/test/java/org/springframework/data/couchbase/domain/SubscriptionToken.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2020 the original author or authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.data.couchbase.domain;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.annotation.Version;
+import org.springframework.data.couchbase.core.mapping.Document;
+import org.springframework.data.couchbase.core.mapping.Field;
+import org.springframework.data.couchbase.core.mapping.id.GeneratedValue;
+import org.springframework.data.couchbase.core.mapping.id.GenerationStrategy;
+
+/**
+ * SubscriptionTokenEntity for tests
+ *
+ * @author Michael Reiche
+ */
+@Getter
+@ToString
+@EqualsAndHashCode
+@Document
+public class SubscriptionToken {
+  private @Id
+  @GeneratedValue(strategy = GenerationStrategy.UNIQUE)
+  String id;
+  private @Version
+  long version;
+  private @Field
+  String subscriptionType;
+  private @Field
+  String userName;
+  private @Field
+  String appId;
+  private @Field
+  String deviceId;
+  private @Field
+  long subscriptionDate;
+
+  public SubscriptionToken(
+      String id,
+      long version,
+      String subscriptionType,
+      String userName,
+      String appId,
+      String deviceId,
+      long subscriptionDate) {
+    this.id = id;
+    this.version = version;
+    this.subscriptionType = subscriptionType;
+    this.userName = userName;
+    this.appId = appId;
+    this.deviceId = deviceId;
+    this.subscriptionDate = subscriptionDate;
+  }
+
+  public void setType(String type) {
+    type = type;
+  }
+}

--- a/src/test/java/org/springframework/data/couchbase/domain/SubscriptionTokenRepository.java
+++ b/src/test/java/org/springframework/data/couchbase/domain/SubscriptionTokenRepository.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2020 the original author or authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.data.couchbase.domain;
+
+import org.springframework.data.repository.PagingAndSortingRepository;
+import org.springframework.stereotype.Repository;
+
+/**
+ * SubscriptionToken Repository for tests
+ *
+ * @author Michael Reiche
+ */
+@Repository
+public interface SubscriptionTokenRepository extends PagingAndSortingRepository<SubscriptionToken, String> {
+}

--- a/src/test/java/org/springframework/data/couchbase/repository/CouchbaseRepositoryKeyValueIntegrationTests.java
+++ b/src/test/java/org/springframework/data/couchbase/repository/CouchbaseRepositoryKeyValueIntegrationTests.java
@@ -24,14 +24,18 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
+import com.couchbase.client.java.kv.GetResult;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.couchbase.config.AbstractCouchbaseConfiguration;
+import org.springframework.data.couchbase.core.CouchbaseTemplate;
 import org.springframework.data.couchbase.domain.Course;
 import org.springframework.data.couchbase.domain.Library;
 import org.springframework.data.couchbase.domain.LibraryRepository;
 import org.springframework.data.couchbase.domain.Submission;
+import org.springframework.data.couchbase.domain.SubscriptionToken;
+import org.springframework.data.couchbase.domain.SubscriptionTokenRepository;
 import org.springframework.data.couchbase.domain.User;
 import org.springframework.data.couchbase.domain.UserRepository;
 import org.springframework.data.couchbase.domain.UserSubmission;
@@ -54,7 +58,20 @@ public class CouchbaseRepositoryKeyValueIntegrationTests extends ClusterAwareInt
 
 	@Autowired UserRepository userRepository;
 	@Autowired LibraryRepository libraryRepository;
+	@Autowired SubscriptionTokenRepository subscriptionTokenRepository;
 	@Autowired UserSubmissionRepository userSubmissionRepository;
+	@Autowired CouchbaseTemplate couchbaseTemplate;
+
+	@Test
+	void subscriptionToken() {
+		SubscriptionToken st = new SubscriptionToken("id", 0, "type", "Dave Smith", "app123", "dev123", 0);
+		st = subscriptionTokenRepository.save(st);
+		st = subscriptionTokenRepository.findById(st.getId()).get();
+
+		GetResult jdkResult = couchbaseTemplate.getCouchbaseClientFactory().getDefaultCollection().get(st.getId());
+		assertNotEquals(0, st.getVersion());
+		assertEquals(jdkResult.cas(), st.getVersion());
+	}
 
 	@Test
 	@IgnoreWhen(clusterTypes = ClusterType.MOCKED)


### PR DESCRIPTION
…ctor; version primative type

The version arg - which is not in the document - will be passed
into the constructor as a null which will fail if it is a primitive
type. This change will pre-populated the converted object with
the version/cas, so that it is not null.

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATACOUCH).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
