### PR TITLE
Datacouch 550 autoindex not working in spring boot app

### DIFF
--- a/src/main/java/org/springframework/data/couchbase/core/CouchbaseTemplate.java
+++ b/src/main/java/org/springframework/data/couchbase/core/CouchbaseTemplate.java
@@ -166,6 +166,10 @@ public class CouchbaseTemplate implements CouchbaseOperations, ApplicationContex
 
 		if (context instanceof ConfigurableApplicationContext && indexCreator != null) {
 			((ConfigurableApplicationContext) context).addApplicationListener(indexCreator);
+			if (mappingContext instanceof CouchbaseMappingContext) {
+				CouchbaseMappingContext cmc = (CouchbaseMappingContext) mappingContext;
+				cmc.setIndexCreator(indexCreator);
+			}
 		}
 	}
 }

--- a/src/main/java/org/springframework/data/couchbase/core/index/CouchbasePersistentEntityIndexCreator.java
+++ b/src/main/java/org/springframework/data/couchbase/core/index/CouchbasePersistentEntityIndexCreator.java
@@ -121,4 +121,7 @@ public class CouchbasePersistentEntityIndexCreator implements ApplicationListene
 		return this.mappingContext.equals(context);
 	}
 
+	public boolean hasSeen(CouchbasePersistentEntity<?> entity) {
+		return classesSeen.containsKey(entity.getType());
+	}
 }


### PR DESCRIPTION
This needs some discussion as to whether or not we want to support this.
I created the branch to capture the debugging and changes I had made
earlier when Denis asked me to investigate this issue.
Mark Paluch has indicated this is maybe not a good idea.

Due to the interdependencies of beans, autoindexing does not work
in the startup of a normal spring-boot application. Processing of
entities occurs during the initialization of CouchbaseMappinContext,
which occurs before initialization of MappingCouchbaseConverter,
which occurs before the initialization of CouchbaseTemplate -
which creates the indexCreator listener. So when the
AbstractMappingContext (CouchbaseMappingContext) is publishing
MappingContextEvents - there is not yet any indexCreator.
And subsequent processing of entities finds the entities cached,
and therefore does not publish MappingContextEvents. This change
overrides the addPersistentEntity() and getPersistentEntity()
methods of AbstractMappingContext such that caching does not
preven the MappingContextEvents from being published.  This change
also exposes indexCreator classesSeen map to CouchbaseMappingContext
so that once an entity has been processed by indexCreator, it is
not published again.

Autoindexing by SpringJUnitConfig did work prior to this change.

There is no test case as our automated testing does not create a spring-boot app.
- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATACOUCH).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [-] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
