### PR TITLE
DATACOUCH-652 - Inject translation service bean in CouchbaseTemplateSupport.

### DIFF
--- a/src/main/java/org/springframework/data/couchbase/config/AbstractCouchbaseConfiguration.java
+++ b/src/main/java/org/springframework/data/couchbase/config/AbstractCouchbaseConfiguration.java
@@ -62,6 +62,7 @@ import com.couchbase.client.java.json.JacksonTransformers;
  * @author Simon Baslé
  * @author Stephane Nicoll
  * @author Subhashni Balakrishnan
+ * @author Jorge Rodriguez Martin
  */
 @Configuration
 public abstract class AbstractCouchbaseConfiguration {
@@ -146,14 +147,26 @@ public abstract class AbstractCouchbaseConfiguration {
 
 	@Bean(name = BeanNames.COUCHBASE_TEMPLATE)
 	public CouchbaseTemplate couchbaseTemplate(CouchbaseClientFactory couchbaseClientFactory,
+			MappingCouchbaseConverter mappingCouchbaseConverter, TranslationService couchbaseTranslationService) {
+		return new CouchbaseTemplate(couchbaseClientFactory, mappingCouchbaseConverter, couchbaseTranslationService);
+	}
+
+	public CouchbaseTemplate couchbaseTemplate(CouchbaseClientFactory couchbaseClientFactory,
 			MappingCouchbaseConverter mappingCouchbaseConverter) {
-		return new CouchbaseTemplate(couchbaseClientFactory, mappingCouchbaseConverter);
+		return couchbaseTemplate(couchbaseClientFactory, mappingCouchbaseConverter, new JacksonTranslationService());
 	}
 
 	@Bean(name = BeanNames.REACTIVE_COUCHBASE_TEMPLATE)
 	public ReactiveCouchbaseTemplate reactiveCouchbaseTemplate(CouchbaseClientFactory couchbaseClientFactory,
+			MappingCouchbaseConverter mappingCouchbaseConverter, TranslationService couchbaseTranslationService) {
+		return new ReactiveCouchbaseTemplate(couchbaseClientFactory, mappingCouchbaseConverter,
+				couchbaseTranslationService);
+	}
+
+	public ReactiveCouchbaseTemplate reactiveCouchbaseTemplate(CouchbaseClientFactory couchbaseClientFactory,
 			MappingCouchbaseConverter mappingCouchbaseConverter) {
-		return new ReactiveCouchbaseTemplate(couchbaseClientFactory, mappingCouchbaseConverter);
+		return reactiveCouchbaseTemplate(couchbaseClientFactory, mappingCouchbaseConverter,
+				new JacksonTranslationService());
 	}
 
 	@Bean(name = BeanNames.COUCHBASE_OPERATIONS_MAPPING)

--- a/src/main/java/org/springframework/data/couchbase/core/CouchbaseTemplate.java
+++ b/src/main/java/org/springframework/data/couchbase/core/CouchbaseTemplate.java
@@ -21,6 +21,8 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
 import org.springframework.data.couchbase.CouchbaseClientFactory;
 import org.springframework.data.couchbase.core.convert.CouchbaseConverter;
+import org.springframework.data.couchbase.core.convert.translation.JacksonTranslationService;
+import org.springframework.data.couchbase.core.convert.translation.TranslationService;
 
 import com.couchbase.client.java.Collection;
 
@@ -30,6 +32,7 @@ import com.couchbase.client.java.Collection;
  * @author Michael Nitschinger
  * @author Michael Reiche
  * @author Aaron Whiteside
+ * @author Jorge Rodriguez Martin
  * @since 3.0
  */
 public class CouchbaseTemplate implements CouchbaseOperations, ApplicationContextAware {
@@ -40,10 +43,15 @@ public class CouchbaseTemplate implements CouchbaseOperations, ApplicationContex
 	private final ReactiveCouchbaseTemplate reactiveCouchbaseTemplate;
 
 	public CouchbaseTemplate(final CouchbaseClientFactory clientFactory, final CouchbaseConverter converter) {
+		this(clientFactory, converter, new JacksonTranslationService());
+	}
+
+	public CouchbaseTemplate(final CouchbaseClientFactory clientFactory, final CouchbaseConverter converter,
+		final TranslationService translationService) {
 		this.clientFactory = clientFactory;
 		this.converter = converter;
-		this.templateSupport = new CouchbaseTemplateSupport(converter);
-		this.reactiveCouchbaseTemplate = new ReactiveCouchbaseTemplate(clientFactory, converter);
+		this.templateSupport = new CouchbaseTemplateSupport(converter, translationService);
+		this.reactiveCouchbaseTemplate = new ReactiveCouchbaseTemplate(clientFactory, converter, translationService);
 	}
 
 	@Override

--- a/src/main/java/org/springframework/data/couchbase/core/CouchbaseTemplateSupport.java
+++ b/src/main/java/org/springframework/data/couchbase/core/CouchbaseTemplateSupport.java
@@ -16,13 +16,10 @@
 
 package org.springframework.data.couchbase.core;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.BeansException;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
 import org.springframework.data.couchbase.core.convert.CouchbaseConverter;
-import org.springframework.data.couchbase.core.convert.translation.JacksonTranslationService;
 import org.springframework.data.couchbase.core.convert.translation.TranslationService;
 import org.springframework.data.couchbase.core.mapping.CouchbaseDocument;
 import org.springframework.data.couchbase.core.mapping.CouchbasePersistentEntity;
@@ -39,11 +36,15 @@ import org.springframework.data.mapping.context.MappingContext;
 import org.springframework.data.mapping.model.ConvertingPropertyAccessor;
 import org.springframework.util.Assert;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /**
  * Internal encode/decode support for CouchbaseTemplate.
  *
  * @author Michael Nitschinger
  * @author Michael Reiche
+ * @author Jorge Rodriguez Martin
  * @since 3.0
  */
 class CouchbaseTemplateSupport implements ApplicationContextAware {
@@ -56,10 +57,10 @@ class CouchbaseTemplateSupport implements ApplicationContextAware {
 	private EntityCallbacks entityCallbacks;
 	private ApplicationContext applicationContext;
 
-	public CouchbaseTemplateSupport(final CouchbaseConverter converter) {
+	public CouchbaseTemplateSupport(final CouchbaseConverter converter, final TranslationService translationService) {
 		this.converter = converter;
 		this.mappingContext = converter.getMappingContext();
-		this.translationService = new JacksonTranslationService();
+		this.translationService = translationService;
 	}
 
 	public CouchbaseDocument encodeEntity(final Object entityToEncode) {

--- a/src/main/java/org/springframework/data/couchbase/core/ReactiveCouchbaseTemplate.java
+++ b/src/main/java/org/springframework/data/couchbase/core/ReactiveCouchbaseTemplate.java
@@ -23,6 +23,8 @@ import org.springframework.dao.DataAccessException;
 import org.springframework.dao.support.PersistenceExceptionTranslator;
 import org.springframework.data.couchbase.CouchbaseClientFactory;
 import org.springframework.data.couchbase.core.convert.CouchbaseConverter;
+import org.springframework.data.couchbase.core.convert.translation.JacksonTranslationService;
+import org.springframework.data.couchbase.core.convert.translation.TranslationService;
 
 import com.couchbase.client.java.Collection;
 
@@ -31,6 +33,7 @@ import com.couchbase.client.java.Collection;
  *
  * @author Michael Nitschinger
  * @author Michael Reiche
+ * @author Jorge Rodriguez Martin
  */
 public class ReactiveCouchbaseTemplate implements ReactiveCouchbaseOperations, ApplicationContextAware {
 
@@ -40,10 +43,15 @@ public class ReactiveCouchbaseTemplate implements ReactiveCouchbaseOperations, A
 	private final CouchbaseTemplateSupport templateSupport;
 
 	public ReactiveCouchbaseTemplate(final CouchbaseClientFactory clientFactory, final CouchbaseConverter converter) {
+		this(clientFactory, converter, new JacksonTranslationService());
+	}
+
+	public ReactiveCouchbaseTemplate(final CouchbaseClientFactory clientFactory, final CouchbaseConverter converter,
+		final TranslationService translationService) {
 		this.clientFactory = clientFactory;
 		this.converter = converter;
 		this.exceptionTranslator = clientFactory.getExceptionTranslator();
-		this.templateSupport = new CouchbaseTemplateSupport(converter);
+		this.templateSupport = new CouchbaseTemplateSupport(converter, translationService);
 	}
 
 	@Override

--- a/src/test/java/org/springframework/data/couchbase/domain/Config.java
+++ b/src/test/java/org/springframework/data/couchbase/domain/Config.java
@@ -43,6 +43,7 @@ import com.couchbase.client.java.json.JacksonTransformers;
 /**
  * @author Michael Nitschinger
  * @author Michael Reiche
+ * @author Jorge Rodriguez Martin
  * @since 3.0
  */
 @Configuration


### PR DESCRIPTION
[DATACOUCH-652](https://jira.spring.io/projects/DATACOUCH/issues/DATACOUCH-652)

TranslationService is defined as bean but in CouchbaseTemplateSupport. 
That bean is not being used and a new instance of JacksonTranslationSerivce is being created in the constructor.

We want CouchbaseTemplateSupport to receive a TranslationService type bean.


- [X] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [X] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATACOUCH).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
