### PR TITLE
DATACOUCH-675 - Factor out interfaces for common methods.

### DIFF
--- a/src/main/java/org/springframework/data/couchbase/core/ExecutableInsertByIdOperation.java
+++ b/src/main/java/org/springframework/data/couchbase/core/ExecutableInsertByIdOperation.java
@@ -26,20 +26,22 @@ public interface ExecutableInsertByIdOperation {
 
 	<T> ExecutableInsertById<T> insertById(Class<T> domainType);
 
-	interface TerminatingInsertById<T> {
+	interface TerminatingInsertById<T> extends OneAndAll<T>{
 
+		@Override
 		T one(T object);
 
+		@Override
 		Collection<? extends T> all(Collection<? extends T> objects);
 
 	}
 
-	interface InsertByIdWithCollection<T> extends TerminatingInsertById<T> {
+	interface InsertByIdWithCollection<T> extends TerminatingInsertById<T>, InCollection<T> {
 
 		TerminatingInsertById<T> inCollection(String collection);
 	}
 
-	interface InsertByIdWithDurability<T> extends InsertByIdWithCollection<T> {
+	interface InsertByIdWithDurability<T> extends InsertByIdWithCollection<T>, WithDurability<T> {
 
 		InsertByIdWithCollection<T> withDurability(DurabilityLevel durabilityLevel);
 
@@ -47,8 +49,9 @@ public interface ExecutableInsertByIdOperation {
 
 	}
 
-	interface InsertByIdWithExpiry<T> extends InsertByIdWithDurability<T> {
+	interface InsertByIdWithExpiry<T> extends InsertByIdWithDurability<T>, WithExpiry<T> {
 
+		@Override
 		InsertByIdWithDurability<T> withExpiry(Duration expiry);
 	}
 

--- a/src/main/java/org/springframework/data/couchbase/core/ExecutableRemoveByIdOperation.java
+++ b/src/main/java/org/springframework/data/couchbase/core/ExecutableRemoveByIdOperation.java
@@ -34,12 +34,12 @@ public interface ExecutableRemoveByIdOperation {
 
 	}
 
-	interface RemoveByIdWithCollection extends TerminatingRemoveById {
+	interface RemoveByIdWithCollection extends TerminatingRemoveById, InCollection {
 
 		TerminatingRemoveById inCollection(String collection);
 	}
 
-	interface RemoveByIdWithDurability extends RemoveByIdWithCollection {
+	interface RemoveByIdWithDurability extends RemoveByIdWithCollection, WithDurability {
 
 		RemoveByIdWithCollection withDurability(DurabilityLevel durabilityLevel);
 

--- a/src/main/java/org/springframework/data/couchbase/core/ExecutableReplaceByIdOperation.java
+++ b/src/main/java/org/springframework/data/couchbase/core/ExecutableReplaceByIdOperation.java
@@ -19,6 +19,7 @@ import java.time.Duration;
 import java.util.Collection;
 
 import com.couchbase.client.core.msg.kv.DurabilityLevel;
+import com.couchbase.client.java.kv.IncrementOptions;
 import com.couchbase.client.java.kv.PersistTo;
 import com.couchbase.client.java.kv.ReplicateTo;
 
@@ -26,20 +27,22 @@ public interface ExecutableReplaceByIdOperation {
 
 	<T> ExecutableReplaceById<T> replaceById(Class<T> domainType);
 
-	interface TerminatingReplaceById<T> {
+	interface TerminatingReplaceById<T> extends OneAndAll<T> {
 
+		@Override
 		T one(T object);
 
+		@Override
 		Collection<? extends T> all(Collection<? extends T> objects);
 
 	}
 
-	interface ReplaceByIdWithCollection<T> extends TerminatingReplaceById<T> {
+	interface ReplaceByIdWithCollection<T> extends TerminatingReplaceById<T> , InCollection<T> {
 
 		TerminatingReplaceById<T> inCollection(String collection);
 	}
 
-	interface ReplaceByIdWithDurability<T> extends ReplaceByIdWithCollection<T> {
+	interface ReplaceByIdWithDurability<T> extends ReplaceByIdWithCollection<T>, WithDurability<T> {
 
 		ReplaceByIdWithCollection<T> withDurability(DurabilityLevel durabilityLevel);
 
@@ -47,8 +50,9 @@ public interface ExecutableReplaceByIdOperation {
 
 	}
 
-	interface ReplaceByIdWithExpiry<T> extends ReplaceByIdWithDurability<T> {
+	interface ReplaceByIdWithExpiry<T> extends ReplaceByIdWithDurability<T>, WithExpiry<T> {
 
+		@Override
 		ReplaceByIdWithDurability<T> withExpiry(final Duration expiry);
 	}
 

--- a/src/main/java/org/springframework/data/couchbase/core/ExecutableUpsertByIdOperation.java
+++ b/src/main/java/org/springframework/data/couchbase/core/ExecutableUpsertByIdOperation.java
@@ -26,20 +26,22 @@ public interface ExecutableUpsertByIdOperation {
 
 	<T> ExecutableUpsertById<T> upsertById(Class<T> domainType);
 
-	interface TerminatingUpsertById<T> {
+	interface TerminatingUpsertById<T> extends OneAndAll<T>{
 
+		@Override
 		T one(T object);
 
+		@Override
 		Collection<? extends T> all(Collection<? extends T> objects);
 
 	}
 
-	interface UpsertByIdWithCollection<T> extends TerminatingUpsertById<T> {
+	interface UpsertByIdWithCollection<T> extends TerminatingUpsertById<T>, InCollection<T> {
 
 		TerminatingUpsertById<T> inCollection(String collection);
 	}
 
-	interface UpsertByIdWithDurability<T> extends UpsertByIdWithCollection<T> {
+	interface UpsertByIdWithDurability<T> extends UpsertByIdWithCollection<T>, WithDurability<T> {
 
 		UpsertByIdWithCollection<T> withDurability(DurabilityLevel durabilityLevel);
 
@@ -47,8 +49,9 @@ public interface ExecutableUpsertByIdOperation {
 
 	}
 
-	interface UpsertByIdWithExpiry<T> extends UpsertByIdWithDurability<T> {
+	interface UpsertByIdWithExpiry<T> extends UpsertByIdWithDurability<T>, WithExpiry<T> {
 
+		@Override
 		UpsertByIdWithDurability<T> withExpiry(Duration expiry);
 	}
 

--- a/src/main/java/org/springframework/data/couchbase/core/InCollection.java
+++ b/src/main/java/org/springframework/data/couchbase/core/InCollection.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2020 the original author or authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.couchbase.core;
+
+/**
+ * A common interface for all of Insert, Replace, Upsert that take collection
+ *
+ * @author Michael Reiche
+ * @param <T> - the entity class
+ */
+public interface InCollection<T> {
+	Object inCollection(String collection);
+}

--- a/src/main/java/org/springframework/data/couchbase/core/OneAndAll.java
+++ b/src/main/java/org/springframework/data/couchbase/core/OneAndAll.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2020 the original author or authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.couchbase.core;
+
+import java.util.Collection;
+
+/**
+ * A common interface for all of Insert, Replace, Upsert
+ *
+ * @author Michael Reiche
+ *
+ * @param <T> - the entity class
+ */
+public interface OneAndAll<T> {
+
+	T one(T object);
+
+  Collection<? extends T> all(Collection<? extends T> objects);
+}

--- a/src/main/java/org/springframework/data/couchbase/core/OneAndAllReactive.java
+++ b/src/main/java/org/springframework/data/couchbase/core/OneAndAllReactive.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2020 the original author or authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.couchbase.core;
+
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.util.Collection;
+
+/**
+ * A common interface for all of Insert, Replace, Upsert
+ *
+ * @author Michael Reiche
+ * @param <T> - the entity class
+ */
+
+public interface OneAndAllReactive<T> {
+	Mono<T> one(T object);
+
+	Flux<? extends T> all(Collection<? extends T> objects);
+}

--- a/src/main/java/org/springframework/data/couchbase/core/ReactiveInsertByIdOperation.java
+++ b/src/main/java/org/springframework/data/couchbase/core/ReactiveInsertByIdOperation.java
@@ -29,7 +29,7 @@ public interface ReactiveInsertByIdOperation {
 
 	<T> ReactiveInsertById<T> insertById(Class<T> domainType);
 
-	interface TerminatingInsertById<T> {
+	interface TerminatingInsertById<T> extends OneAndAllReactive<T>{
 
 		Mono<T> one(T object);
 
@@ -37,12 +37,12 @@ public interface ReactiveInsertByIdOperation {
 
 	}
 
-	interface InsertByIdWithCollection<T> extends TerminatingInsertById<T> {
+	interface InsertByIdWithCollection<T> extends TerminatingInsertById<T>, InCollection<T> {
 
 		TerminatingInsertById<T> inCollection(String collection);
 	}
 
-	interface InsertByIdWithDurability<T> extends InsertByIdWithCollection<T> {
+	interface InsertByIdWithDurability<T> extends InsertByIdWithCollection<T>, WithDurability<T> {
 
 		InsertByIdWithCollection<T> withDurability(DurabilityLevel durabilityLevel);
 
@@ -50,7 +50,7 @@ public interface ReactiveInsertByIdOperation {
 
 	}
 
-	interface InsertByIdWithExpiry<T> extends InsertByIdWithDurability<T> {
+	interface InsertByIdWithExpiry<T> extends InsertByIdWithDurability<T>, WithExpiry<T>{
 
 		InsertByIdWithDurability<T> withExpiry(Duration expiry);
 	}

--- a/src/main/java/org/springframework/data/couchbase/core/ReactiveRemoveByIdOperation.java
+++ b/src/main/java/org/springframework/data/couchbase/core/ReactiveRemoveByIdOperation.java
@@ -36,12 +36,12 @@ public interface ReactiveRemoveByIdOperation {
 
 	}
 
-	interface RemoveByIdWithCollection extends TerminatingRemoveById {
+	interface RemoveByIdWithCollection extends TerminatingRemoveById, InCollection {
 
 		TerminatingRemoveById inCollection(String collection);
 	}
 
-	interface RemoveByIdWithDurability extends RemoveByIdWithCollection {
+	interface RemoveByIdWithDurability extends RemoveByIdWithCollection, WithDurability {
 
 		RemoveByIdWithCollection withDurability(DurabilityLevel durabilityLevel);
 

--- a/src/main/java/org/springframework/data/couchbase/core/ReactiveReplaceByIdOperation.java
+++ b/src/main/java/org/springframework/data/couchbase/core/ReactiveReplaceByIdOperation.java
@@ -29,7 +29,7 @@ public interface ReactiveReplaceByIdOperation {
 
 	<T> ReactiveReplaceById<T> replaceById(Class<T> domainType);
 
-	interface TerminatingReplaceById<T> {
+	interface TerminatingReplaceById<T> extends OneAndAllReactive<T> {
 
 		Mono<T> one(T object);
 
@@ -37,12 +37,12 @@ public interface ReactiveReplaceByIdOperation {
 
 	}
 
-	interface ReplaceByIdWithCollection<T> extends TerminatingReplaceById<T> {
+	interface ReplaceByIdWithCollection<T> extends TerminatingReplaceById<T>, InCollection<T> {
 
 		TerminatingReplaceById<T> inCollection(String collection);
 	}
 
-	interface ReplaceByIdWithDurability<T> extends ReplaceByIdWithCollection<T> {
+	interface ReplaceByIdWithDurability<T> extends ReplaceByIdWithCollection<T>, WithDurability<T> {
 
 		ReplaceByIdWithCollection<T> withDurability(DurabilityLevel durabilityLevel);
 
@@ -50,7 +50,7 @@ public interface ReactiveReplaceByIdOperation {
 
 	}
 
-	interface ReplaceByIdWithExpiry<T> extends ReplaceByIdWithDurability<T> {
+	interface ReplaceByIdWithExpiry<T> extends ReplaceByIdWithDurability<T>, WithExpiry<T> {
 
 		ReplaceByIdWithDurability<T> withExpiry(final Duration expiry);
 	}

--- a/src/main/java/org/springframework/data/couchbase/core/ReactiveUpsertByIdOperation.java
+++ b/src/main/java/org/springframework/data/couchbase/core/ReactiveUpsertByIdOperation.java
@@ -29,7 +29,7 @@ public interface ReactiveUpsertByIdOperation {
 
 	<T> ReactiveUpsertById<T> upsertById(Class<T> domainType);
 
-	interface TerminatingUpsertById<T> {
+	interface TerminatingUpsertById<T> extends OneAndAllReactive<T>{
 
 		Mono<T> one(T object);
 
@@ -37,12 +37,12 @@ public interface ReactiveUpsertByIdOperation {
 
 	}
 
-	interface UpsertByIdWithCollection<T> extends TerminatingUpsertById<T> {
+	interface UpsertByIdWithCollection<T> extends TerminatingUpsertById<T>, InCollection<T> {
 
 		TerminatingUpsertById<T> inCollection(String collection);
 	}
 
-	interface UpsertByIdWithDurability<T> extends UpsertByIdWithCollection<T> {
+	interface UpsertByIdWithDurability<T> extends UpsertByIdWithCollection<T>, WithDurability<T> {
 
 		UpsertByIdWithCollection<T> withDurability(DurabilityLevel durabilityLevel);
 
@@ -50,7 +50,7 @@ public interface ReactiveUpsertByIdOperation {
 
 	}
 
-	interface UpsertByIdWithExpiry<T> extends UpsertByIdWithDurability<T> {
+	interface UpsertByIdWithExpiry<T> extends UpsertByIdWithDurability<T>, WithExpiry<T> {
 
 		UpsertByIdWithDurability<T> withExpiry(Duration expiry);
 	}

--- a/src/main/java/org/springframework/data/couchbase/core/WithDurability.java
+++ b/src/main/java/org/springframework/data/couchbase/core/WithDurability.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2020 the original author or authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.couchbase.core;
+
+import com.couchbase.client.core.msg.kv.DurabilityLevel;
+import com.couchbase.client.java.kv.PersistTo;
+import com.couchbase.client.java.kv.ReplicateTo;
+
+/**
+ * A common interface for all of Insert, Replace, Upsert that take Durability
+ *
+ * @author Michael Reiche
+ * @param <T> - the entity class
+ */
+public interface WithDurability<T> {
+	Object withDurability(DurabilityLevel durabilityLevel);
+
+	Object withDurability(PersistTo persistTo, ReplicateTo replicateTo);
+}

--- a/src/main/java/org/springframework/data/couchbase/core/WithExpiry.java
+++ b/src/main/java/org/springframework/data/couchbase/core/WithExpiry.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2020 the original author or authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.couchbase.core;
+
+import java.time.Duration;
+
+/**
+ * A common interface for all of Insert, Replace, Upsert that take expiry
+ *
+ * @author Michael Reiche
+ * @param <T> - the entity class
+ */
+public interface WithExpiry<T> {
+	Object withExpiry(Duration expiry);
+}

--- a/src/test/java/org/springframework/data/couchbase/domain/UserAnnotated2.java
+++ b/src/test/java/org/springframework/data/couchbase/domain/UserAnnotated2.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2020 the original author or authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.data.couchbase.domain;
+
+import java.util.concurrent.TimeUnit;
+
+import org.springframework.data.couchbase.core.mapping.Document;
+
+/**
+ * Annotated User entity for tests
+ *
+ * @author Michael Reiche
+ */
+
+@Document(expiryExpression = "${myExpiryExpression}", expiryUnit = TimeUnit.SECONDS)
+public class UserAnnotated2 extends User {
+	static {
+		System.setProperty("myExpiryExpression", "2");
+	}
+
+	public UserAnnotated2(String id, String firstname, String lastname) {
+		super(id, firstname, lastname);
+	}
+}


### PR DESCRIPTION
This is the same as the earlier DATACOUCH-645, but with the expiryExpression bug-fix and tests removed.

Added interfaces for apis on core objects which are common among
many objects. For instance withExpiry and withExpiryAnnotation on all the
insert/replace/upsert/remove objects.  The definition of an interface
simplifies testing of all the possible combinations - instead of having
four (or eight, counting Reactive), there is one interface to test
them all.

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATACOUCH).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [-] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
