### PR TITLE
DATACOUCH-653 - Update example versions in documentation.

### DIFF
--- a/src/main/asciidoc/configuration.adoc
+++ b/src/main/asciidoc/configuration.adoc
@@ -16,7 +16,7 @@ As a result, the library can be included like any other maven dependency:
 <dependency>
     <groupId>org.springframework.data</groupId>
     <artifactId>spring-data-couchbase</artifactId>
-    <version>4.0.0.RELEASE</version>
+    <version>4.1.1</version>
 </dependency>
 ----
 ====
@@ -33,7 +33,7 @@ Here is an example on how to use the current SNAPSHOT dependency:
 <dependency>
   <groupId>org.springframework.data</groupId>
   <artifactId>spring-data-couchbase</artifactId>
-  <version>4.0.0.BUILD-SNAPSHOT</version>
+  <version>4.2.0-SNAPSHOT</version>
 </dependency>
 
 <repository>


### PR DESCRIPTION
The format has changed as well. The release versions no longer have
the .RELEASE suffix - they are just the version number (i.e. 4.1.1)
And the snapshot versions have the suffix -SNAPSHOT (i.e. 4.2.0-SNAPSHOT)
instead of 4.1.0.BUILD-SNAPSHOT

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATACOUCH).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
