### PR TITLE
DATACOUCH-645 - Support Document(expiryExpression) annotation.

### DIFF
--- a/src/main/java/org/springframework/data/couchbase/core/ExecutableInsertByIdOperation.java
+++ b/src/main/java/org/springframework/data/couchbase/core/ExecutableInsertByIdOperation.java
@@ -26,20 +26,22 @@ public interface ExecutableInsertByIdOperation {
 
 	<T> ExecutableInsertById<T> insertById(Class<T> domainType);
 
-	interface TerminatingInsertById<T> {
+	interface TerminatingInsertById<T> extends OneAndAll<T>{
 
+		@Override
 		T one(T object);
 
+		@Override
 		Collection<? extends T> all(Collection<? extends T> objects);
 
 	}
 
-	interface InsertByIdWithCollection<T> extends TerminatingInsertById<T> {
+	interface InsertByIdWithCollection<T> extends TerminatingInsertById<T>, InCollection<T> {
 
 		TerminatingInsertById<T> inCollection(String collection);
 	}
 
-	interface InsertByIdWithDurability<T> extends InsertByIdWithCollection<T> {
+	interface InsertByIdWithDurability<T> extends InsertByIdWithCollection<T>, WithDurability<T> {
 
 		InsertByIdWithCollection<T> withDurability(DurabilityLevel durabilityLevel);
 
@@ -47,8 +49,9 @@ public interface ExecutableInsertByIdOperation {
 
 	}
 
-	interface InsertByIdWithExpiry<T> extends InsertByIdWithDurability<T> {
+	interface InsertByIdWithExpiry<T> extends InsertByIdWithDurability<T>, WithExpiry<T> {
 
+		@Override
 		InsertByIdWithDurability<T> withExpiry(Duration expiry);
 	}
 

--- a/src/main/java/org/springframework/data/couchbase/core/ExecutableRemoveByIdOperation.java
+++ b/src/main/java/org/springframework/data/couchbase/core/ExecutableRemoveByIdOperation.java
@@ -34,12 +34,12 @@ public interface ExecutableRemoveByIdOperation {
 
 	}
 
-	interface RemoveByIdWithCollection extends TerminatingRemoveById {
+	interface RemoveByIdWithCollection extends TerminatingRemoveById, InCollection {
 
 		TerminatingRemoveById inCollection(String collection);
 	}
 
-	interface RemoveByIdWithDurability extends RemoveByIdWithCollection {
+	interface RemoveByIdWithDurability extends RemoveByIdWithCollection, WithDurability {
 
 		RemoveByIdWithCollection withDurability(DurabilityLevel durabilityLevel);
 

--- a/src/main/java/org/springframework/data/couchbase/core/ExecutableReplaceByIdOperation.java
+++ b/src/main/java/org/springframework/data/couchbase/core/ExecutableReplaceByIdOperation.java
@@ -19,6 +19,7 @@ import java.time.Duration;
 import java.util.Collection;
 
 import com.couchbase.client.core.msg.kv.DurabilityLevel;
+import com.couchbase.client.java.kv.IncrementOptions;
 import com.couchbase.client.java.kv.PersistTo;
 import com.couchbase.client.java.kv.ReplicateTo;
 
@@ -26,20 +27,22 @@ public interface ExecutableReplaceByIdOperation {
 
 	<T> ExecutableReplaceById<T> replaceById(Class<T> domainType);
 
-	interface TerminatingReplaceById<T> {
+	interface TerminatingReplaceById<T> extends OneAndAll<T> {
 
+		@Override
 		T one(T object);
 
+		@Override
 		Collection<? extends T> all(Collection<? extends T> objects);
 
 	}
 
-	interface ReplaceByIdWithCollection<T> extends TerminatingReplaceById<T> {
+	interface ReplaceByIdWithCollection<T> extends TerminatingReplaceById<T> , InCollection<T> {
 
 		TerminatingReplaceById<T> inCollection(String collection);
 	}
 
-	interface ReplaceByIdWithDurability<T> extends ReplaceByIdWithCollection<T> {
+	interface ReplaceByIdWithDurability<T> extends ReplaceByIdWithCollection<T>, WithDurability<T> {
 
 		ReplaceByIdWithCollection<T> withDurability(DurabilityLevel durabilityLevel);
 
@@ -47,8 +50,9 @@ public interface ExecutableReplaceByIdOperation {
 
 	}
 
-	interface ReplaceByIdWithExpiry<T> extends ReplaceByIdWithDurability<T> {
+	interface ReplaceByIdWithExpiry<T> extends ReplaceByIdWithDurability<T>, WithExpiry<T> {
 
+		@Override
 		ReplaceByIdWithDurability<T> withExpiry(final Duration expiry);
 	}
 

--- a/src/main/java/org/springframework/data/couchbase/core/ExecutableUpsertByIdOperation.java
+++ b/src/main/java/org/springframework/data/couchbase/core/ExecutableUpsertByIdOperation.java
@@ -26,20 +26,22 @@ public interface ExecutableUpsertByIdOperation {
 
 	<T> ExecutableUpsertById<T> upsertById(Class<T> domainType);
 
-	interface TerminatingUpsertById<T> {
+	interface TerminatingUpsertById<T> extends OneAndAll<T>{
 
+		@Override
 		T one(T object);
 
+		@Override
 		Collection<? extends T> all(Collection<? extends T> objects);
 
 	}
 
-	interface UpsertByIdWithCollection<T> extends TerminatingUpsertById<T> {
+	interface UpsertByIdWithCollection<T> extends TerminatingUpsertById<T>, InCollection<T> {
 
 		TerminatingUpsertById<T> inCollection(String collection);
 	}
 
-	interface UpsertByIdWithDurability<T> extends UpsertByIdWithCollection<T> {
+	interface UpsertByIdWithDurability<T> extends UpsertByIdWithCollection<T>, WithDurability<T> {
 
 		UpsertByIdWithCollection<T> withDurability(DurabilityLevel durabilityLevel);
 
@@ -47,8 +49,9 @@ public interface ExecutableUpsertByIdOperation {
 
 	}
 
-	interface UpsertByIdWithExpiry<T> extends UpsertByIdWithDurability<T> {
+	interface UpsertByIdWithExpiry<T> extends UpsertByIdWithDurability<T>, WithExpiry<T> {
 
+		@Override
 		UpsertByIdWithDurability<T> withExpiry(Duration expiry);
 	}
 

--- a/src/main/java/org/springframework/data/couchbase/core/InCollection.java
+++ b/src/main/java/org/springframework/data/couchbase/core/InCollection.java
@@ -13,21 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-package org.springframework.data.couchbase.domain;
-
-import org.springframework.data.couchbase.core.mapping.Document;
+package org.springframework.data.couchbase.core;
 
 /**
- * Annotated User entity for tests
+ * A common interface for all of Insert, Replace, Upsert that take collection
  *
  * @author Michael Reiche
+ *
+ * @param <T> - the entity class
  */
-
-@Document(expiry = 1)
-public class UserAnnotated extends User {
-
-	public UserAnnotated(String id, String firstname, String lastname) {
-		super(id, firstname, lastname);
-	}
+public interface InCollection<T> {
+ Object inCollection(String collection);
 }

--- a/src/main/java/org/springframework/data/couchbase/core/OneAndAll.java
+++ b/src/main/java/org/springframework/data/couchbase/core/OneAndAll.java
@@ -13,21 +13,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package org.springframework.data.couchbase.core;
 
-package org.springframework.data.couchbase.domain;
-
-import org.springframework.data.couchbase.core.mapping.Document;
+import java.util.Collection;
 
 /**
- * Annotated User entity for tests
+ * A common interface for all of Insert, Replace, Upsert
  *
  * @author Michael Reiche
+ *
+ * @param <T> - the entity class
  */
+public interface OneAndAll<T> {
 
-@Document(expiry = 1)
-public class UserAnnotated extends User {
+  T one(T object);
 
-	public UserAnnotated(String id, String firstname, String lastname) {
-		super(id, firstname, lastname);
-	}
+  Collection<? extends T> all(Collection<? extends T> objects);
 }

--- a/src/main/java/org/springframework/data/couchbase/core/OneAndAllReactive.java
+++ b/src/main/java/org/springframework/data/couchbase/core/OneAndAllReactive.java
@@ -13,21 +13,23 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package org.springframework.data.couchbase.core;
 
-package org.springframework.data.couchbase.domain;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
-import org.springframework.data.couchbase.core.mapping.Document;
+import java.util.Collection;
 
 /**
- * Annotated User entity for tests
+ * A common interface for all of Insert, Replace, Upsert
  *
  * @author Michael Reiche
+ *
+ * @param <T> - the entity class
  */
 
-@Document(expiry = 1)
-public class UserAnnotated extends User {
+public interface OneAndAllReactive<T> {
+  Mono<T> one(T object);
 
-	public UserAnnotated(String id, String firstname, String lastname) {
-		super(id, firstname, lastname);
-	}
+  Flux<? extends T> all(Collection<? extends T> objects);
 }

--- a/src/main/java/org/springframework/data/couchbase/core/ReactiveInsertByIdOperation.java
+++ b/src/main/java/org/springframework/data/couchbase/core/ReactiveInsertByIdOperation.java
@@ -29,7 +29,7 @@ public interface ReactiveInsertByIdOperation {
 
 	<T> ReactiveInsertById<T> insertById(Class<T> domainType);
 
-	interface TerminatingInsertById<T> {
+	interface TerminatingInsertById<T> extends OneAndAllReactive<T>{
 
 		Mono<T> one(T object);
 
@@ -37,12 +37,12 @@ public interface ReactiveInsertByIdOperation {
 
 	}
 
-	interface InsertByIdWithCollection<T> extends TerminatingInsertById<T> {
+	interface InsertByIdWithCollection<T> extends TerminatingInsertById<T>, InCollection<T> {
 
 		TerminatingInsertById<T> inCollection(String collection);
 	}
 
-	interface InsertByIdWithDurability<T> extends InsertByIdWithCollection<T> {
+	interface InsertByIdWithDurability<T> extends InsertByIdWithCollection<T>, WithDurability<T> {
 
 		InsertByIdWithCollection<T> withDurability(DurabilityLevel durabilityLevel);
 
@@ -50,7 +50,7 @@ public interface ReactiveInsertByIdOperation {
 
 	}
 
-	interface InsertByIdWithExpiry<T> extends InsertByIdWithDurability<T> {
+	interface InsertByIdWithExpiry<T> extends InsertByIdWithDurability<T>, WithExpiry<T>{
 
 		InsertByIdWithDurability<T> withExpiry(Duration expiry);
 	}

--- a/src/main/java/org/springframework/data/couchbase/core/ReactiveInsertByIdOperationSupport.java
+++ b/src/main/java/org/springframework/data/couchbase/core/ReactiveInsertByIdOperationSupport.java
@@ -15,7 +15,6 @@
  */
 package org.springframework.data.couchbase.core;
 
-import org.springframework.data.couchbase.core.mapping.Document;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
@@ -72,7 +71,7 @@ public class ReactiveInsertByIdOperationSupport implements ReactiveInsertByIdOpe
 			return Mono.just(object).flatMap(o -> {
 				CouchbaseDocument converted = template.support().encodeEntity(o);
 				return template.getCollection(collection).reactive()
-						.insert(converted.getId(), converted.export(), buildInsertOptions()).map(result -> {
+						.insert(converted.getId(), converted.export(), buildInsertOptions(converted)).map(result -> {
 							Object updatedObject = template.support().applyUpdatedId(o, converted.getId());
 							return (T) template.support().applyUpdatedCas(updatedObject, result.cas());
 						});
@@ -90,7 +89,7 @@ public class ReactiveInsertByIdOperationSupport implements ReactiveInsertByIdOpe
 			return Flux.fromIterable(objects).flatMap(this::one);
 		}
 
-		private InsertOptions buildInsertOptions() {
+		private InsertOptions buildInsertOptions(CouchbaseDocument doc) { // CouchbaseDocument converted
 			final InsertOptions options = InsertOptions.insertOptions();
 			if (persistTo != PersistTo.NONE || replicateTo != ReplicateTo.NONE) {
 				options.durability(persistTo, replicateTo);
@@ -99,10 +98,8 @@ public class ReactiveInsertByIdOperationSupport implements ReactiveInsertByIdOpe
 			}
 			if (expiry != null && !expiry.isZero()) {
 				options.expiry(expiry);
-			} else if (domainType.isAnnotationPresent(Document.class)) {
-				Document documentAnn = domainType.getAnnotation(Document.class);
-				long durationSeconds = documentAnn.expiryUnit().toSeconds(documentAnn.expiry());
-				options.expiry(Duration.ofSeconds(durationSeconds));
+			} else if (doc.getExpiration() != 0) {
+				options.expiry(Duration.ofSeconds(doc.getExpiration()));
 			}
 			return options;
 		}

--- a/src/main/java/org/springframework/data/couchbase/core/ReactiveRemoveByIdOperation.java
+++ b/src/main/java/org/springframework/data/couchbase/core/ReactiveRemoveByIdOperation.java
@@ -36,12 +36,12 @@ public interface ReactiveRemoveByIdOperation {
 
 	}
 
-	interface RemoveByIdWithCollection extends TerminatingRemoveById {
+	interface RemoveByIdWithCollection extends TerminatingRemoveById, InCollection {
 
 		TerminatingRemoveById inCollection(String collection);
 	}
 
-	interface RemoveByIdWithDurability extends RemoveByIdWithCollection {
+	interface RemoveByIdWithDurability extends RemoveByIdWithCollection, WithDurability {
 
 		RemoveByIdWithCollection withDurability(DurabilityLevel durabilityLevel);
 

--- a/src/main/java/org/springframework/data/couchbase/core/ReactiveReplaceByIdOperation.java
+++ b/src/main/java/org/springframework/data/couchbase/core/ReactiveReplaceByIdOperation.java
@@ -29,7 +29,7 @@ public interface ReactiveReplaceByIdOperation {
 
 	<T> ReactiveReplaceById<T> replaceById(Class<T> domainType);
 
-	interface TerminatingReplaceById<T> {
+	interface TerminatingReplaceById<T> extends OneAndAllReactive<T> {
 
 		Mono<T> one(T object);
 
@@ -37,12 +37,12 @@ public interface ReactiveReplaceByIdOperation {
 
 	}
 
-	interface ReplaceByIdWithCollection<T> extends TerminatingReplaceById<T> {
+	interface ReplaceByIdWithCollection<T> extends TerminatingReplaceById<T>, InCollection<T> {
 
 		TerminatingReplaceById<T> inCollection(String collection);
 	}
 
-	interface ReplaceByIdWithDurability<T> extends ReplaceByIdWithCollection<T> {
+	interface ReplaceByIdWithDurability<T> extends ReplaceByIdWithCollection<T>, WithDurability<T> {
 
 		ReplaceByIdWithCollection<T> withDurability(DurabilityLevel durabilityLevel);
 
@@ -50,7 +50,7 @@ public interface ReactiveReplaceByIdOperation {
 
 	}
 
-	interface ReplaceByIdWithExpiry<T> extends ReplaceByIdWithDurability<T> {
+	interface ReplaceByIdWithExpiry<T> extends ReplaceByIdWithDurability<T>, WithExpiry<T> {
 
 		ReplaceByIdWithDurability<T> withExpiry(final Duration expiry);
 	}

--- a/src/main/java/org/springframework/data/couchbase/core/ReactiveUpsertByIdOperation.java
+++ b/src/main/java/org/springframework/data/couchbase/core/ReactiveUpsertByIdOperation.java
@@ -29,7 +29,7 @@ public interface ReactiveUpsertByIdOperation {
 
 	<T> ReactiveUpsertById<T> upsertById(Class<T> domainType);
 
-	interface TerminatingUpsertById<T> {
+	interface TerminatingUpsertById<T> extends OneAndAllReactive<T>{
 
 		Mono<T> one(T object);
 
@@ -37,12 +37,12 @@ public interface ReactiveUpsertByIdOperation {
 
 	}
 
-	interface UpsertByIdWithCollection<T> extends TerminatingUpsertById<T> {
+	interface UpsertByIdWithCollection<T> extends TerminatingUpsertById<T>, InCollection<T> {
 
 		TerminatingUpsertById<T> inCollection(String collection);
 	}
 
-	interface UpsertByIdWithDurability<T> extends UpsertByIdWithCollection<T> {
+	interface UpsertByIdWithDurability<T> extends UpsertByIdWithCollection<T>, WithDurability<T> {
 
 		UpsertByIdWithCollection<T> withDurability(DurabilityLevel durabilityLevel);
 
@@ -50,7 +50,7 @@ public interface ReactiveUpsertByIdOperation {
 
 	}
 
-	interface UpsertByIdWithExpiry<T> extends UpsertByIdWithDurability<T> {
+	interface UpsertByIdWithExpiry<T> extends UpsertByIdWithDurability<T>, WithExpiry<T> {
 
 		UpsertByIdWithDurability<T> withExpiry(Duration expiry);
 	}

--- a/src/main/java/org/springframework/data/couchbase/core/WithDurability.java
+++ b/src/main/java/org/springframework/data/couchbase/core/WithDurability.java
@@ -13,21 +13,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package org.springframework.data.couchbase.core;
 
-package org.springframework.data.couchbase.domain;
-
-import org.springframework.data.couchbase.core.mapping.Document;
+import com.couchbase.client.core.msg.kv.DurabilityLevel;
+import com.couchbase.client.java.kv.PersistTo;
+import com.couchbase.client.java.kv.ReplicateTo;
 
 /**
- * Annotated User entity for tests
+ * A common interface for all of Insert, Replace, Upsert that take Durability
  *
  * @author Michael Reiche
+ *
+ * @param <T> - the entity class
  */
+public interface WithDurability<T> {
+  Object withDurability(DurabilityLevel durabilityLevel);
 
-@Document(expiry = 1)
-public class UserAnnotated extends User {
-
-	public UserAnnotated(String id, String firstname, String lastname) {
-		super(id, firstname, lastname);
-	}
+  Object withDurability(PersistTo persistTo, ReplicateTo replicateTo);
 }

--- a/src/main/java/org/springframework/data/couchbase/core/WithExpiry.java
+++ b/src/main/java/org/springframework/data/couchbase/core/WithExpiry.java
@@ -13,21 +13,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package org.springframework.data.couchbase.core;
 
-package org.springframework.data.couchbase.domain;
-
-import org.springframework.data.couchbase.core.mapping.Document;
+import java.time.Duration;
 
 /**
- * Annotated User entity for tests
+ * A common interface for all of Insert, Replace, Upsert that take expiry
  *
  * @author Michael Reiche
+ *
+ * @param <T> - the entity class
  */
-
-@Document(expiry = 1)
-public class UserAnnotated extends User {
-
-	public UserAnnotated(String id, String firstname, String lastname) {
-		super(id, firstname, lastname);
-	}
+public interface WithExpiry<T> {
+  Object withExpiry(Duration expiry);
 }

--- a/src/test/java/org/springframework/data/couchbase/core/CouchbaseTemplateKeyValueIntegrationTests.java
+++ b/src/test/java/org/springframework/data/couchbase/core/CouchbaseTemplateKeyValueIntegrationTests.java
@@ -27,9 +27,14 @@ import static org.springframework.data.couchbase.config.BeanNames.COUCHBASE_TEMP
 import static org.springframework.data.couchbase.config.BeanNames.REACTIVE_COUCHBASE_TEMPLATE;
 
 import java.io.IOException;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
 import java.time.Duration;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.UUID;
 
+import com.couchbase.client.java.manager.query.CreatePrimaryQueryIndexOptions;;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -37,14 +42,17 @@ import org.junit.jupiter.api.Test;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.dao.DataIntegrityViolationException;
-import org.springframework.dao.DataRetrievalFailureException;
 import org.springframework.dao.DuplicateKeyException;
 import org.springframework.data.couchbase.CouchbaseClientFactory;
 import org.springframework.data.couchbase.SimpleCouchbaseClientFactory;
+import org.springframework.data.couchbase.core.ExecutableReplaceByIdOperation.ExecutableReplaceById;
+import org.springframework.data.couchbase.core.ExecutableRemoveByIdOperation.ExecutableRemoveById;
+
 import org.springframework.data.couchbase.domain.Config;
 import org.springframework.data.couchbase.domain.PersonValue;
 import org.springframework.data.couchbase.domain.User;
 import org.springframework.data.couchbase.domain.UserAnnotated;
+import org.springframework.data.couchbase.domain.UserAnnotated2;
 import org.springframework.data.couchbase.util.ClusterAwareIntegrationTests;
 import org.springframework.data.couchbase.util.ClusterType;
 import org.springframework.data.couchbase.util.IgnoreWhen;
@@ -69,6 +77,8 @@ class CouchbaseTemplateKeyValueIntegrationTests extends ClusterAwareIntegrationT
 	static void beforeAll() {
 		couchbaseClientFactory = new SimpleCouchbaseClientFactory(connectionString(), authenticator(), bucketName());
 		couchbaseClientFactory.getBucket().waitUntilReady(Duration.ofSeconds(10));
+		couchbaseClientFactory.getCluster().queryIndexes().createPrimaryIndex(bucketName(),
+				CreatePrimaryQueryIndexOptions.createPrimaryQueryIndexOptions().ignoreIfExists(true));
 	}
 
 	@AfterAll
@@ -81,6 +91,9 @@ class CouchbaseTemplateKeyValueIntegrationTests extends ClusterAwareIntegrationT
 		ApplicationContext ac = new AnnotationConfigApplicationContext(Config.class);
 		couchbaseTemplate = (CouchbaseTemplate) ac.getBean(COUCHBASE_TEMPLATE);
 		reactiveCouchbaseTemplate = (ReactiveCouchbaseTemplate) ac.getBean(REACTIVE_COUCHBASE_TEMPLATE);
+		couchbaseTemplate.removeByQuery(User.class).all();
+		couchbaseTemplate.removeByQuery(UserAnnotated.class).all();
+		couchbaseTemplate.removeByQuery(UserAnnotated2.class).all();
 	}
 
 	@Test
@@ -103,88 +116,78 @@ class CouchbaseTemplateKeyValueIntegrationTests extends ClusterAwareIntegrationT
 	}
 
 	@Test
-	void upsertWithDurability() {
-		User user = new User(UUID.randomUUID().toString(), "firstname", "lastname");
-		User modified = couchbaseTemplate.upsertById(User.class).withDurability(PersistTo.ACTIVE, ReplicateTo.NONE)
-				.one(user);
-		assertEquals(user, modified);
-		User found = couchbaseTemplate.findById(User.class).one(user.getId());
-		assertEquals(user, found);
-		couchbaseTemplate.removeById().one(user.getId());
-	}
+	void withDurability()
+			throws NoSuchMethodException, IllegalAccessException, InvocationTargetException, InstantiationException {
+		Class clazz = User.class; // for now, just User.class. There is no Durability annotation.
+		// insert, replace, upsert
+		for (OneAndAll<User> operator : new OneAndAll[] { couchbaseTemplate.insertById(clazz),
+				couchbaseTemplate.replaceById(clazz), couchbaseTemplate.upsertById(clazz)}) {
+			// create an entity of type clazz
+			Constructor cons = clazz.getConstructor(String.class, String.class, String.class);
+			User user = (User) cons.newInstance("" + operator.getClass().getSimpleName() + "_" + clazz.getSimpleName(),
+					"firstname", "lastname");
 
-	@Test
-	void upsertWithExpiry() {
-		User user = new User(UUID.randomUUID().toString(), "firstname", "lastname");
-		try {
-			User modified = couchbaseTemplate.upsertById(User.class).withExpiry(Duration.ofSeconds(1)).one(user);
-			assertEquals(user, modified);
-			sleepSecs(2);
+			if (clazz.equals(User.class)) { // User.java doesn't have an durability annotation
+				operator = (OneAndAll) ((WithDurability<User>) operator).withDurability(PersistTo.ACTIVE, ReplicateTo.NONE);
+			}
+
+			// if replace, we need to insert a document to replace
+			if (operator instanceof ExecutableReplaceById) {
+				couchbaseTemplate.insertById(User.class).one(user);
+			}
+			// call to insert/replace/update
+			User returned = (User)operator.one(user);
+			assertEquals(user, returned);
 			User found = couchbaseTemplate.findById(User.class).one(user.getId());
-			assertNull(found, "found should have been null as document should be expired");
-		} finally {
-			try {
-				couchbaseTemplate.removeById().one(user.getId());
-			} catch (DataRetrievalFailureException e) {
-				//
+			assertEquals(user, found);
+
+			if (operator instanceof ExecutableReplaceById) {
+				couchbaseTemplate.removeById().withDurability(PersistTo.ACTIVE, ReplicateTo.NONE).one(user.getId());
+				User removed = (User) couchbaseTemplate.findById(user.getClass()).one(user.getId());
+				assertNull(removed, "found should have been null as document should be removed");
 			}
 		}
+
 	}
 
 	@Test
-	void upsertWithExpiryAnnotation() {
-		UserAnnotated user = new UserAnnotated(UUID.randomUUID().toString(), "firstname", "lastname");
-		try {
-			UserAnnotated modified = couchbaseTemplate.upsertById(UserAnnotated.class).one(user);
-			assertEquals(user, modified);
-			sleepSecs(6);
-			User found = couchbaseTemplate.findById(User.class).one(user.getId());
-			assertNull(found, "found should have been null as document should be expired");
-		} finally {
-			try {
-				couchbaseTemplate.removeById().one(user.getId());
-			} catch (DataRetrievalFailureException e) {
-				//
-			}
-		}
-	}
+	void withExpiryAndExpiryAnnotation()
+			throws IllegalAccessException, InstantiationException, NoSuchMethodException, InvocationTargetException {
+		// ( withExpiry()<User>, expiry=1<UserAnnotated>, expiryExpression=${myExpiry}<UserAnnotated2> ) X ( insert,
+		// replace, upsert )
+		Set<User> users = new HashSet<>(); // set of all documents we will insert
+		// Entity classes
+		for (Class clazz : new Class[] { User.class, UserAnnotated.class, UserAnnotated2.class }) {
+			// insert, replace, upsert
+			for (OneAndAll<User> operator : new OneAndAll[] { couchbaseTemplate.insertById(clazz),
+					couchbaseTemplate.replaceById(clazz), couchbaseTemplate.upsertById(clazz) }) {
 
-	@Test
-	void replaceWithExpiry() {
-		User user = new User(UUID.randomUUID().toString(), "firstname", "lastname");
-		try {
-			User modified = couchbaseTemplate.upsertById(User.class).withExpiry(Duration.ofSeconds(1)).one(user);
-			couchbaseTemplate.replaceById(User.class).withExpiry(Duration.ofSeconds(1)).one(user);
-			assertEquals(user, modified);
-			sleepSecs(2);
-			User found = couchbaseTemplate.findById(User.class).one(user.getId());
-			assertNull(found, "found should have been null as document should be expired");
-		} finally {
-			try {
-				couchbaseTemplate.removeById().one(user.getId());
-			} catch (DataRetrievalFailureException e) {
-				//
-			}
-		}
-	}
+				// create an entity of type clazz
+				Constructor cons = clazz.getConstructor(String.class, String.class, String.class);
+				User user = (User) cons.newInstance("" + operator.getClass().getSimpleName() + "_" + clazz.getSimpleName(),
+						"firstname", "lastname");
 
-	@Test
-	void replaceWithExpiryAnnotation() {
-		UserAnnotated user = new UserAnnotated(UUID.randomUUID().toString(), "firstname", "lastname");
-		try {
-			UserAnnotated modified = couchbaseTemplate.upsertById(UserAnnotated.class).one(user);
-			modified = couchbaseTemplate.replaceById(UserAnnotated.class).one(user);
-			assertEquals(user, modified);
-			sleepSecs(6);
-			User found = couchbaseTemplate.findById(UserAnnotated.class).one(user.getId());
-			assertNull(found, "found should have been null as document should be expired");
-		} finally {
-			try {
-				couchbaseTemplate.removeById().one(user.getId());
-			} catch (DataRetrievalFailureException e) {
-				//
+				if (clazz.equals(User.class)) { // User.java doesn't have an expiry annotation
+					operator = (OneAndAll) ((WithExpiry<User>) operator).withExpiry(Duration.ofSeconds(1));
+				}
+
+				// if replace or remove, we need to insert a document to replace
+				if (operator instanceof ExecutableReplaceById || operator instanceof ExecutableRemoveById) {
+					couchbaseTemplate.insertById(User.class).one(user);
+				}
+				// call to insert/replace/update
+				User returned = (User)operator.one(user);
+				assertEquals(user, returned);
+				users.add(user);
 			}
 		}
+		// check that they are gone after a few seconds.
+		sleepSecs(4);
+		for (User user : users) {
+			User found = (User) couchbaseTemplate.findById(user.getClass()).one(user.getId());
+			assertNull(found, "found should have been null as document should be expired");
+		}
+
 	}
 
 	@Test
@@ -227,10 +230,7 @@ class CouchbaseTemplateKeyValueIntegrationTests extends ClusterAwareIntegrationT
 		User user = new User(UUID.randomUUID().toString(), "firstname", "lastname");
 		User inserted = couchbaseTemplate.insertById(User.class).one(user);
 		assertEquals(user, inserted);
-
 		assertThrows(DuplicateKeyException.class, () -> couchbaseTemplate.insertById(User.class).one(user));
-		couchbaseTemplate.removeById().one(user.getId());
-
 	}
 
 	@Test
@@ -239,47 +239,7 @@ class CouchbaseTemplateKeyValueIntegrationTests extends ClusterAwareIntegrationT
 		User inserted = couchbaseTemplate.insertById(User.class).withDurability(PersistTo.ACTIVE, ReplicateTo.NONE)
 				.one(user);
 		assertEquals(user, inserted);
-
 		assertThrows(DuplicateKeyException.class, () -> couchbaseTemplate.insertById(User.class).one(user));
-		couchbaseTemplate.removeById().one(user.getId());
-
-	}
-
-	@Test
-	void insertByIdwithExpiry() {
-		User user = new User(UUID.randomUUID().toString(), "firstname", "lastname");
-		try {
-			User inserted = couchbaseTemplate.insertById(User.class).withExpiry(Duration.ofSeconds(1)).one(user);
-			assertEquals(user, inserted);
-			sleepSecs(2);
-			User found = couchbaseTemplate.findById(User.class).one(user.getId());
-			assertNull(found, "found should have been null as document should be expired");
-		} finally {
-			try {
-				couchbaseTemplate.removeById().one(user.getId());
-			} catch (DataRetrievalFailureException e) {
-				// ignore
-			}
-		}
-
-	}
-
-	@Test
-	void insertWithExpiryAnnotation() {
-		UserAnnotated user = new UserAnnotated(UUID.randomUUID().toString(), "firstname", "lastname");
-		try {
-			UserAnnotated inserted = couchbaseTemplate.insertById(UserAnnotated.class).one(user);
-			assertEquals(user, inserted);
-			sleepSecs(6);
-			User found = couchbaseTemplate.findById(User.class).one(user.getId());
-			assertNull(found, "found should have been null as document should be expired");
-		} finally {
-			try {
-				couchbaseTemplate.removeById().one(user.getId());
-			} catch (DataRetrievalFailureException e) {
-				// ignore
-			}
-		}
 	}
 
 	@Test
@@ -292,52 +252,44 @@ class CouchbaseTemplateKeyValueIntegrationTests extends ClusterAwareIntegrationT
 		assertEquals(user, inserted);
 
 		assertTrue(couchbaseTemplate.existsById().one(id));
-		couchbaseTemplate.removeById().one(user.getId());
 
 	}
 
 	@Test
 	@IgnoreWhen(clusterTypes = ClusterType.MOCKED)
 	void saveAndFindImmutableById() {
-		PersonValue personValue = new PersonValue(null, 123, "f", "l");
-		System.out.println("personValue: " + personValue);
-		// personValue = personValue.withVersion(123);
+		PersonValue personValue = new PersonValue(UUID.randomUUID().toString(), 123, "f", "l");
 		PersonValue inserted = null;
 		PersonValue upserted = null;
 		PersonValue replaced = null;
 
-		try {
+		inserted = couchbaseTemplate.insertById(PersonValue.class).one(personValue);
+		assertNotEquals(0, inserted.getVersion());
+		PersonValue foundInserted = couchbaseTemplate.findById(PersonValue.class).one(inserted.getId());
+		assertNotNull(foundInserted, "inserted personValue not found");
+		assertEquals(inserted, foundInserted);
 
-			inserted = couchbaseTemplate.insertById(PersonValue.class).one(personValue);
-			assertNotEquals(0, inserted.getVersion());
-			PersonValue foundInserted = couchbaseTemplate.findById(PersonValue.class).one(inserted.getId());
-			assertNotNull(foundInserted, "inserted personValue not found");
-			assertEquals(inserted, foundInserted);
+		// upsert will insert
+		couchbaseTemplate.removeById().one(inserted.getId());
+		upserted = couchbaseTemplate.upsertById(PersonValue.class).one(inserted);
+		assertNotEquals(0, upserted.getVersion());
+		PersonValue foundUpserted = couchbaseTemplate.findById(PersonValue.class).one(upserted.getId());
+		assertNotNull(foundUpserted, "upserted personValue not found");
+		assertEquals(upserted, foundUpserted);
 
-			// upsert will be inserted
-			couchbaseTemplate.removeById().one(inserted.getId());
-			upserted = couchbaseTemplate.upsertById(PersonValue.class).one(inserted);
-			assertNotEquals(0, upserted.getVersion());
-			PersonValue foundUpserted = couchbaseTemplate.findById(PersonValue.class).one(upserted.getId());
-			assertNotNull(foundUpserted, "upserted personValue not found");
-			assertEquals(upserted, foundUpserted);
+		// upsert will replace
+		upserted = couchbaseTemplate.upsertById(PersonValue.class).one(inserted);
+		assertNotEquals(0, upserted.getVersion());
+		PersonValue foundUpserted2 = couchbaseTemplate.findById(PersonValue.class).one(upserted.getId());
+		assertNotNull(foundUpserted2, "upserted personValue not found");
+		assertEquals(upserted, foundUpserted2);
 
-			// upsert will be replaced
-			upserted = couchbaseTemplate.upsertById(PersonValue.class).one(inserted);
-			assertNotEquals(0, upserted.getVersion());
-			PersonValue foundUpserted2 = couchbaseTemplate.findById(PersonValue.class).one(upserted.getId());
-			assertNotNull(foundUpserted2, "upserted personValue not found");
-			assertEquals(upserted, foundUpserted2);
+		replaced = couchbaseTemplate.replaceById(PersonValue.class).one(upserted);
+		assertNotEquals(0, replaced.getVersion());
+		PersonValue foundReplaced = couchbaseTemplate.findById(PersonValue.class).one(replaced.getId());
+		assertNotNull(foundReplaced, "replaced personValue not found");
+		assertEquals(replaced, foundReplaced);
 
-			replaced = couchbaseTemplate.replaceById(PersonValue.class).one(upserted);
-			assertNotEquals(0, replaced.getVersion());
-			PersonValue foundReplaced = couchbaseTemplate.findById(PersonValue.class).one(replaced.getId());
-			assertNotNull(foundReplaced, "replaced personValue not found");
-			assertEquals(replaced, foundReplaced);
-
-		} finally {
-			couchbaseTemplate.removeById().one(inserted.getId());
-		}
 	}
 
 	private void sleepSecs(int i) {

--- a/src/test/java/org/springframework/data/couchbase/core/CouchbaseTemplateQueryIntegrationTests.java
+++ b/src/test/java/org/springframework/data/couchbase/core/CouchbaseTemplateQueryIntegrationTests.java
@@ -26,6 +26,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
 
+import com.couchbase.client.java.manager.query.CreatePrimaryQueryIndexOptions;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -65,12 +66,8 @@ class CouchbaseTemplateQueryIntegrationTests extends ClusterAwareIntegrationTest
 	@BeforeAll
 	static void beforeAll() {
 		couchbaseClientFactory = new SimpleCouchbaseClientFactory(connectionString(), authenticator(), bucketName());
-
-		try {
-			couchbaseClientFactory.getCluster().queryIndexes().createPrimaryIndex(bucketName());
-		} catch (IndexExistsException ex) {
-			// ignore, all good.
-		}
+		couchbaseClientFactory.getCluster().queryIndexes().createPrimaryIndex(bucketName(),
+				CreatePrimaryQueryIndexOptions.createPrimaryQueryIndexOptions().ignoreIfExists(true));
 	}
 
 	@AfterAll
@@ -177,8 +174,7 @@ class CouchbaseTemplateQueryIntegrationTests extends ClusterAwareIntegrationTest
 		Query nonSpecialUsers = new Query(QueryCriteria.where("firstname").notLike("special"));
 
 		couchbaseTemplate.removeByQuery(User.class).consistentWith(QueryScanConsistency.REQUEST_PLUS)
-				.matching(nonSpecialUsers)
-				.all();
+				.matching(nonSpecialUsers).all();
 
 		assertNull(couchbaseTemplate.findById(User.class).one(user1.getId()));
 		assertNull(couchbaseTemplate.findById(User.class).one(user2.getId()));

--- a/src/test/java/org/springframework/data/couchbase/domain/UserAnnotated2.java
+++ b/src/test/java/org/springframework/data/couchbase/domain/UserAnnotated2.java
@@ -16,6 +16,8 @@
 
 package org.springframework.data.couchbase.domain;
 
+import java.util.concurrent.TimeUnit;
+
 import org.springframework.data.couchbase.core.mapping.Document;
 
 /**
@@ -24,10 +26,13 @@ import org.springframework.data.couchbase.core.mapping.Document;
  * @author Michael Reiche
  */
 
-@Document(expiry = 1)
-public class UserAnnotated extends User {
+@Document(expiryExpression = "${myExpiryExpression}", expiryUnit = TimeUnit.SECONDS)
+public class UserAnnotated2 extends User {
+	static {
+		System.setProperty("myExpiryExpression", "2");
+	}
 
-	public UserAnnotated(String id, String firstname, String lastname) {
+	public UserAnnotated2(String id, String firstname, String lastname) {
 		super(id, firstname, lastname);
 	}
 }

--- a/src/test/java/org/springframework/data/couchbase/repository/CouchbaseRepositoryQueryIntegrationTests.java
+++ b/src/test/java/org/springframework/data/couchbase/repository/CouchbaseRepositoryQueryIntegrationTests.java
@@ -30,6 +30,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.stream.Collectors;
 
+import com.couchbase.client.java.manager.query.CreatePrimaryQueryIndexOptions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -74,11 +75,8 @@ public class CouchbaseRepositoryQueryIntegrationTests extends ClusterAwareIntegr
 
 	@BeforeEach
 	void beforeEach() {
-		try {
-			clientFactory.getCluster().queryIndexes().createPrimaryIndex(bucketName());
-		} catch (IndexExistsException ex) {
-			// ignore, all good.
-		}
+		clientFactory.getCluster().queryIndexes().createPrimaryIndex(bucketName(),
+				CreatePrimaryQueryIndexOptions.createPrimaryQueryIndexOptions().ignoreIfExists(true));
 	}
 
 	@Test

--- a/src/test/java/org/springframework/data/couchbase/repository/ReactiveCouchbaseRepositoryQueryIntegrationTests.java
+++ b/src/test/java/org/springframework/data/couchbase/repository/ReactiveCouchbaseRepositoryQueryIntegrationTests.java
@@ -22,6 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.couchbase.client.java.manager.query.CreatePrimaryQueryIndexOptions;
 import reactor.core.publisher.Flux;
 import reactor.test.StepVerifier;
 
@@ -70,11 +71,8 @@ public class ReactiveCouchbaseRepositoryQueryIntegrationTests extends ClusterAwa
 
 	@BeforeEach
 	void beforeEach() {
-		try {
-			clientFactory.getCluster().queryIndexes().createPrimaryIndex(bucketName());
-		} catch (IndexExistsException ex) {
-			// ignore, all good.
-		}
+		clientFactory.getCluster().queryIndexes().createPrimaryIndex(bucketName(),
+				CreatePrimaryQueryIndexOptions.createPrimaryQueryIndexOptions().ignoreIfExists(true));
 	}
 
 	@Test


### PR DESCRIPTION
1) get the expiryExpression from the converted CouchbaseDocument.

2) added interfaces for apis on core objects which are common among
many objects. For instance withExpiry and withExpirty on all the
insert/replace/upsert/remove objects.  The definition of an interface
simplyfies testing of all the possible combinations - instead of having
four (or eight, counting Reactive), there is one interface to test
them all.

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATACOUCH).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
