### PR TITLE
DATACOUCH-550 - Refactored the usage of CouchbasePersistentEntityIndexCreator

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -150,9 +150,9 @@
         </dependency>
 
         <dependency>
-            <groupId>com.github.Couchbase</groupId>
+            <groupId>com.couchbase.mock</groupId>
             <artifactId>CouchbaseMock</artifactId>
-            <version>73e493d259</version>
+            <version>1.5.25</version>
             <scope>test</scope>
         </dependency>
 

--- a/src/main/java/org/springframework/data/couchbase/config/AbstractCouchbaseConfiguration.java
+++ b/src/main/java/org/springframework/data/couchbase/config/AbstractCouchbaseConfiguration.java
@@ -37,6 +37,7 @@ import org.springframework.data.couchbase.core.convert.CouchbaseCustomConversion
 import org.springframework.data.couchbase.core.convert.MappingCouchbaseConverter;
 import org.springframework.data.couchbase.core.convert.translation.JacksonTranslationService;
 import org.springframework.data.couchbase.core.convert.translation.TranslationService;
+import org.springframework.data.couchbase.core.index.CouchbasePersistentEntityIndexCreator;
 import org.springframework.data.couchbase.core.mapping.CouchbaseMappingContext;
 import org.springframework.data.couchbase.core.mapping.Document;
 import org.springframework.data.couchbase.repository.config.ReactiveRepositoryOperationsMapping;
@@ -268,7 +269,6 @@ public abstract class AbstractCouchbaseConfiguration {
 		mappingContext.setInitialEntitySet(getInitialEntitySet());
 		mappingContext.setSimpleTypeHolder(customConversions.getSimpleTypeHolder());
 		mappingContext.setFieldNamingStrategy(fieldNamingStrategy());
-		mappingContext.setAutoIndexCreation(autoIndexCreation());
 
 		return mappingContext;
 	}
@@ -278,6 +278,18 @@ public abstract class AbstractCouchbaseConfiguration {
 	 */
 	protected boolean autoIndexCreation() {
 		return false;
+	}
+
+	/**
+	 * Creates a {@link CouchbasePersistentEntityIndexCreator} bean that takes on the responsibility of automatically
+	 * creating indices.
+	 *
+	 * Does nothing if {@link #autoIndexCreation()} returns false.
+	 */
+	@Bean
+	public CouchbasePersistentEntityIndexCreator couchbasePersistentEntityIndexCreator(CouchbaseMappingContext couchbaseMappingContext,
+   			CouchbaseClientFactory clientFactory) {
+		return new CouchbasePersistentEntityIndexCreator(couchbaseMappingContext, clientFactory, typeKey(), autoIndexCreation());
 	}
 
 	/**

--- a/src/main/java/org/springframework/data/couchbase/core/index/CouchbasePersistentEntityIndexResolver.java
+++ b/src/main/java/org/springframework/data/couchbase/core/index/CouchbasePersistentEntityIndexResolver.java
@@ -20,7 +20,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import org.springframework.data.couchbase.core.CouchbaseOperations;
 import org.springframework.data.couchbase.core.mapping.CouchbasePersistentEntity;
 import org.springframework.data.couchbase.core.mapping.CouchbasePersistentProperty;
 import org.springframework.data.couchbase.core.mapping.Document;
@@ -35,13 +34,13 @@ import org.springframework.util.StringUtils;
 public class CouchbasePersistentEntityIndexResolver implements QueryIndexResolver {
 
 	private final MappingContext<? extends CouchbasePersistentEntity<?>, CouchbasePersistentProperty> mappingContext;
-	private final CouchbaseOperations operations;
+	private final String typeKey;
 
 	public CouchbasePersistentEntityIndexResolver(
 			final MappingContext<? extends CouchbasePersistentEntity<?>, CouchbasePersistentProperty> mappingContext,
-			CouchbaseOperations operations) {
+			final String typeKey) {
 		this.mappingContext = mappingContext;
-		this.operations = operations;
+		this.typeKey = typeKey;
 	}
 
 	@Override
@@ -135,7 +134,6 @@ public class CouchbasePersistentEntityIndexResolver implements QueryIndexResolve
 	}
 
 	private String getPredicate(final MappingCouchbaseEntityInformation<?, Object> entityInfo) {
-		String typeKey = operations.getConverter().getTypeKey();
 		String typeValue = entityInfo.getJavaType().getName();
 		return "`" + typeKey + "` = \"" + typeValue + "\"";
 	}

--- a/src/main/java/org/springframework/data/couchbase/core/index/QueryIndexResolver.java
+++ b/src/main/java/org/springframework/data/couchbase/core/index/QueryIndexResolver.java
@@ -15,7 +15,6 @@
  */
 package org.springframework.data.couchbase.core.index;
 
-import org.springframework.data.couchbase.core.CouchbaseOperations;
 import org.springframework.data.couchbase.core.mapping.CouchbaseMappingContext;
 import org.springframework.data.couchbase.core.mapping.CouchbasePersistentEntity;
 import org.springframework.data.couchbase.core.mapping.CouchbasePersistentProperty;
@@ -43,9 +42,9 @@ public interface QueryIndexResolver {
 	 */
 	static QueryIndexResolver create(
 			MappingContext<? extends CouchbasePersistentEntity<?>, CouchbasePersistentProperty> mappingContext,
-			CouchbaseOperations operations) {
+			String typeKey) {
 		Assert.notNull(mappingContext, "CouchbaseMappingContext must not be null!");
-		return new CouchbasePersistentEntityIndexResolver(mappingContext, operations);
+		return new CouchbasePersistentEntityIndexResolver(mappingContext, typeKey);
 	}
 
 	/**


### PR DESCRIPTION
pom.xml
- updated CouchbaseMock dependency to the official release on maven central, which now includes the required commit.

CouchbaseTemplate.java
- remove creation of CouchbasePersistentEntityIndexCreator
- there can only be a single CouchbaseMappingContext and CouchbasePersistentEntityIndexCreator, not sure why there was code dealing with multiples of each, and there was no corresponding tests for these assumptions.
- no longer does the job of a @Configuation class by gluing beans together with their dependencies.

CouchbaseMappingContext.java
- removed references to auto index creation, that functionality should be a completely separate concern.

CouchbasePersistentEntityIndexCreator.java
- as well as implementing ApplicationListener, it now also implements InitializingBean
- when afterPropertiesSet() is called it uses CouchbaseMappingContext#getPersistentEntities to retrieve the list of entity candidates for index creation. This will handle the creation of indices for entities known at @configuration time.
- for entities not in the initialEntitySet of the MappingContext, the ApplicationListener will handle those entities at runtime.
- this is needed because the AbstractMappingContext will emit events when it is initialized via InitializingBean, and any beans that depend on MappingContext and also implement ApplicationListener expecting to receive those events won't.
 - in our case because Spring will have fully initialised the CouchbaseMappingContext instance before passing it to the CouchbasePersistentEntityIndexCreator instance we won't get those events.
- added a boolean flag to indicate if automatic index creation is to be enabled or now, passed in by the factory method that creates this bean.
- minor logging cleanup, use property placeholders where appropriate

AbstractCouchbaseConfiguration.java
- added a new factory method for the CouchbasePersistentEntityIndexCreator bean.
- CouchbaseMappingContext no longer has anything to do with index creation, other than supplying a candidate list of entities that may need indices.

Prompted by:
spring-projects/spring-boot#24525
and the discussion on #295