### PR TITLE
DATACOUCH-661 - Fix integrations tests from 650

### DIFF
--- a/src/test/java/org/springframework/data/couchbase/domain/Airport.java
+++ b/src/test/java/org/springframework/data/couchbase/domain/Airport.java
@@ -46,4 +46,43 @@ public class Airport {
 	public String getIcao() {
 		return icao;
 	}
+
+	public String toString() {
+		StringBuilder sb = new StringBuilder();
+		sb.append("{ id: ");
+		sb.append(getId());
+		sb.append(", iata: ");
+		sb.append(iata);
+		sb.append(", icao: ");
+		sb.append(icao);
+		sb.append(" }");
+		return sb.toString();
+	}
+
+	public boolean equals(Object o) {
+		if (o == null) {
+			return false;
+		}
+		if (!(o instanceof Airport)) {
+			return false;
+		}
+		Airport that = (Airport) o;
+		if (diff(this.id,that.id)) {
+			return false;
+		}
+		if (diff(this.iata,that.iata)) {
+			return false;
+		}
+		if (diff(this.icao,that.icao)) {
+			return false;
+		}
+		return true;
+	}
+
+	private boolean diff(String s1, String s2){
+		if ((s1 == null && s2 != null) || !s1.equals(s2)) {
+			return true;
+		}
+		return false;
+	}
 }

--- a/src/test/java/org/springframework/data/couchbase/repository/ReactiveCouchbaseRepositoryQueryIntegrationTests.java
+++ b/src/test/java/org/springframework/data/couchbase/repository/ReactiveCouchbaseRepositoryQueryIntegrationTests.java
@@ -16,7 +16,22 @@
 
 package org.springframework.data.couchbase.repository;
 
-import com.couchbase.client.core.error.IndexExistsException;
+import static java.util.Arrays.asList;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import reactor.core.publisher.Flux;
+import reactor.test.StepVerifier;
+
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.stream.Collectors;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -35,18 +50,8 @@ import org.springframework.data.couchbase.util.ClusterAwareIntegrationTests;
 import org.springframework.data.couchbase.util.ClusterType;
 import org.springframework.data.couchbase.util.IgnoreWhen;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
-import reactor.test.StepVerifier;
 
-import java.util.List;
-import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
-import java.util.stream.Collectors;
-
-import static java.util.Arrays.*;
-import static org.assertj.core.api.Assertions.*;
-import static org.junit.jupiter.api.Assertions.*;
+import com.couchbase.client.core.error.IndexExistsException;
 
 /**
  * template class for Reactive Couchbase operations
@@ -58,13 +63,10 @@ import static org.junit.jupiter.api.Assertions.*;
 @IgnoreWhen(missesCapabilities = Capabilities.QUERY, clusterTypes = ClusterType.MOCKED)
 public class ReactiveCouchbaseRepositoryQueryIntegrationTests extends ClusterAwareIntegrationTests {
 
-	@Autowired
-	CouchbaseClientFactory clientFactory;
+	@Autowired CouchbaseClientFactory clientFactory;
 
-	@Autowired
-	ReactiveAirportRepository airportRepository; // intellij flags "Could not Autowire", but it runs ok.
-	@Autowired
-	ReactiveUserRepository userRepository; // intellij flags "Could not Autowire", but it runs ok.
+	@Autowired ReactiveAirportRepository airportRepository; // intellij flags "Could not Autowire", but it runs ok.
+	@Autowired ReactiveUserRepository userRepository; // intellij flags "Could not Autowire", but it runs ok.
 
 	@BeforeEach
 	void beforeEach() {
@@ -119,7 +121,7 @@ public class ReactiveCouchbaseRepositoryQueryIntegrationTests extends ClusterAwa
 
 	@Test
 	void count() {
-		String[] iatas = {"JFK", "IAD", "SFO", "SJC", "SEA", "LAX", "PHX"};
+		String[] iatas = { "JFK", "IAD", "SFO", "SJC", "SEA", "LAX", "PHX" };
 		Future[] future = new Future[iatas.length];
 		ExecutorService executorService = Executors.newFixedThreadPool(iatas.length);
 		try {
@@ -129,7 +131,7 @@ public class ReactiveCouchbaseRepositoryQueryIntegrationTests extends ClusterAwa
 				airportRepository.save(airport).block();
 			}
 
-			Long airportCount = airportCount = airportRepository.count().block();
+			Long airportCount = airportRepository.count().block();
 			assertEquals(iatas.length, airportCount);
 
 			airportCount = airportRepository.countByIataIn("JFK", "IAD", "SFO").block();
@@ -154,7 +156,7 @@ public class ReactiveCouchbaseRepositoryQueryIntegrationTests extends ClusterAwa
 	}
 
 	@Test
-		// DATACOUCH-650
+	// DATACOUCH-650
 	void deleteAllById() {
 
 		Airport vienna = new Airport("airports::vie", "vie", "LOWW");
@@ -162,13 +164,15 @@ public class ReactiveCouchbaseRepositoryQueryIntegrationTests extends ClusterAwa
 		Airport losAngeles = new Airport("airports::lax", "lax", "KLAX");
 
 		try {
-			airportRepository.saveAll(asList(vienna, frankfurt, losAngeles)).as(StepVerifier::create).verifyComplete();
+			airportRepository.saveAll(asList(vienna, frankfurt, losAngeles)).as(StepVerifier::create)
+					.expectNext(vienna, frankfurt, losAngeles).verifyComplete();
 
-			airportRepository.deleteAllById(asList(vienna.getId(), losAngeles.getId())).as(StepVerifier::create).verifyComplete();
+			airportRepository.deleteAllById(asList(vienna.getId(), losAngeles.getId())).as(StepVerifier::create)
+					.verifyComplete();
 
 			airportRepository.findAll().as(StepVerifier::create).expectNext(frankfurt).verifyComplete();
 		} finally {
-			airportRepository.deleteAll();
+			airportRepository.deleteAll().block();
 		}
 	}
 


### PR DESCRIPTION
The problems were in the tests themselves.  The changes in datacouch-650 are fine.
These only run with "mvn integration-test", so the failures were not being caught.

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATACOUCH).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
