### PR TITLE
DATACOUCH-630 - Add expiry to replace 4.2.x

### DIFF
--- a/src/main/java/org/springframework/data/couchbase/core/ExecutableReplaceByIdOperation.java
+++ b/src/main/java/org/springframework/data/couchbase/core/ExecutableReplaceByIdOperation.java
@@ -15,6 +15,7 @@
  */
 package org.springframework.data.couchbase.core;
 
+import java.time.Duration;
 import java.util.Collection;
 
 import com.couchbase.client.core.msg.kv.DurabilityLevel;
@@ -46,6 +47,11 @@ public interface ExecutableReplaceByIdOperation {
 
 	}
 
-	interface ExecutableReplaceById<T> extends ReplaceByIdWithDurability<T> {}
+	interface ReplaceByIdWithExpiry<T> extends ReplaceByIdWithDurability<T> {
+
+		ReplaceByIdWithDurability<T> withExpiry(final Duration expiry);
+	}
+
+	interface ExecutableReplaceById<T> extends ReplaceByIdWithExpiry<T> {}
 
 }

--- a/src/main/java/org/springframework/data/couchbase/core/ReactiveReplaceByIdOperation.java
+++ b/src/main/java/org/springframework/data/couchbase/core/ReactiveReplaceByIdOperation.java
@@ -18,6 +18,7 @@ package org.springframework.data.couchbase.core;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
+import java.time.Duration;
 import java.util.Collection;
 
 import com.couchbase.client.core.msg.kv.DurabilityLevel;
@@ -49,6 +50,11 @@ public interface ReactiveReplaceByIdOperation {
 
 	}
 
-	interface ReactiveReplaceById<T> extends ReplaceByIdWithDurability<T> {}
+	interface ReplaceByIdWithExpiry<T> extends ReplaceByIdWithDurability<T> {
+
+		ReplaceByIdWithDurability<T> withExpiry(final Duration expiry);
+	}
+
+	interface ReactiveReplaceById<T> extends ReplaceByIdWithExpiry<T> {}
 
 }


### PR DESCRIPTION
This is identical to the change for 4.0.x and 4.1.x

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATACOUCH).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
