### PR TITLE
DATACOUCH-588 - Part 2 of framework changes. Add support for projecti…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -197,6 +197,14 @@
             <version>${kotlin}</version>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <version>4.0.3</version>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
     <repositories>

--- a/src/main/java/org/springframework/data/couchbase/core/ExecutableExistsByIdOperation.java
+++ b/src/main/java/org/springframework/data/couchbase/core/ExecutableExistsByIdOperation.java
@@ -18,6 +18,9 @@ package org.springframework.data.couchbase.core;
 import java.util.Collection;
 import java.util.Map;
 
+import org.springframework.data.couchbase.core.support.OneAndAllExists;
+import org.springframework.data.couchbase.core.support.WithCollection;
+
 public interface ExecutableExistsByIdOperation {
 
 	/**
@@ -25,7 +28,7 @@ public interface ExecutableExistsByIdOperation {
 	 */
 	ExecutableExistsById existsById();
 
-	interface TerminatingExistsById {
+	interface TerminatingExistsById extends OneAndAllExists {
 
 		/**
 		 * Performs the operation on the ID given.
@@ -45,7 +48,7 @@ public interface ExecutableExistsByIdOperation {
 
 	}
 
-	interface ExistsByIdWithCollection extends TerminatingExistsById {
+	interface ExistsByIdWithCollection extends TerminatingExistsById, WithCollection {
 
 		/**
 		 * Allows to specify a different collection than the default one configured.

--- a/src/main/java/org/springframework/data/couchbase/core/ExecutableFindByAnalyticsOperation.java
+++ b/src/main/java/org/springframework/data/couchbase/core/ExecutableFindByAnalyticsOperation.java
@@ -19,11 +19,14 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
 
-import com.couchbase.client.java.analytics.AnalyticsScanConsistency;
-import com.couchbase.client.java.query.QueryScanConsistency;
 import org.springframework.dao.IncorrectResultSizeDataAccessException;
 import org.springframework.data.couchbase.core.query.AnalyticsQuery;
+import org.springframework.data.couchbase.core.support.OneAndAll;
+import org.springframework.data.couchbase.core.support.WithAnalyticsConsistency;
+import org.springframework.data.couchbase.core.support.WithAnalyticsQuery;
 import org.springframework.lang.Nullable;
+
+import com.couchbase.client.java.analytics.AnalyticsScanConsistency;
 
 public interface ExecutableFindByAnalyticsOperation {
 
@@ -34,7 +37,7 @@ public interface ExecutableFindByAnalyticsOperation {
 	 */
 	<T> ExecutableFindByAnalytics<T> findByAnalytics(Class<T> domainType);
 
-	interface TerminatingFindByAnalytics<T> {
+	interface TerminatingFindByAnalytics<T> extends OneAndAll<T> {
 
 		/**
 		 * Get exactly zero or one result.
@@ -102,7 +105,7 @@ public interface ExecutableFindByAnalyticsOperation {
 
 	}
 
-	interface FindByAnalyticsWithQuery<T> extends TerminatingFindByAnalytics<T> {
+	interface FindByAnalyticsWithQuery<T> extends TerminatingFindByAnalytics<T>, WithAnalyticsQuery<T> {
 
 		/**
 		 * Set the filter for the analytics query to be used.
@@ -114,6 +117,7 @@ public interface ExecutableFindByAnalyticsOperation {
 
 	}
 
+	@Deprecated
 	interface FindByAnalyticsConsistentWith<T> extends FindByAnalyticsWithQuery<T> {
 
 		/**
@@ -121,10 +125,22 @@ public interface ExecutableFindByAnalyticsOperation {
 		 *
 		 * @param scanConsistency the custom scan consistency to use for this analytics query.
 		 */
+		@Deprecated
 		FindByAnalyticsWithQuery<T> consistentWith(AnalyticsScanConsistency scanConsistency);
 
 	}
 
-	interface ExecutableFindByAnalytics<T> extends FindByAnalyticsConsistentWith<T> {}
+	interface FindByAnalyticsWithConsistency<T> extends FindByAnalyticsConsistentWith<T>, WithAnalyticsConsistency<T> {
+
+		/**
+		 * Allows to override the default scan consistency.
+		 *
+		 * @param scanConsistency the custom scan consistency to use for this analytics query.
+		 */
+		FindByAnalyticsConsistentWith<T> withConsistency(AnalyticsScanConsistency scanConsistency);
+
+	}
+
+	interface ExecutableFindByAnalytics<T> extends FindByAnalyticsWithConsistency<T> {}
 
 }

--- a/src/main/java/org/springframework/data/couchbase/core/ExecutableFindByAnalyticsOperationSupport.java
+++ b/src/main/java/org/springframework/data/couchbase/core/ExecutableFindByAnalyticsOperationSupport.java
@@ -15,11 +15,10 @@
  */
 package org.springframework.data.couchbase.core;
 
-import org.springframework.data.couchbase.core.ReactiveFindByAnalyticsOperationSupport.ReactiveFindByAnalyticsSupport;
-
 import java.util.List;
 import java.util.stream.Stream;
 
+import org.springframework.data.couchbase.core.ReactiveFindByAnalyticsOperationSupport.ReactiveFindByAnalyticsSupport;
 import org.springframework.data.couchbase.core.query.AnalyticsQuery;
 
 import com.couchbase.client.java.analytics.AnalyticsScanConsistency;
@@ -79,7 +78,13 @@ public class ExecutableFindByAnalyticsOperationSupport implements ExecutableFind
 		}
 
 		@Override
+		@Deprecated
 		public FindByAnalyticsWithQuery<T> consistentWith(final AnalyticsScanConsistency scanConsistency) {
+			return new ExecutableFindByAnalyticsSupport<>(template, domainType, query, scanConsistency);
+		}
+
+		@Override
+		public FindByAnalyticsWithConsistency<T> withConsistency(final AnalyticsScanConsistency scanConsistency) {
 			return new ExecutableFindByAnalyticsSupport<>(template, domainType, query, scanConsistency);
 		}
 

--- a/src/main/java/org/springframework/data/couchbase/core/ExecutableFindByIdOperation.java
+++ b/src/main/java/org/springframework/data/couchbase/core/ExecutableFindByIdOperation.java
@@ -17,6 +17,10 @@ package org.springframework.data.couchbase.core;
 
 import java.util.Collection;
 
+import org.springframework.data.couchbase.core.support.OneAndAllId;
+import org.springframework.data.couchbase.core.support.WithCollection;
+import org.springframework.data.couchbase.core.support.WithProjectionId;
+
 public interface ExecutableFindByIdOperation {
 
 	/**
@@ -26,7 +30,7 @@ public interface ExecutableFindByIdOperation {
 	 */
 	<T> ExecutableFindById<T> findById(Class<T> domainType);
 
-	interface TerminatingFindById<T> {
+	interface TerminatingFindById<T> extends OneAndAllId<T> {
 
 		/**
 		 * Finds one document based on the given ID.
@@ -46,7 +50,7 @@ public interface ExecutableFindByIdOperation {
 
 	}
 
-	interface FindByIdWithCollection<T> extends TerminatingFindById<T> {
+	interface FindByIdWithCollection<T> extends TerminatingFindById<T>, WithCollection<T> {
 
 		/**
 		 * Allows to specify a different collection than the default one configured.
@@ -57,7 +61,7 @@ public interface ExecutableFindByIdOperation {
 
 	}
 
-	interface FindByIdWithProjection<T> extends FindByIdWithCollection<T> {
+	interface FindByIdWithProjection<T> extends FindByIdWithCollection<T>, WithProjectionId<T> {
 
 		/**
 		 * Load only certain fields for the document.

--- a/src/main/java/org/springframework/data/couchbase/core/ExecutableFindByIdOperationSupport.java
+++ b/src/main/java/org/springframework/data/couchbase/core/ExecutableFindByIdOperationSupport.java
@@ -15,12 +15,11 @@
  */
 package org.springframework.data.couchbase.core;
 
-import org.springframework.data.couchbase.core.ReactiveFindByIdOperationSupport.ReactiveFindByIdSupport;
-
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 
+import org.springframework.data.couchbase.core.ReactiveFindByIdOperationSupport.ReactiveFindByIdSupport;
 import org.springframework.util.Assert;
 
 public class ExecutableFindByIdOperationSupport implements ExecutableFindByIdOperation {

--- a/src/main/java/org/springframework/data/couchbase/core/ExecutableFindFromReplicasByIdOperation.java
+++ b/src/main/java/org/springframework/data/couchbase/core/ExecutableFindFromReplicasByIdOperation.java
@@ -17,11 +17,14 @@ package org.springframework.data.couchbase.core;
 
 import java.util.Collection;
 
+import org.springframework.data.couchbase.core.support.AnyId;
+import org.springframework.data.couchbase.core.support.WithCollection;
+
 public interface ExecutableFindFromReplicasByIdOperation {
 
 	<T> ExecutableFindFromReplicasById<T> findFromReplicasById(Class<T> domainType);
 
-	interface TerminatingFindFromReplicasById<T> {
+	interface TerminatingFindFromReplicasById<T> extends AnyId<T> {
 
 		T any(String id);
 
@@ -29,7 +32,7 @@ public interface ExecutableFindFromReplicasByIdOperation {
 
 	}
 
-	interface FindFromReplicasByIdWithCollection<T> extends TerminatingFindFromReplicasById<T> {
+	interface FindFromReplicasByIdWithCollection<T> extends TerminatingFindFromReplicasById<T>, WithCollection<T> {
 
 		TerminatingFindFromReplicasById<T> inCollection(String collection);
 	}

--- a/src/main/java/org/springframework/data/couchbase/core/ExecutableFindFromReplicasByIdOperationSupport.java
+++ b/src/main/java/org/springframework/data/couchbase/core/ExecutableFindFromReplicasByIdOperationSupport.java
@@ -30,21 +30,25 @@ public class ExecutableFindFromReplicasByIdOperationSupport implements Executabl
 
 	@Override
 	public <T> ExecutableFindFromReplicasById<T> findFromReplicasById(Class<T> domainType) {
-		return new ExecutableFindFromReplicasByIdSupport<>(template, domainType, null);
+		return new ExecutableFindFromReplicasByIdSupport<>(template, domainType, domainType, null);
 	}
 
 	static class ExecutableFindFromReplicasByIdSupport<T> implements ExecutableFindFromReplicasById<T> {
 
 		private final CouchbaseTemplate template;
-		private final Class<T> domainType;
+		private final Class<?> domainType;
+		private final Class<T> returnType;
 		private final String collection;
 		private final ReactiveFindFromReplicasByIdSupport<T> reactiveSupport;
 
-		ExecutableFindFromReplicasByIdSupport(CouchbaseTemplate template, Class<T> domainType, String collection) {
+		ExecutableFindFromReplicasByIdSupport(CouchbaseTemplate template, Class<?> domainType, Class<T> returnType,
+				String collection) {
 			this.template = template;
 			this.domainType = domainType;
 			this.collection = collection;
-			this.reactiveSupport = new ReactiveFindFromReplicasByIdSupport<>(template.reactive(), domainType, collection);
+			this.returnType = returnType;
+			this.reactiveSupport = new ReactiveFindFromReplicasByIdSupport<>(template.reactive(), domainType, returnType,
+					collection);
 		}
 
 		@Override
@@ -60,7 +64,7 @@ public class ExecutableFindFromReplicasByIdOperationSupport implements Executabl
 		@Override
 		public TerminatingFindFromReplicasById<T> inCollection(final String collection) {
 			Assert.hasText(collection, "Collection must not be null nor empty.");
-			return new ExecutableFindFromReplicasByIdSupport<>(template, domainType, collection);
+			return new ExecutableFindFromReplicasByIdSupport<>(template, domainType, returnType, collection);
 		}
 
 	}

--- a/src/main/java/org/springframework/data/couchbase/core/ExecutableInsertByIdOperation.java
+++ b/src/main/java/org/springframework/data/couchbase/core/ExecutableInsertByIdOperation.java
@@ -18,6 +18,9 @@ package org.springframework.data.couchbase.core;
 import java.time.Duration;
 import java.util.Collection;
 
+import org.springframework.data.couchbase.core.support.OneAndAllEntity;
+import org.springframework.data.couchbase.core.support.WithCollection;
+
 import com.couchbase.client.core.msg.kv.DurabilityLevel;
 import com.couchbase.client.java.kv.PersistTo;
 import com.couchbase.client.java.kv.ReplicateTo;
@@ -26,7 +29,7 @@ public interface ExecutableInsertByIdOperation {
 
 	<T> ExecutableInsertById<T> insertById(Class<T> domainType);
 
-	interface TerminatingInsertById<T> extends OneAndAll<T>{
+	interface TerminatingInsertById<T> extends OneAndAllEntity<T> {
 
 		@Override
 		T one(T object);
@@ -36,7 +39,7 @@ public interface ExecutableInsertByIdOperation {
 
 	}
 
-	interface InsertByIdWithCollection<T> extends TerminatingInsertById<T>, InCollection<T> {
+	interface InsertByIdWithCollection<T> extends TerminatingInsertById<T>, WithCollection<T> {
 
 		TerminatingInsertById<T> inCollection(String collection);
 	}

--- a/src/main/java/org/springframework/data/couchbase/core/ExecutableRemoveByIdOperation.java
+++ b/src/main/java/org/springframework/data/couchbase/core/ExecutableRemoveByIdOperation.java
@@ -18,6 +18,9 @@ package org.springframework.data.couchbase.core;
 import java.util.Collection;
 import java.util.List;
 
+import org.springframework.data.couchbase.core.support.OneAndAllId;
+import org.springframework.data.couchbase.core.support.WithCollection;
+
 import com.couchbase.client.core.msg.kv.DurabilityLevel;
 import com.couchbase.client.java.kv.PersistTo;
 import com.couchbase.client.java.kv.ReplicateTo;
@@ -26,7 +29,7 @@ public interface ExecutableRemoveByIdOperation {
 
 	ExecutableRemoveById removeById();
 
-	interface TerminatingRemoveById {
+	interface TerminatingRemoveById extends OneAndAllId<RemoveResult> {
 
 		RemoveResult one(String id);
 
@@ -34,12 +37,12 @@ public interface ExecutableRemoveByIdOperation {
 
 	}
 
-	interface RemoveByIdWithCollection extends TerminatingRemoveById, InCollection {
+	interface RemoveByIdWithCollection extends TerminatingRemoveById, WithCollection<RemoveResult> {
 
 		TerminatingRemoveById inCollection(String collection);
 	}
 
-	interface RemoveByIdWithDurability extends RemoveByIdWithCollection, WithDurability {
+	interface RemoveByIdWithDurability extends RemoveByIdWithCollection, WithDurability<RemoveResult> {
 
 		RemoveByIdWithCollection withDurability(DurabilityLevel durabilityLevel);
 

--- a/src/main/java/org/springframework/data/couchbase/core/ExecutableRemoveByQueryOperation.java
+++ b/src/main/java/org/springframework/data/couchbase/core/ExecutableRemoveByQueryOperation.java
@@ -18,6 +18,10 @@ package org.springframework.data.couchbase.core;
 import java.util.List;
 
 import org.springframework.data.couchbase.core.query.Query;
+import org.springframework.data.couchbase.core.query.QueryCriteriaDefinition;
+import org.springframework.data.couchbase.core.support.WithCollection;
+import org.springframework.data.couchbase.core.support.WithConsistency;
+import org.springframework.data.couchbase.core.support.WithQuery;
 
 import com.couchbase.client.java.query.QueryScanConsistency;
 
@@ -31,24 +35,36 @@ public interface ExecutableRemoveByQueryOperation {
 
 	}
 
-	interface RemoveByQueryWithQuery<T> extends TerminatingRemoveByQuery<T> {
+	interface RemoveByQueryWithQuery<T> extends TerminatingRemoveByQuery<T>, WithQuery<T> {
 
 		TerminatingRemoveByQuery<T> matching(Query query);
 
-	}
-
-	interface RemoveByQueryConsistentWith<T> extends RemoveByQueryWithQuery<T> {
-
-		RemoveByQueryWithQuery<T> consistentWith(QueryScanConsistency scanConsistency);
+		default TerminatingRemoveByQuery<T> matching(QueryCriteriaDefinition criteria) {
+			return matching(Query.query(criteria));
+		}
 
 	}
 
-	interface RemoveByQueryInCollection<T> extends RemoveByQueryConsistentWith<T> {
+	interface RemoveByQueryInCollection<T> extends RemoveByQueryWithQuery<T>, WithCollection<T> {
 
-		RemoveByQueryConsistentWith<T> inCollection(String collection);
+		RemoveByQueryWithQuery<T> inCollection(String collection);
 
 	}
 
-	interface ExecutableRemoveByQuery<T> extends RemoveByQueryInCollection<T> {}
+	@Deprecated
+	interface RemoveByQueryConsistentWith<T> extends RemoveByQueryInCollection<T> {
+
+		@Deprecated
+		RemoveByQueryInCollection<T> consistentWith(QueryScanConsistency scanConsistency);
+
+	}
+
+	interface RemoveByQueryWithConsistency<T> extends RemoveByQueryConsistentWith<T>, WithConsistency<T> {
+
+		RemoveByQueryConsistentWith<T> withConsistency(QueryScanConsistency scanConsistency);
+
+	}
+
+	interface ExecutableRemoveByQuery<T> extends RemoveByQueryWithConsistency<T> {}
 
 }

--- a/src/main/java/org/springframework/data/couchbase/core/ExecutableRemoveByQueryOperationSupport.java
+++ b/src/main/java/org/springframework/data/couchbase/core/ExecutableRemoveByQueryOperationSupport.java
@@ -19,6 +19,7 @@ import java.util.List;
 
 import org.springframework.data.couchbase.core.ReactiveRemoveByQueryOperationSupport.ReactiveRemoveByQuerySupport;
 import org.springframework.data.couchbase.core.query.Query;
+import org.springframework.util.Assert;
 
 import com.couchbase.client.java.query.QueryScanConsistency;
 
@@ -35,7 +36,7 @@ public class ExecutableRemoveByQueryOperationSupport implements ExecutableRemove
 	@Override
 	public <T> ExecutableRemoveByQuery<T> removeByQuery(Class<T> domainType) {
 		return new ExecutableRemoveByQuerySupport<>(template, domainType, ALL_QUERY, QueryScanConsistency.NOT_BOUNDED,
-				"_default._default");
+				null);
 	}
 
 	static class ExecutableRemoveByQuerySupport<T> implements ExecutableRemoveByQuery<T> {
@@ -69,12 +70,19 @@ public class ExecutableRemoveByQueryOperationSupport implements ExecutableRemove
 		}
 
 		@Override
-		public RemoveByQueryWithQuery<T> consistentWith(final QueryScanConsistency scanConsistency) {
+		@Deprecated
+		public RemoveByQueryInCollection<T> consistentWith(final QueryScanConsistency scanConsistency) {
 			return new ExecutableRemoveByQuerySupport<>(template, domainType, query, scanConsistency, collection);
 		}
 
 		@Override
-		public RemoveByQueryInCollection<T> inCollection(final String collection) {
+		public RemoveByQueryConsistentWith<T> withConsistency(final QueryScanConsistency scanConsistency) {
+			return new ExecutableRemoveByQuerySupport<>(template, domainType, query, scanConsistency, collection);
+		}
+
+		@Override
+		public RemoveByQueryWithConsistency<T> inCollection(final String collection) {
+			Assert.hasText(collection, "Collection must not be null nor empty.");
 			return new ExecutableRemoveByQuerySupport<>(template, domainType, query, scanConsistency, collection);
 		}
 

--- a/src/main/java/org/springframework/data/couchbase/core/ExecutableReplaceByIdOperation.java
+++ b/src/main/java/org/springframework/data/couchbase/core/ExecutableReplaceByIdOperation.java
@@ -18,8 +18,10 @@ package org.springframework.data.couchbase.core;
 import java.time.Duration;
 import java.util.Collection;
 
+import org.springframework.data.couchbase.core.support.OneAndAllEntity;
+import org.springframework.data.couchbase.core.support.WithCollection;
+
 import com.couchbase.client.core.msg.kv.DurabilityLevel;
-import com.couchbase.client.java.kv.IncrementOptions;
 import com.couchbase.client.java.kv.PersistTo;
 import com.couchbase.client.java.kv.ReplicateTo;
 
@@ -27,7 +29,7 @@ public interface ExecutableReplaceByIdOperation {
 
 	<T> ExecutableReplaceById<T> replaceById(Class<T> domainType);
 
-	interface TerminatingReplaceById<T> extends OneAndAll<T> {
+	interface TerminatingReplaceById<T> extends OneAndAllEntity<T> {
 
 		@Override
 		T one(T object);
@@ -37,7 +39,7 @@ public interface ExecutableReplaceByIdOperation {
 
 	}
 
-	interface ReplaceByIdWithCollection<T> extends TerminatingReplaceById<T> , InCollection<T> {
+	interface ReplaceByIdWithCollection<T> extends TerminatingReplaceById<T>, WithCollection<T> {
 
 		TerminatingReplaceById<T> inCollection(String collection);
 	}

--- a/src/main/java/org/springframework/data/couchbase/core/ExecutableUpsertByIdOperation.java
+++ b/src/main/java/org/springframework/data/couchbase/core/ExecutableUpsertByIdOperation.java
@@ -18,6 +18,9 @@ package org.springframework.data.couchbase.core;
 import java.time.Duration;
 import java.util.Collection;
 
+import org.springframework.data.couchbase.core.support.OneAndAllEntity;
+import org.springframework.data.couchbase.core.support.WithCollection;
+
 import com.couchbase.client.core.msg.kv.DurabilityLevel;
 import com.couchbase.client.java.kv.PersistTo;
 import com.couchbase.client.java.kv.ReplicateTo;
@@ -26,7 +29,7 @@ public interface ExecutableUpsertByIdOperation {
 
 	<T> ExecutableUpsertById<T> upsertById(Class<T> domainType);
 
-	interface TerminatingUpsertById<T> extends OneAndAll<T>{
+	interface TerminatingUpsertById<T> extends OneAndAllEntity<T> {
 
 		@Override
 		T one(T object);
@@ -36,7 +39,7 @@ public interface ExecutableUpsertByIdOperation {
 
 	}
 
-	interface UpsertByIdWithCollection<T> extends TerminatingUpsertById<T>, InCollection<T> {
+	interface UpsertByIdWithCollection<T> extends TerminatingUpsertById<T>, WithCollection<T> {
 
 		TerminatingUpsertById<T> inCollection(String collection);
 	}

--- a/src/main/java/org/springframework/data/couchbase/core/ReactiveExistsByIdOperation.java
+++ b/src/main/java/org/springframework/data/couchbase/core/ReactiveExistsByIdOperation.java
@@ -20,6 +20,9 @@ import reactor.core.publisher.Mono;
 import java.util.Collection;
 import java.util.Map;
 
+import org.springframework.data.couchbase.core.support.OneAndAllExistsReactive;
+import org.springframework.data.couchbase.core.support.WithCollection;
+
 public interface ReactiveExistsByIdOperation {
 
 	/**
@@ -27,7 +30,7 @@ public interface ReactiveExistsByIdOperation {
 	 */
 	ReactiveExistsById existsById();
 
-	interface TerminatingExistsById {
+	interface TerminatingExistsById extends OneAndAllExistsReactive {
 
 		/**
 		 * Performs the operation on the ID given.
@@ -47,7 +50,7 @@ public interface ReactiveExistsByIdOperation {
 
 	}
 
-	interface ExistsByIdWithCollection extends TerminatingExistsById {
+	interface ExistsByIdWithCollection extends TerminatingExistsById, WithCollection {
 
 		/**
 		 * Allows to specify a different collection than the default one configured.

--- a/src/main/java/org/springframework/data/couchbase/core/ReactiveFindByAnalyticsOperation.java
+++ b/src/main/java/org/springframework/data/couchbase/core/ReactiveFindByAnalyticsOperation.java
@@ -15,14 +15,16 @@
  */
 package org.springframework.data.couchbase.core;
 
-import com.couchbase.client.java.analytics.AnalyticsScanConsistency;
-import org.springframework.dao.IncorrectResultSizeDataAccessException;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
+import org.springframework.dao.IncorrectResultSizeDataAccessException;
 import org.springframework.data.couchbase.core.query.AnalyticsQuery;
+import org.springframework.data.couchbase.core.support.OneAndAllReactive;
+import org.springframework.data.couchbase.core.support.WithAnalyticsConsistency;
+import org.springframework.data.couchbase.core.support.WithAnalyticsQuery;
 
-import java.util.Optional;
+import com.couchbase.client.java.analytics.AnalyticsScanConsistency;
 
 public interface ReactiveFindByAnalyticsOperation {
 
@@ -36,7 +38,7 @@ public interface ReactiveFindByAnalyticsOperation {
 	/**
 	 * Compose find execution by calling one of the terminating methods.
 	 */
-	interface TerminatingFindByAnalytics<T> {
+	interface TerminatingFindByAnalytics<T> extends OneAndAllReactive {
 
 		/**
 		 * Get exactly zero or one result.
@@ -76,7 +78,7 @@ public interface ReactiveFindByAnalyticsOperation {
 
 	}
 
-	interface FindByAnalyticsWithQuery<T> extends TerminatingFindByAnalytics<T> {
+	interface FindByAnalyticsWithQuery<T> extends TerminatingFindByAnalytics<T>, WithAnalyticsQuery<T> {
 
 		/**
 		 * Set the filter for the analytics query to be used.
@@ -88,6 +90,7 @@ public interface ReactiveFindByAnalyticsOperation {
 
 	}
 
+	@Deprecated
 	interface FindByAnalyticsConsistentWith<T> extends FindByAnalyticsWithQuery<T> {
 
 		/**
@@ -95,10 +98,22 @@ public interface ReactiveFindByAnalyticsOperation {
 		 *
 		 * @param scanConsistency the custom scan consistency to use for this analytics query.
 		 */
+		@Deprecated
 		FindByAnalyticsWithQuery<T> consistentWith(AnalyticsScanConsistency scanConsistency);
 
 	}
 
-	interface ReactiveFindByAnalytics<T> extends FindByAnalyticsConsistentWith<T> {}
+	interface FindByAnalyticsWithConsistency<T> extends FindByAnalyticsConsistentWith<T>, WithAnalyticsConsistency<T> {
+
+		/**
+		 * Allows to override the default scan consistency.
+		 *
+		 * @param scanConsistency the custom scan consistency to use for this analytics query.
+		 */
+		FindByAnalyticsWithQuery<T> withConsistency(AnalyticsScanConsistency scanConsistency);
+
+	}
+
+	interface ReactiveFindByAnalytics<T> extends FindByAnalyticsWithConsistency<T> {}
 
 }

--- a/src/main/java/org/springframework/data/couchbase/core/ReactiveFindByAnalyticsOperationSupport.java
+++ b/src/main/java/org/springframework/data/couchbase/core/ReactiveFindByAnalyticsOperationSupport.java
@@ -15,13 +15,13 @@
  */
 package org.springframework.data.couchbase.core;
 
-import com.couchbase.client.java.analytics.AnalyticsOptions;
-import com.couchbase.client.java.analytics.AnalyticsScanConsistency;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import org.springframework.data.couchbase.core.query.AnalyticsQuery;
 
+import com.couchbase.client.java.analytics.AnalyticsOptions;
+import com.couchbase.client.java.analytics.AnalyticsScanConsistency;
 import com.couchbase.client.java.analytics.ReactiveAnalyticsResult;
 
 public class ReactiveFindByAnalyticsOperationSupport implements ReactiveFindByAnalyticsOperation {
@@ -60,7 +60,13 @@ public class ReactiveFindByAnalyticsOperationSupport implements ReactiveFindByAn
 		}
 
 		@Override
+		@Deprecated
 		public FindByAnalyticsWithQuery<T> consistentWith(AnalyticsScanConsistency scanConsistency) {
+			return new ReactiveFindByAnalyticsSupport<>(template, domainType, query, scanConsistency);
+		}
+
+		@Override
+		public FindByAnalyticsWithQuery<T> withConsistency(AnalyticsScanConsistency scanConsistency) {
 			return new ReactiveFindByAnalyticsSupport<>(template, domainType, query, scanConsistency);
 		}
 

--- a/src/main/java/org/springframework/data/couchbase/core/ReactiveFindByIdOperation.java
+++ b/src/main/java/org/springframework/data/couchbase/core/ReactiveFindByIdOperation.java
@@ -20,6 +20,10 @@ import reactor.core.publisher.Mono;
 
 import java.util.Collection;
 
+import org.springframework.data.couchbase.core.support.OneAndAllIdReactive;
+import org.springframework.data.couchbase.core.support.WithCollection;
+import org.springframework.data.couchbase.core.support.WithProjectionId;
+
 public interface ReactiveFindByIdOperation {
 
 	/**
@@ -29,7 +33,7 @@ public interface ReactiveFindByIdOperation {
 	 */
 	<T> ReactiveFindById<T> findById(Class<T> domainType);
 
-	interface TerminatingFindById<T> {
+	interface TerminatingFindById<T> extends OneAndAllIdReactive<T> {
 
 		/**
 		 * Finds one document based on the given ID.
@@ -49,7 +53,7 @@ public interface ReactiveFindByIdOperation {
 
 	}
 
-	interface FindByIdWithCollection<T> extends TerminatingFindById<T> {
+	interface FindByIdWithCollection<T> extends TerminatingFindById<T>, WithCollection<T> {
 
 		/**
 		 * Allows to specify a different collection than the default one configured.
@@ -59,7 +63,7 @@ public interface ReactiveFindByIdOperation {
 		TerminatingFindById<T> inCollection(String collection);
 	}
 
-	interface FindByIdWithProjection<T> extends FindByIdWithCollection<T> {
+	interface FindByIdWithProjection<T> extends FindByIdWithCollection<T>, WithProjectionId<T> {
 
 		/**
 		 * Load only certain fields for the document.

--- a/src/main/java/org/springframework/data/couchbase/core/ReactiveFindByIdOperationSupport.java
+++ b/src/main/java/org/springframework/data/couchbase/core/ReactiveFindByIdOperationSupport.java
@@ -15,9 +15,8 @@
  */
 package org.springframework.data.couchbase.core;
 
-import static com.couchbase.client.java.kv.GetOptions.*;
+import static com.couchbase.client.java.kv.GetOptions.getOptions;
 
-import com.couchbase.client.core.error.DocumentNotFoundException;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
@@ -27,6 +26,7 @@ import java.util.List;
 
 import org.springframework.util.Assert;
 
+import com.couchbase.client.core.error.DocumentNotFoundException;
 import com.couchbase.client.java.codec.RawJsonTranscoder;
 import com.couchbase.client.java.kv.GetOptions;
 

--- a/src/main/java/org/springframework/data/couchbase/core/ReactiveFindFromReplicasByIdOperation.java
+++ b/src/main/java/org/springframework/data/couchbase/core/ReactiveFindFromReplicasByIdOperation.java
@@ -20,11 +20,14 @@ import reactor.core.publisher.Mono;
 
 import java.util.Collection;
 
+import org.springframework.data.couchbase.core.support.AnyIdReactive;
+import org.springframework.data.couchbase.core.support.WithCollection;
+
 public interface ReactiveFindFromReplicasByIdOperation {
 
 	<T> ReactiveFindFromReplicasById<T> findFromReplicasById(Class<T> domainType);
 
-	interface TerminatingFindFromReplicasById<T> {
+	interface TerminatingFindFromReplicasById<T> extends AnyIdReactive<T> {
 
 		Mono<T> any(String id);
 
@@ -32,7 +35,7 @@ public interface ReactiveFindFromReplicasByIdOperation {
 
 	}
 
-	interface FindFromReplicasByIdWithCollection<T> extends TerminatingFindFromReplicasById<T> {
+	interface FindFromReplicasByIdWithCollection<T> extends TerminatingFindFromReplicasById<T>, WithCollection<T> {
 
 		TerminatingFindFromReplicasById<T> inCollection(String collection);
 	}

--- a/src/main/java/org/springframework/data/couchbase/core/ReactiveInsertByIdOperation.java
+++ b/src/main/java/org/springframework/data/couchbase/core/ReactiveInsertByIdOperation.java
@@ -21,6 +21,9 @@ import reactor.core.publisher.Mono;
 import java.time.Duration;
 import java.util.Collection;
 
+import org.springframework.data.couchbase.core.support.OneAndAllEntityReactive;
+import org.springframework.data.couchbase.core.support.WithCollection;
+
 import com.couchbase.client.core.msg.kv.DurabilityLevel;
 import com.couchbase.client.java.kv.PersistTo;
 import com.couchbase.client.java.kv.ReplicateTo;
@@ -29,7 +32,7 @@ public interface ReactiveInsertByIdOperation {
 
 	<T> ReactiveInsertById<T> insertById(Class<T> domainType);
 
-	interface TerminatingInsertById<T> extends OneAndAllReactive<T>{
+	interface TerminatingInsertById<T> extends OneAndAllEntityReactive<T> {
 
 		Mono<T> one(T object);
 
@@ -37,7 +40,7 @@ public interface ReactiveInsertByIdOperation {
 
 	}
 
-	interface InsertByIdWithCollection<T> extends TerminatingInsertById<T>, InCollection<T> {
+	interface InsertByIdWithCollection<T> extends TerminatingInsertById<T>, WithCollection<T> {
 
 		TerminatingInsertById<T> inCollection(String collection);
 	}
@@ -50,7 +53,7 @@ public interface ReactiveInsertByIdOperation {
 
 	}
 
-	interface InsertByIdWithExpiry<T> extends InsertByIdWithDurability<T>, WithExpiry<T>{
+	interface InsertByIdWithExpiry<T> extends InsertByIdWithDurability<T>, WithExpiry<T> {
 
 		InsertByIdWithDurability<T> withExpiry(Duration expiry);
 	}

--- a/src/main/java/org/springframework/data/couchbase/core/ReactiveRemoveByIdOperation.java
+++ b/src/main/java/org/springframework/data/couchbase/core/ReactiveRemoveByIdOperation.java
@@ -20,6 +20,9 @@ import reactor.core.publisher.Mono;
 
 import java.util.Collection;
 
+import org.springframework.data.couchbase.core.support.OneAndAllIdReactive;
+import org.springframework.data.couchbase.core.support.WithCollection;
+
 import com.couchbase.client.core.msg.kv.DurabilityLevel;
 import com.couchbase.client.java.kv.PersistTo;
 import com.couchbase.client.java.kv.ReplicateTo;
@@ -28,7 +31,7 @@ public interface ReactiveRemoveByIdOperation {
 
 	ReactiveRemoveById removeById();
 
-	interface TerminatingRemoveById {
+	interface TerminatingRemoveById extends OneAndAllIdReactive<RemoveResult> {
 
 		Mono<RemoveResult> one(String id);
 
@@ -36,12 +39,12 @@ public interface ReactiveRemoveByIdOperation {
 
 	}
 
-	interface RemoveByIdWithCollection extends TerminatingRemoveById, InCollection {
+	interface RemoveByIdWithCollection extends TerminatingRemoveById, WithCollection<RemoveResult> {
 
 		TerminatingRemoveById inCollection(String collection);
 	}
 
-	interface RemoveByIdWithDurability extends RemoveByIdWithCollection, WithDurability {
+	interface RemoveByIdWithDurability extends RemoveByIdWithCollection, WithDurability<RemoveResult> {
 
 		RemoveByIdWithCollection withDurability(DurabilityLevel durabilityLevel);
 

--- a/src/main/java/org/springframework/data/couchbase/core/ReactiveRemoveByIdOperationSupport.java
+++ b/src/main/java/org/springframework/data/couchbase/core/ReactiveRemoveByIdOperationSupport.java
@@ -85,12 +85,6 @@ public class ReactiveRemoveByIdOperationSupport implements ReactiveRemoveByIdOpe
 		}
 
 		@Override
-		public TerminatingRemoveById inCollection(final String collection) {
-			Assert.hasText(collection, "Collection must not be null nor empty.");
-			return new ReactiveRemoveByIdSupport(template, collection, persistTo, replicateTo, durabilityLevel);
-		}
-
-		@Override
 		public RemoveByIdWithCollection withDurability(final DurabilityLevel durabilityLevel) {
 			Assert.notNull(durabilityLevel, "Durability Level must not be null.");
 			return new ReactiveRemoveByIdSupport(template, collection, persistTo, replicateTo, durabilityLevel);
@@ -100,6 +94,12 @@ public class ReactiveRemoveByIdOperationSupport implements ReactiveRemoveByIdOpe
 		public RemoveByIdWithCollection withDurability(final PersistTo persistTo, final ReplicateTo replicateTo) {
 			Assert.notNull(persistTo, "PersistTo must not be null.");
 			Assert.notNull(replicateTo, "ReplicateTo must not be null.");
+			return new ReactiveRemoveByIdSupport(template, collection, persistTo, replicateTo, durabilityLevel);
+		}
+
+		@Override
+		public RemoveByIdWithDurability inCollection(final String collection) {
+			Assert.hasText(collection, "Collection must not be null nor empty.");
 			return new ReactiveRemoveByIdSupport(template, collection, persistTo, replicateTo, durabilityLevel);
 		}
 

--- a/src/main/java/org/springframework/data/couchbase/core/ReactiveRemoveByQueryOperation.java
+++ b/src/main/java/org/springframework/data/couchbase/core/ReactiveRemoveByQueryOperation.java
@@ -18,6 +18,10 @@ package org.springframework.data.couchbase.core;
 import reactor.core.publisher.Flux;
 
 import org.springframework.data.couchbase.core.query.Query;
+import org.springframework.data.couchbase.core.query.QueryCriteriaDefinition;
+import org.springframework.data.couchbase.core.support.WithCollection;
+import org.springframework.data.couchbase.core.support.WithConsistency;
+import org.springframework.data.couchbase.core.support.WithQuery;
 
 import com.couchbase.client.java.query.QueryScanConsistency;
 
@@ -29,24 +33,34 @@ public interface ReactiveRemoveByQueryOperation {
 		Flux<RemoveResult> all();
 	}
 
-	interface RemoveByQueryWithQuery<T> extends TerminatingRemoveByQuery<T> {
+	interface RemoveByQueryWithQuery<T> extends TerminatingRemoveByQuery<T>, WithQuery<RemoveResult> {
 
 		TerminatingRemoveByQuery<T> matching(Query query);
 
+		default TerminatingRemoveByQuery<T> matching(QueryCriteriaDefinition criteria) {
+			return matching(Query.query(criteria));
+		}
 	}
 
-	interface RemoveByQueryConsistentWith<T> extends RemoveByQueryWithQuery<T> {
+	interface RemoveByQueryInCollection<T> extends RemoveByQueryWithQuery<T>, WithCollection<RemoveResult> {
 
-		RemoveByQueryWithQuery<T> consistentWith(QueryScanConsistency scanConsistency);
-
-	}
-
-	interface RemoveByQueryInCollection<T> extends RemoveByQueryConsistentWith<T> {
-
-		RemoveByQueryConsistentWith<T> inCollection(String collection);
+		RemoveByQueryWithQuery<T> inCollection(String collection);
 
 	}
 
-	interface ReactiveRemoveByQuery<T> extends RemoveByQueryInCollection<T> {}
+	@Deprecated
+	interface RemoveByQueryConsistentWith<T> extends RemoveByQueryInCollection<T> {
+		@Deprecated
+		RemoveByQueryInCollection<T> consistentWith(QueryScanConsistency scanConsistency);
+
+	}
+
+	interface RemoveByQueryWithConsistency<T> extends RemoveByQueryConsistentWith<T>, WithConsistency<RemoveResult> {
+
+		RemoveByQueryConsistentWith<T> withConsistency(QueryScanConsistency scanConsistency);
+
+	}
+
+	interface ReactiveRemoveByQuery<T> extends RemoveByQueryWithConsistency<T> {}
 
 }

--- a/src/main/java/org/springframework/data/couchbase/core/ReactiveReplaceByIdOperation.java
+++ b/src/main/java/org/springframework/data/couchbase/core/ReactiveReplaceByIdOperation.java
@@ -21,6 +21,9 @@ import reactor.core.publisher.Mono;
 import java.time.Duration;
 import java.util.Collection;
 
+import org.springframework.data.couchbase.core.support.OneAndAllEntityReactive;
+import org.springframework.data.couchbase.core.support.WithCollection;
+
 import com.couchbase.client.core.msg.kv.DurabilityLevel;
 import com.couchbase.client.java.kv.PersistTo;
 import com.couchbase.client.java.kv.ReplicateTo;
@@ -29,7 +32,7 @@ public interface ReactiveReplaceByIdOperation {
 
 	<T> ReactiveReplaceById<T> replaceById(Class<T> domainType);
 
-	interface TerminatingReplaceById<T> extends OneAndAllReactive<T> {
+	interface TerminatingReplaceById<T> extends OneAndAllEntityReactive<T> {
 
 		Mono<T> one(T object);
 
@@ -37,7 +40,7 @@ public interface ReactiveReplaceByIdOperation {
 
 	}
 
-	interface ReplaceByIdWithCollection<T> extends TerminatingReplaceById<T>, InCollection<T> {
+	interface ReplaceByIdWithCollection<T> extends TerminatingReplaceById<T>, WithCollection<T> {
 
 		TerminatingReplaceById<T> inCollection(String collection);
 	}

--- a/src/main/java/org/springframework/data/couchbase/core/ReactiveUpsertByIdOperation.java
+++ b/src/main/java/org/springframework/data/couchbase/core/ReactiveUpsertByIdOperation.java
@@ -21,6 +21,9 @@ import reactor.core.publisher.Mono;
 import java.time.Duration;
 import java.util.Collection;
 
+import org.springframework.data.couchbase.core.support.OneAndAllEntityReactive;
+import org.springframework.data.couchbase.core.support.WithCollection;
+
 import com.couchbase.client.core.msg.kv.DurabilityLevel;
 import com.couchbase.client.java.kv.PersistTo;
 import com.couchbase.client.java.kv.ReplicateTo;
@@ -29,7 +32,7 @@ public interface ReactiveUpsertByIdOperation {
 
 	<T> ReactiveUpsertById<T> upsertById(Class<T> domainType);
 
-	interface TerminatingUpsertById<T> extends OneAndAllReactive<T>{
+	interface TerminatingUpsertById<T> extends OneAndAllEntityReactive<T> {
 
 		Mono<T> one(T object);
 
@@ -37,7 +40,7 @@ public interface ReactiveUpsertByIdOperation {
 
 	}
 
-	interface UpsertByIdWithCollection<T> extends TerminatingUpsertById<T>, InCollection<T> {
+	interface UpsertByIdWithCollection<T> extends TerminatingUpsertById<T>, WithCollection<T> {
 
 		TerminatingUpsertById<T> inCollection(String collection);
 	}

--- a/src/main/java/org/springframework/data/couchbase/core/query/StringQuery.java
+++ b/src/main/java/org/springframework/data/couchbase/core/query/StringQuery.java
@@ -15,10 +15,10 @@
  */
 package org.springframework.data.couchbase.core.query;
 
+import org.springframework.data.couchbase.core.ReactiveCouchbaseTemplate;
+
 import com.couchbase.client.java.json.JsonArray;
 import com.couchbase.client.java.json.JsonValue;
-import org.springframework.data.couchbase.core.ReactiveCouchbaseTemplate;
-import org.springframework.data.couchbase.repository.query.StringBasedN1qlQueryParser;
 
 /**
  * Query created from the string in @Query annotation in the repository interface.
@@ -52,7 +52,8 @@ public class StringQuery extends Query {
 	}
 
 	@Override
-	public String toN1qlSelectString(ReactiveCouchbaseTemplate template, Class domainClass, boolean isCount) {
+	public String toN1qlSelectString(ReactiveCouchbaseTemplate template, String collection, Class domainClass,
+			Class resultClass, boolean isCount, String[] distinctFields) {
 		final StringBuilder statement = new StringBuilder();
 		appendInlineN1qlStatement(statement); // apply the string statement
 		// To use generated parameters for literals

--- a/src/main/java/org/springframework/data/couchbase/core/support/AnyId.java
+++ b/src/main/java/org/springframework/data/couchbase/core/support/AnyId.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2020 the original author or authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.couchbase.core.support;
+
+import java.util.Collection;
+
+/**
+ * A common interface for those that support one(T), all(Collection<T>)
+ *
+ * @author Michael Reiche
+ * @param <T> - the entity class
+ */
+public interface AnyId<T> {
+
+	T any(String id);
+
+	Collection<? extends T> any(Collection<String> ids);
+}

--- a/src/main/java/org/springframework/data/couchbase/core/support/AnyIdReactive.java
+++ b/src/main/java/org/springframework/data/couchbase/core/support/AnyIdReactive.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2020 the original author or authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.couchbase.core.support;
+
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.util.Collection;
+
+/**
+ * A common interface for those that support one(T), all(Collection<T>)
+ *
+ * @author Michael Reiche
+ * @param <T> - the entity class
+ */
+
+public interface AnyIdReactive<T> {
+	Mono<T> any(String id);
+
+	Flux<? extends T> any(Collection<String> ids);
+}

--- a/src/main/java/org/springframework/data/couchbase/core/support/OneAndAll.java
+++ b/src/main/java/org/springframework/data/couchbase/core/support/OneAndAll.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2020 the original author or authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.couchbase.core.support;
+
+import java.util.Collection;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+/**
+ * A common interface for those that support one(T), all(Collection<T>)
+ *
+ * @author Michael Reiche
+ *
+ * @param <T> - the entity class
+ */
+public interface OneAndAll<T> {
+
+  Optional<T> one();
+
+  Optional<T> first();
+
+  T oneValue();
+
+  T firstValue();
+
+  Collection<? extends T> all();
+
+  Stream<T> stream();
+
+  long count();
+
+  boolean exists();
+}

--- a/src/main/java/org/springframework/data/couchbase/core/support/OneAndAllEntity.java
+++ b/src/main/java/org/springframework/data/couchbase/core/support/OneAndAllEntity.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2020 the original author or authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.couchbase.core.support;
+
+import java.util.Collection;
+
+/**
+ * A common interface for those that support one(T), all(Collection<T>)
+ *
+ * @author Michael Reiche
+ *
+ * @param <T> - the entity class
+ */
+public interface OneAndAllEntity<T> {
+
+	T one(T object);
+
+  Collection<? extends T> all(Collection<? extends T> objects);
+}

--- a/src/main/java/org/springframework/data/couchbase/core/support/OneAndAllEntityReactive.java
+++ b/src/main/java/org/springframework/data/couchbase/core/support/OneAndAllEntityReactive.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2020 the original author or authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.couchbase.core.support;
+
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.util.Collection;
+
+/**
+ * A common interface for those that support one(T), all(Collection<T>)
+ *
+ * @author Michael Reiche
+ * @param <T> - the entity class
+ */
+
+public interface OneAndAllEntityReactive<T> {
+	Mono<T> one(T object);
+
+	Flux<? extends T> all(Collection<? extends T> objects);
+}

--- a/src/main/java/org/springframework/data/couchbase/core/support/OneAndAllExists.java
+++ b/src/main/java/org/springframework/data/couchbase/core/support/OneAndAllExists.java
@@ -13,20 +13,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.springframework.data.couchbase.core;
+package org.springframework.data.couchbase.core.support;
 
 import java.util.Collection;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Stream;
 
 /**
- * A common interface for all of Insert, Replace, Upsert
+ * A common interface for those that support one(T), all(Collection<T>)
  *
  * @author Michael Reiche
  *
  * @param <T> - the entity class
  */
-public interface OneAndAll<T> {
+public interface OneAndAllExists {
+  boolean one(String id);
 
-	T one(T object);
-
-  Collection<? extends T> all(Collection<? extends T> objects);
+  Map<String,Boolean> all(Collection<String> ids);
 }

--- a/src/main/java/org/springframework/data/couchbase/core/support/OneAndAllExistsReactive.java
+++ b/src/main/java/org/springframework/data/couchbase/core/support/OneAndAllExistsReactive.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2020 the original author or authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.couchbase.core.support;
+
+import reactor.core.publisher.Mono;
+
+import java.util.Collection;
+import java.util.Map;
+
+/**
+ * A common interface for those that support one(T), all(Collection<T>)
+ *
+ * @author Michael Reiche
+ *
+ * @param <T> - the entity class
+ */
+public interface OneAndAllExistsReactive {
+  Mono<Boolean> one(String id);
+
+  Mono<Map<String,Boolean>> all(Collection<String> ids);
+}

--- a/src/main/java/org/springframework/data/couchbase/core/support/OneAndAllId.java
+++ b/src/main/java/org/springframework/data/couchbase/core/support/OneAndAllId.java
@@ -13,22 +13,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.springframework.data.couchbase.core;
-
-import reactor.core.publisher.Flux;
-import reactor.core.publisher.Mono;
+package org.springframework.data.couchbase.core.support;
 
 import java.util.Collection;
 
 /**
- * A common interface for all of Insert, Replace, Upsert
+ * A common interface for those that support one(String), all(Collection<String>)
  *
  * @author Michael Reiche
+ *
  * @param <T> - the entity class
  */
+public interface OneAndAllId<T> {
 
-public interface OneAndAllReactive<T> {
-	Mono<T> one(T object);
+	T one(String id);
 
-	Flux<? extends T> all(Collection<? extends T> objects);
+  Collection<? extends T> all(Collection<String> ids);
 }

--- a/src/main/java/org/springframework/data/couchbase/core/support/OneAndAllIdReactive.java
+++ b/src/main/java/org/springframework/data/couchbase/core/support/OneAndAllIdReactive.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2020 the original author or authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.couchbase.core.support;
+
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.util.Collection;
+
+/**
+ * A common interface for those that support one(String), all(Collection<String>)
+ *
+ * @author Michael Reiche
+ * @param <T> - the entity class
+ */
+
+public interface OneAndAllIdReactive<T> {
+	Mono<T> one(String id);
+
+	Flux<? extends T> all(Collection<String> ids);
+}

--- a/src/main/java/org/springframework/data/couchbase/core/support/OneAndAllReactive.java
+++ b/src/main/java/org/springframework/data/couchbase/core/support/OneAndAllReactive.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2020 the original author or authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.couchbase.core.support;
+
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.util.Collection;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+/**
+ * A common interface for those that support one(T), all(Collection<T>)
+ *
+ * @author Michael Reiche
+ * @param <T> - the entity class
+ */
+
+public interface OneAndAllReactive<T> {
+	Mono<T> one();
+
+	Mono<T> first();
+
+	Flux<? extends T> all();
+
+	Mono<Long> count();
+
+	Mono<Boolean> exists();
+}

--- a/src/main/java/org/springframework/data/couchbase/core/support/WithAnalyticsConsistency.java
+++ b/src/main/java/org/springframework/data/couchbase/core/support/WithAnalyticsConsistency.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2020 the original author or authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.couchbase.core.support;
+
+import com.couchbase.client.java.analytics.AnalyticsScanConsistency;
+
+/**
+ * A common interface for all of Insert, Replace, Upsert that take consistency
+ *
+ * @author Michael Reiche
+ * @param <T> - the entity class
+ */
+public interface WithAnalyticsConsistency<T> {
+	Object withConsistency(AnalyticsScanConsistency scanConsistency);
+}

--- a/src/main/java/org/springframework/data/couchbase/core/support/WithAnalyticsQuery.java
+++ b/src/main/java/org/springframework/data/couchbase/core/support/WithAnalyticsQuery.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2020 the original author or authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.couchbase.core.support;
+
+import org.springframework.data.couchbase.core.query.AnalyticsQuery;
+
+/**
+ * A common interface for all of Insert, Replace, Upsert that take Query
+ *
+ * @author Michael Reiche
+ * @param <T> - the entity class
+ */
+public interface WithAnalyticsQuery<T> {
+	Object matching(AnalyticsQuery query);
+}

--- a/src/main/java/org/springframework/data/couchbase/core/support/WithCollection.java
+++ b/src/main/java/org/springframework/data/couchbase/core/support/WithCollection.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2020 the original author or authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.couchbase.core.support;
+
+/**
+ * A common interface for all of Insert, Replace, Upsert that take Collection
+ *
+ * @author Michael Reiche
+ * @param <T> - the entity class
+ */
+public interface WithCollection<T> {
+	Object inCollection(String collectionName);
+}

--- a/src/main/java/org/springframework/data/couchbase/core/support/WithConsistency.java
+++ b/src/main/java/org/springframework/data/couchbase/core/support/WithConsistency.java
@@ -13,14 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.springframework.data.couchbase.core;
+package org.springframework.data.couchbase.core.support;
+
+import com.couchbase.client.java.query.QueryScanConsistency;
 
 /**
- * A common interface for all of Insert, Replace, Upsert that take collection
+ * A common interface for all of Insert, Replace, Upsert that take consistency
  *
  * @author Michael Reiche
  * @param <T> - the entity class
  */
-public interface InCollection<T> {
-	Object inCollection(String collection);
+public interface WithConsistency<T> {
+	Object withConsistency(QueryScanConsistency scanConsistency);
 }

--- a/src/main/java/org/springframework/data/couchbase/core/support/WithDistinct.java
+++ b/src/main/java/org/springframework/data/couchbase/core/support/WithDistinct.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2020 the original author or authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.couchbase.core.support;
+
+/**
+ * A common interface for all of Insert, Replace, Upsert that take Distinct
+ *
+ * @author Michael Reiche
+ * @param <T> - the entity class
+ */
+public interface WithDistinct<T> {
+	Object distinct(String[] distinctFields);
+}

--- a/src/main/java/org/springframework/data/couchbase/core/support/WithProjection.java
+++ b/src/main/java/org/springframework/data/couchbase/core/support/WithProjection.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2020 the original author or authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.couchbase.core.support;
+
+/**
+ * A common interface for all of Insert, Replace, Upsert that take Projection
+ *
+ * @author Michael Reiche
+ * @param <R> - the entity class
+ */
+public interface WithProjection<R> {
+	Object as(Class<R> returnType);
+
+}

--- a/src/main/java/org/springframework/data/couchbase/core/support/WithProjectionId.java
+++ b/src/main/java/org/springframework/data/couchbase/core/support/WithProjectionId.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2020 the original author or authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.couchbase.core.support;
+
+/**
+ * A common interface for those that support project()
+ *
+ * @author Michael Reiche
+ * @param <R> - the entity class
+ */
+public interface WithProjectionId<R> {
+	Object project(String[] fields);
+
+}

--- a/src/main/java/org/springframework/data/couchbase/core/support/WithQuery.java
+++ b/src/main/java/org/springframework/data/couchbase/core/support/WithQuery.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2020 the original author or authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.couchbase.core.support;
+
+import org.springframework.data.couchbase.core.query.Query;
+import org.springframework.data.couchbase.core.query.QueryCriteria;
+import org.springframework.data.couchbase.core.query.QueryCriteriaDefinition;
+
+/**
+ * A common interface for all of Insert, Replace, Upsert that take Query
+ *
+ * @author Michael Reiche
+ * @param <T> - the entity class
+ */
+public interface WithQuery<T> {
+	Object matching(Query query);
+
+	Object matching(QueryCriteriaDefinition queryCriteria);
+}

--- a/src/main/java/org/springframework/data/couchbase/repository/query/AbstractCouchbaseQuery.java
+++ b/src/main/java/org/springframework/data/couchbase/repository/query/AbstractCouchbaseQuery.java
@@ -18,6 +18,7 @@ package org.springframework.data.couchbase.repository.query;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.data.couchbase.core.CouchbaseOperations;
 import org.springframework.data.couchbase.core.ExecutableFindByQueryOperation;
+import org.springframework.data.couchbase.core.ExecutableFindByQueryOperation.ExecutableFindByQuery;
 import org.springframework.data.couchbase.core.query.Query;
 import org.springframework.data.couchbase.repository.query.CouchbaseQueryExecution.DeleteExecution;
 import org.springframework.data.couchbase.repository.query.CouchbaseQueryExecution.PagedExecution;
@@ -82,8 +83,7 @@ public abstract class AbstractCouchbaseQuery extends AbstractCouchbaseQueryBase<
 		query = applyAnnotatedConsistencyIfPresent(query);
 		// query = applyAnnotatedCollationIfPresent(query, accessor); // not yet implemented
 
-		ExecutableFindByQueryOperation.ExecutableFindByQuery<?> find = typeToRead == null
-				? findOperationWithProjection //
+		ExecutableFindByQuery<?> find = typeToRead == null ? findOperationWithProjection //
 				: findOperationWithProjection; // not yet implemented in core .as(typeToRead);
 
 		String collection = "_default._default";// method.getEntityInformation().getCollectionName(); // not yet implemented

--- a/src/main/java/org/springframework/data/couchbase/repository/query/AbstractCouchbaseQueryBase.java
+++ b/src/main/java/org/springframework/data/couchbase/repository/query/AbstractCouchbaseQueryBase.java
@@ -36,9 +36,9 @@ import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 
 /**
- * {@link RepositoryQuery} implementation for Couchbase.
- *
- * CouchbaseOperationsType is either CouchbaseOperations or ReactiveCouchbaseOperations
+ * {@link RepositoryQuery} implementation for Couchbase. CouchbaseOperationsType is either CouchbaseOperations or
+ * ReactiveCouchbaseOperations
+ * 
  * @author Michael Reiche
  * @since 4.1
  */
@@ -105,6 +105,7 @@ public abstract class AbstractCouchbaseQueryBase<CouchbaseOperationsType> implem
 
 	/**
 	 * Execute the query with the provided parameters
+	 * 
 	 * @see org.springframework.data.repository.query.RepositoryQuery#execute(java.lang.Object[])
 	 */
 	public Object execute(Object[] parameters) {

--- a/src/main/java/org/springframework/data/couchbase/repository/query/AbstractReactiveCouchbaseQuery.java
+++ b/src/main/java/org/springframework/data/couchbase/repository/query/AbstractReactiveCouchbaseQuery.java
@@ -81,7 +81,7 @@ public abstract class AbstractReactiveCouchbaseQuery extends AbstractCouchbaseQu
 		query = applyAnnotatedConsistencyIfPresent(query);
 		// query = applyAnnotatedCollationIfPresent(query, accessor); // not yet implemented
 
-		ReactiveFindByQueryOperation.FindByQueryWithQuery<?> find = typeToRead == null //
+		ReactiveFindByQuery<?> find = typeToRead == null //
 				? findOperationWithProjection //
 				: findOperationWithProjection; // note yet implemented in core .as(typeToRead);
 

--- a/src/main/java/org/springframework/data/couchbase/repository/query/N1qlRepositoryQueryExecutor.java
+++ b/src/main/java/org/springframework/data/couchbase/repository/query/N1qlRepositoryQueryExecutor.java
@@ -73,11 +73,8 @@ public class N1qlRepositoryQueryExecutor {
 			query = new N1qlQueryCreator(tree, accessor, queryMethod, operations.getConverter()).createQuery();
 		}
 
-		// q = (ExecutableFindByQueryOperation.ExecutableFindByQuery) operations.findByQuery(domainClass)
-		// .consistentWith(buildQueryScanConsistency()).matching(query);
-
 		ExecutableFindByQueryOperation.ExecutableFindByQuery<?> operation = (ExecutableFindByQueryOperation.ExecutableFindByQuery<?>) operations
-				.findByQuery(domainClass).consistentWith(buildQueryScanConsistency());
+				.findByQuery(domainClass).withConsistency(buildQueryScanConsistency());
 		if (queryMethod.isCountQuery()) {
 			return operation.matching(query).count();
 		} else if (queryMethod.isCollectionQuery()) {

--- a/src/main/java/org/springframework/data/couchbase/repository/support/SimpleCouchbaseRepository.java
+++ b/src/main/java/org/springframework/data/couchbase/repository/support/SimpleCouchbaseRepository.java
@@ -138,13 +138,13 @@ public class SimpleCouchbaseRepository<T, ID> implements CouchbaseRepository<T, 
 
 	@Override
 	public long count() {
-		return couchbaseOperations.findByQuery(entityInformation.getJavaType()).consistentWith(buildQueryScanConsistency())
+		return couchbaseOperations.findByQuery(entityInformation.getJavaType()).withConsistency(buildQueryScanConsistency())
 				.count();
 	}
 
 	@Override
 	public void deleteAll() {
-		couchbaseOperations.removeByQuery(entityInformation.getJavaType()).consistentWith(buildQueryScanConsistency())
+		couchbaseOperations.removeByQuery(entityInformation.getJavaType()).withConsistency(buildQueryScanConsistency())
 				.all();
 	}
 
@@ -185,7 +185,7 @@ public class SimpleCouchbaseRepository<T, ID> implements CouchbaseRepository<T, 
 	 * @return the list of found entities, already executed.
 	 */
 	private List<T> findAll(Query query) {
-		return couchbaseOperations.findByQuery(entityInformation.getJavaType()).consistentWith(buildQueryScanConsistency())
+		return couchbaseOperations.findByQuery(entityInformation.getJavaType()).withConsistency(buildQueryScanConsistency())
 				.matching(query).all();
 	}
 

--- a/src/main/java/org/springframework/data/couchbase/repository/support/SimpleReactiveCouchbaseRepository.java
+++ b/src/main/java/org/springframework/data/couchbase/repository/support/SimpleReactiveCouchbaseRepository.java
@@ -184,7 +184,7 @@ public class SimpleReactiveCouchbaseRepository<T, ID> implements ReactiveCouchba
 
 	@Override
 	public Mono<Long> count() {
-		return operations.findByQuery(entityInformation.getJavaType()).consistentWith(buildQueryScanConsistency()).count();
+		return operations.findByQuery(entityInformation.getJavaType()).withConsistency(buildQueryScanConsistency()).count();
 	}
 
 	@Override
@@ -202,7 +202,7 @@ public class SimpleReactiveCouchbaseRepository<T, ID> implements ReactiveCouchba
 	}
 
 	private Flux<T> findAll(Query query) {
-		return operations.findByQuery(entityInformation.getJavaType()).consistentWith(buildQueryScanConsistency())
+		return operations.findByQuery(entityInformation.getJavaType()).withConsistency(buildQueryScanConsistency())
 				.matching(query).all();
 	}
 

--- a/src/test/java/org/springframework/data/couchbase/core/CouchbaseTemplateQueryCollectionIntegrationTests.java
+++ b/src/test/java/org/springframework/data/couchbase/core/CouchbaseTemplateQueryCollectionIntegrationTests.java
@@ -1,0 +1,339 @@
+/*
+ * Copyright 2021 the original author or authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.data.couchbase.core;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Instant;
+import java.time.temporal.TemporalAccessor;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.couchbase.core.query.Query;
+import org.springframework.data.couchbase.core.query.QueryCriteria;
+import org.springframework.data.couchbase.domain.Address;
+import org.springframework.data.couchbase.domain.Airport;
+import org.springframework.data.couchbase.domain.Course;
+import org.springframework.data.couchbase.domain.NaiveAuditorAware;
+import org.springframework.data.couchbase.domain.Submission;
+import org.springframework.data.couchbase.domain.User;
+import org.springframework.data.couchbase.domain.UserJustLastName;
+import org.springframework.data.couchbase.domain.UserSubmission;
+import org.springframework.data.couchbase.domain.UserSubmissionProjected;
+import org.springframework.data.couchbase.domain.time.AuditingDateTimeProvider;
+import org.springframework.data.couchbase.util.Capabilities;
+import org.springframework.data.couchbase.util.ClusterType;
+import org.springframework.data.couchbase.util.CollectionAwareIntegrationTests;
+import org.springframework.data.couchbase.util.IgnoreWhen;
+
+import com.couchbase.client.java.query.QueryScanConsistency;
+
+/**
+ * Query tests Theses tests rely on a cb server running This class tests collection support with
+ * inCollection(collection) It should be identical to CouchbaseTemplateQueryIntegrationTests except for the setup and
+ * the inCollection(collectionName) calls. Testing without collections could also be done by this class simply by using
+ * scopeName = null and collectionName = null (except for inCollection() checks that the collectionName is not null)
+ *
+ * @author Michael Reiche
+ */
+@IgnoreWhen(missesCapabilities = { Capabilities.QUERY, Capabilities.COLLECTIONS }, clusterTypes = ClusterType.MOCKED)
+class CouchbaseTemplateQueryCollectionIntegrationTests extends CollectionAwareIntegrationTests {
+
+	@BeforeAll
+	public static void beforeAll() {
+		// first call the super method
+		callSuperBeforeAll(new Object() {});
+		// then do processing for this class
+		// collectionName = null;
+		// scopeName = null;
+	}
+
+	@AfterAll
+	public static void afterAll() {
+		// first do the processing for this class
+		// no-op
+		// then call the super method
+		callSuperAfterAll(new Object() {});
+	}
+
+	@BeforeEach
+	@Override
+	public void beforeEach() {
+		// first call the super method
+		super.beforeEach();
+		// then do processing for this class
+		couchbaseTemplate.removeByQuery(User.class).inCollection(collectionName).all();
+	}
+
+	@AfterEach
+	@Override
+	public void afterEach() {
+		// first call the super method
+		super.afterEach();
+		// then do processing for this class
+		// no-op
+	}
+
+	@Test
+	void findByQueryAll() {
+		try {
+			User user1 = new User(UUID.randomUUID().toString(), "user1", "user1");
+			User user2 = new User(UUID.randomUUID().toString(), "user2", "user2");
+
+			couchbaseTemplate.upsertById(User.class).inCollection(collectionName).all(Arrays.asList(user1, user2));
+
+			final List<User> foundUsers = couchbaseTemplate.findByQuery(User.class)
+					.withConsistency(QueryScanConsistency.REQUEST_PLUS).inCollection(collectionName).all();
+
+			for (User u : foundUsers) {
+				if (!(u.equals(user1) || u.equals(user2))) {
+					// somebody didn't clean up after themselves.
+					couchbaseTemplate.removeById().inCollection(collectionName).one(u.getId());
+				}
+			}
+			assertEquals(2, foundUsers.size());
+			TemporalAccessor auditTime = new AuditingDateTimeProvider().getNow().get();
+			long auditMillis = Instant.from(auditTime).toEpochMilli();
+			String auditUser = new NaiveAuditorAware().getCurrentAuditor().get();
+
+			for (User u : foundUsers) {
+				assertTrue(u.equals(user1) || u.equals(user2));
+				assertEquals(auditUser, u.getCreator());
+				assertEquals(auditMillis, u.getCreatedDate());
+				assertEquals(auditUser, u.getLastModifiedBy());
+				assertEquals(auditMillis, u.getLastModifiedDate());
+			}
+			couchbaseTemplate.findById(User.class).inCollection(collectionName).one(user1.getId());
+			reactiveCouchbaseTemplate.findById(User.class).inCollection(collectionName).one(user1.getId()).block();
+		} finally {
+			couchbaseTemplate.removeByQuery(User.class).inCollection(collectionName).all();
+		}
+
+		User usery = couchbaseTemplate.findById(User.class).inCollection(collectionName).one("userx");
+		assertNull(usery, "usery should be null");
+		User userz = reactiveCouchbaseTemplate.findById(User.class).inCollection(collectionName).one("userx").block();
+		assertNull(userz, "userz should be null");
+
+	}
+
+	@Test
+	void findByMatchingQuery() {
+		User user1 = new User(UUID.randomUUID().toString(), "user1", "user1");
+		User user2 = new User(UUID.randomUUID().toString(), "user2", "user2");
+		User specialUser = new User(UUID.randomUUID().toString(), "special", "special");
+
+		couchbaseTemplate.upsertById(User.class).inCollection(collectionName).all(Arrays.asList(user1, user2, specialUser));
+
+		Query specialUsers = new Query(QueryCriteria.where("firstname").like("special"));
+		final List<User> foundUsers = couchbaseTemplate.findByQuery(User.class)
+				.withConsistency(QueryScanConsistency.REQUEST_PLUS).inCollection(collectionName).matching(specialUsers).all();
+
+		assertEquals(1, foundUsers.size());
+	}
+
+	@Test
+	void findByMatchingQueryProjected() {
+
+		UserSubmission user = new UserSubmission();
+		user.setId(UUID.randomUUID().toString());
+		user.setUsername("dave");
+		user.setRoles(Arrays.asList("role1", "role2"));
+		Address address = new Address();
+		address.setStreet("1234 Olcott Street");
+		user.setAddress(address);
+		user.setSubmissions(
+				Arrays.asList(new Submission(UUID.randomUUID().toString(), user.getId(), "tid", "status", 123)));
+		user.setCourses(Arrays.asList(new Course(UUID.randomUUID().toString(), user.getId(), "581"),
+				new Course(UUID.randomUUID().toString(), user.getId(), "777")));
+		couchbaseTemplate.upsertById(UserSubmission.class).inCollection(collectionName).one(user);
+
+		Query daveUsers = new Query(QueryCriteria.where("username").like("dave"));
+
+		final List<UserSubmissionProjected> foundUserSubmissions = couchbaseTemplate.findByQuery(UserSubmission.class)
+				.as(UserSubmissionProjected.class).withConsistency(QueryScanConsistency.REQUEST_PLUS)
+				.inCollection(collectionName).matching(daveUsers).all();
+		assertEquals(1, foundUserSubmissions.size());
+		assertEquals(user.getUsername(), foundUserSubmissions.get(0).getUsername());
+		assertEquals(user.getId(), foundUserSubmissions.get(0).getId());
+		assertEquals(user.getCourses(), foundUserSubmissions.get(0).getCourses());
+		assertEquals(user.getAddress(), foundUserSubmissions.get(0).getAddress());
+
+		couchbaseTemplate.removeByQuery(UserSubmission.class).inCollection(collectionName).all();
+
+		User user1 = new User(UUID.randomUUID().toString(), "user1", "user1");
+		User user2 = new User(UUID.randomUUID().toString(), "user2", "user2");
+		User specialUser = new User(UUID.randomUUID().toString(), "special", "special");
+
+		couchbaseTemplate.upsertById(User.class).inCollection(collectionName).all(Arrays.asList(user1, user2, specialUser));
+
+		Query specialUsers = new Query(QueryCriteria.where("firstname").like("special"));
+		final List<UserJustLastName> foundUsers = couchbaseTemplate.findByQuery(User.class).as(UserJustLastName.class)
+				.withConsistency(QueryScanConsistency.REQUEST_PLUS).inCollection(collectionName).matching(specialUsers).all();
+		assertEquals(1, foundUsers.size());
+
+		final List<UserJustLastName> foundUsersReactive = reactiveCouchbaseTemplate.findByQuery(User.class)
+				.as(UserJustLastName.class).withConsistency(QueryScanConsistency.REQUEST_PLUS).inCollection(collectionName)
+				.matching(specialUsers).all().collectList().block();
+		assertEquals(1, foundUsersReactive.size());
+
+	}
+
+	@Test
+	void removeByQueryAll() {
+		User user1 = new User(UUID.randomUUID().toString(), "user1", "user1");
+		User user2 = new User(UUID.randomUUID().toString(), "user2", "user2");
+
+		couchbaseTemplate.upsertById(User.class).inCollection(collectionName).all(Arrays.asList(user1, user2));
+
+		assertTrue(couchbaseTemplate.existsById().inCollection(collectionName).one(user1.getId()));
+		assertTrue(couchbaseTemplate.existsById().inCollection(collectionName).one(user2.getId()));
+
+		couchbaseTemplate.removeByQuery(User.class).withConsistency(QueryScanConsistency.REQUEST_PLUS)
+				.inCollection(collectionName).all();
+
+		assertNull(couchbaseTemplate.findById(User.class).inCollection(collectionName).one(user1.getId()));
+		assertNull(couchbaseTemplate.findById(User.class).inCollection(collectionName).one(user2.getId()));
+
+	}
+
+	@Test
+	void removeByMatchingQuery() {
+		User user1 = new User(UUID.randomUUID().toString(), "user1", "user1");
+		User user2 = new User(UUID.randomUUID().toString(), "user2", "user2");
+		User specialUser = new User(UUID.randomUUID().toString(), "special", "special");
+
+		couchbaseTemplate.upsertById(User.class).inCollection(collectionName).all(Arrays.asList(user1, user2, specialUser));
+
+		assertTrue(couchbaseTemplate.existsById().inCollection(collectionName).one(user1.getId()));
+		assertTrue(couchbaseTemplate.existsById().inCollection(collectionName).one(user2.getId()));
+		assertTrue(couchbaseTemplate.existsById().inCollection(collectionName).one(specialUser.getId()));
+
+		Query nonSpecialUsers = new Query(QueryCriteria.where("firstname").notLike("special"));
+
+		couchbaseTemplate.removeByQuery(User.class).withConsistency(QueryScanConsistency.REQUEST_PLUS)
+				.inCollection(collectionName).matching(nonSpecialUsers).all();
+
+		assertNull(couchbaseTemplate.findById(User.class).inCollection(collectionName).one(user1.getId()));
+		assertNull(couchbaseTemplate.findById(User.class).inCollection(collectionName).one(user2.getId()));
+		assertNotNull(couchbaseTemplate.findById(User.class).inCollection(collectionName).one(specialUser.getId()));
+
+	}
+
+	@Test
+	void distinct() {
+		String[] iatas = { "JFK", "IAD", "SFO", "SJC", "SEA", "LAX", "PHX" };
+		String[] icaos = { "ic0", "ic1", "ic0", "ic1", "ic0", "ic1", "ic0" };
+
+		try {
+			for (int i = 0; i < iatas.length; i++) {
+				Airport airport = new Airport("airports::" + iatas[i], iatas[i] /*iata*/, icaos[i] /* icao */);
+				couchbaseTemplate.insertById(Airport.class).inCollection(collectionName).one(airport);
+			}
+
+			// distinct and count(distinct(...)) calls. use as() and consistentWith to verify fluent api
+			// as the fluent api for Distinct is tricky
+
+			// distinct icao
+			List<Airport> airports1 = couchbaseTemplate.findByQuery(Airport.class).distinct(new String[] { "icao" })
+					.as(Airport.class).withConsistency(QueryScanConsistency.REQUEST_PLUS).inCollection(collectionName).all();
+			assertEquals(2, airports1.size());
+
+			// distinct all-fields-in-Airport.class
+			List<Airport> airports2 = couchbaseTemplate.findByQuery(Airport.class).distinct(new String[] {}).as(Airport.class)
+					.withConsistency(QueryScanConsistency.REQUEST_PLUS).inCollection(collectionName).all();
+			assertEquals(7, airports2.size());
+
+			// count( distinct { iata, icao } )
+			long count1 = couchbaseTemplate.findByQuery(Airport.class).distinct(new String[] { "iata", "icao" })
+					.as(Airport.class).withConsistency(QueryScanConsistency.REQUEST_PLUS).inCollection(collectionName).count();
+			assertEquals(7, count1);
+
+			// count( distinct (all fields in icaoClass)
+			Class icaoClass = (new Object() {
+				String iata;
+				String icao;
+			}).getClass();
+			long count2 = couchbaseTemplate.findByQuery(Airport.class).distinct(new String[] {}).as(icaoClass)
+					.withConsistency(QueryScanConsistency.REQUEST_PLUS).inCollection(collectionName).count();
+			assertEquals(7, count2);
+
+		} finally {
+			couchbaseTemplate.removeById().inCollection(collectionName)
+					.all(Arrays.stream(iatas).map((iata) -> "airports::" + iata).collect(Collectors.toSet()));
+		}
+	}
+
+	@Test
+	void distinctReactive() {
+		String[] iatas = { "JFK", "IAD", "SFO", "SJC", "SEA", "LAX", "PHX" };
+		String[] icaos = { "ic0", "ic1", "ic0", "ic1", "ic0", "ic1", "ic0" };
+
+		try {
+			for (int i = 0; i < iatas.length; i++) {
+				Airport airport = new Airport("airports::" + iatas[i], iatas[i] /*iata*/, icaos[i] /* icao */);
+				reactiveCouchbaseTemplate.insertById(Airport.class).inCollection(collectionName).one(airport).block();
+			}
+
+			// distinct and count(distinct(...)) calls. use as() and consistentWith to verify fluent api
+			// as the fluent api for Distinct is tricky
+
+			// distinct icao
+			List<Airport> airports1 = reactiveCouchbaseTemplate.findByQuery(Airport.class).distinct(new String[] { "icao" })
+					.as(Airport.class).withConsistency(QueryScanConsistency.REQUEST_PLUS).inCollection(collectionName).all()
+					.collectList().block();
+			assertEquals(2, airports1.size());
+
+			// distinct all-fields-in-Airport.class
+			List<Airport> airports2 = reactiveCouchbaseTemplate.findByQuery(Airport.class).distinct(new String[] {})
+					.as(Airport.class).withConsistency(QueryScanConsistency.REQUEST_PLUS).inCollection(collectionName).all()
+					.collectList().block();
+			assertEquals(7, airports2.size());
+
+			// count( distinct icao )
+			// not currently possible to have multiple fields in COUNT(DISTINCT field1, field2, ... ) due to MB43475
+			long count1 = reactiveCouchbaseTemplate.findByQuery(Airport.class).distinct(new String[] { "icao" })
+					.as(Airport.class).withConsistency(QueryScanConsistency.REQUEST_PLUS).inCollection(collectionName).count()
+					.block();
+			assertEquals(2, count1);
+
+			// count( distinct (all fields in icaoClass) // which only has one field
+			// not currently possible to have multiple fields in COUNT(DISTINCT field1, field2, ... ) due to MB43475
+			Class icaoClass = (new Object() {
+				String icao;
+			}).getClass();
+			long count2 = (long) reactiveCouchbaseTemplate.findByQuery(Airport.class).distinct(new String[] {}).as(icaoClass)
+					.withConsistency(QueryScanConsistency.REQUEST_PLUS).inCollection(collectionName).count().block();
+			assertEquals(2, count2);
+
+		} finally {
+			reactiveCouchbaseTemplate.removeById().inCollection(collectionName)
+					.all(Arrays.stream(iatas).map((iata) -> "airports::" + iata).collect(Collectors.toSet())).collectList()
+					.block();
+		}
+	}
+
+}

--- a/src/test/java/org/springframework/data/couchbase/domain/Address.java
+++ b/src/test/java/org/springframework/data/couchbase/domain/Address.java
@@ -1,17 +1,12 @@
 package org.springframework.data.couchbase.domain;
 
-import org.springframework.data.annotation.Id;
-import org.springframework.data.couchbase.config.AbstractCouchbaseConfiguration;
 import org.springframework.data.couchbase.core.mapping.Document;
-import org.springframework.data.couchbase.core.mapping.id.GeneratedValue;
-import org.springframework.data.couchbase.core.mapping.id.GenerationStrategy;
-
-import java.util.UUID;
 
 @Document
-public class Address extends AbstractEntity {
+public class Address extends ComparableEntity {
 
-	private	String street;
+	private String street;
+	private String city;
 
 	public Address() {}
 
@@ -23,11 +18,12 @@ public class Address extends AbstractEntity {
 		this.street = street;
 	}
 
-	public String toString() {
-		StringBuilder sb = new StringBuilder();
-		sb.append("{\"street\"=\"");
-		sb.append(getStreet());
-		sb.append("\"}");
-		return sb.toString();
+	public String getCity() {
+		return city;
 	}
+
+	public void setCity(String city) {
+		this.city = city;
+	}
+
 }

--- a/src/test/java/org/springframework/data/couchbase/domain/Airline.java
+++ b/src/test/java/org/springframework/data/couchbase/domain/Airline.java
@@ -23,7 +23,7 @@ import org.springframework.data.couchbase.core.mapping.Document;
 
 @Document
 @CompositeQueryIndex(fields = { "id", "name desc" })
-public class Airline {
+public class Airline extends ComparableEntity {
 	@Id String id;
 
 	@QueryIndexed String name;
@@ -42,15 +42,4 @@ public class Airline {
 		return name;
 	}
 
-	@Override
-	public String toString(){
-		StringBuilder sb=new StringBuilder();
-		sb.append("airline: { ");
-		sb.append("  id: ");
-		sb.append(id);
-		sb.append(" , name: ");
-		sb.append(name);
-		sb.append(" }");
-		return sb.toString();
-	}
 }

--- a/src/test/java/org/springframework/data/couchbase/domain/Airport.java
+++ b/src/test/java/org/springframework/data/couchbase/domain/Airport.java
@@ -27,7 +27,7 @@ import org.springframework.data.couchbase.core.mapping.Document;
  * @author Michael Reiche
  */
 @Document
-public class Airport {
+public class Airport extends ComparableEntity {
 	@Id String id;
 
 	String iata;
@@ -53,42 +53,4 @@ public class Airport {
 		return icao;
 	}
 
-	public String toString() {
-		StringBuilder sb = new StringBuilder();
-		sb.append("{ id: ");
-		sb.append(getId());
-		sb.append(", iata: ");
-		sb.append(iata);
-		sb.append(", icao: ");
-		sb.append(icao);
-		sb.append(" }");
-		return sb.toString();
-	}
-
-	public boolean equals(Object o) {
-		if (o == null) {
-			return false;
-		}
-		if (!(o instanceof Airport)) {
-			return false;
-		}
-		Airport that = (Airport) o;
-		if (diff(this.id,that.id)) {
-			return false;
-		}
-		if (diff(this.iata,that.iata)) {
-			return false;
-		}
-		if (diff(this.icao,that.icao)) {
-			return false;
-		}
-		return true;
-	}
-
-	private boolean diff(String s1, String s2){
-		if ((s1 == null && s2 != null) || !s1.equals(s2)) {
-			return true;
-		}
-		return false;
-	}
 }

--- a/src/test/java/org/springframework/data/couchbase/domain/ComparableEntity.java
+++ b/src/test/java/org/springframework/data/couchbase/domain/ComparableEntity.java
@@ -16,7 +16,8 @@
 
 package org.springframework.data.couchbase.domain;
 
-import java.lang.reflect.Field;
+import com.couchbase.mock.deps.com.google.gson.Gson;
+import com.couchbase.mock.deps.com.google.gson.GsonBuilder;
 
 /**
  * Comparable entity base class for tests
@@ -26,7 +27,7 @@ import java.lang.reflect.Field;
 public class ComparableEntity {
 
 	/**
-	 * equals() method that recursively calls equals on on fields
+	 * equals() method that relies on toString()
 	 * 
 	 * @param that
 	 * @return
@@ -41,54 +42,12 @@ public class ComparableEntity {
 				|| !(this.getClass().isAssignableFrom(that.getClass()) || that.getClass().isAssignableFrom(this.getClass()))) {
 			return false;
 		}
-		// check that all the fields in this have an equal field in that
-		for (Field f : this.getClass().getFields()) {
-			if (!same(f, this, that)) {
-				return false;
-			}
-		}
-		// check that all the fields in that have an equal field in this
-		for (Field f : that.getClass().getFields()) {
-			if (!same(f, that, this)) {
-				return false;
-			}
-		}
-		// check that all the declared fields in this have an equal field in that
-		for (Field f : this.getClass().getDeclaredFields()) {
-			if (!same(f, this, that)) {
-				return false;
-			}
-		}
-		// check that all the declared fields in that have an equal field in this
-		for (Field f : that.getClass().getDeclaredFields()) {
-			if (!same(f, that, this)) {
-				return false;
-			}
-		}
-		return true;
+		return this.toString().equals(that.toString());
+
 	}
 
-	private static boolean same(Field f, Object a, Object b) {
-		Object thisField = null;
-		Object thatField = null;
-
-		try {
-			thisField = f.get(a);
-			thatField = f.get(b);
-		} catch (IllegalAccessException e) {
-			// assume that the important fields are in toString()
-			thisField = a.toString();
-			thatField = b.toString();
-		}
-		if (thisField == null && thatField == null) {
-			return true;
-		}
-		if (thisField == null && thatField != null) {
-			return false;
-		}
-		if (!thisField.equals(thatField)) {
-			return false;
-		}
-		return true;
+	public String toString() throws RuntimeException {
+		Gson gson = new GsonBuilder().create();
+		return gson.toJson(this);
 	}
 }

--- a/src/test/java/org/springframework/data/couchbase/domain/ConfigScoped.java
+++ b/src/test/java/org/springframework/data/couchbase/domain/ConfigScoped.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2012-2020 the original author or authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.data.couchbase.domain;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.couchbase.repository.auditing.EnableCouchbaseAuditing;
+import org.springframework.data.couchbase.repository.config.EnableCouchbaseRepositories;
+
+/**
+ * Configuration that uses a scope. This is a separate class as it is difficult to debug if you forget to unset the
+ * scopeName and the config is used for non-collection operations.
+ *
+ * @Author Michael Reiche
+ */
+@Configuration
+@EnableCouchbaseRepositories
+@EnableCouchbaseAuditing // this activates auditing
+public class ConfigScoped extends Config {
+
+	static String scopeName = null;
+
+	@Override
+	protected String getScopeName() {
+		return scopeName;
+	}
+
+	public static void setScopeName(String scopeName) {
+		ConfigScoped.scopeName = scopeName;
+	}
+}

--- a/src/test/java/org/springframework/data/couchbase/domain/Course.java
+++ b/src/test/java/org/springframework/data/couchbase/domain/Course.java
@@ -40,16 +40,4 @@ public class Course extends ComparableEntity {
 		return id;
 	}
 
-	public String toString() {
-		StringBuffer sb = new StringBuffer("Course(");
-		sb.append("id=");
-		sb.append(id);
-		sb.append(", userId=");
-		sb.append(userId);
-		sb.append(", room=");
-		sb.append(room);
-		sb.append(")");
-		return sb.toString();
-	}
-
 }

--- a/src/test/java/org/springframework/data/couchbase/domain/Submission.java
+++ b/src/test/java/org/springframework/data/couchbase/domain/Submission.java
@@ -40,20 +40,4 @@ public class Submission extends ComparableEntity {
 		return id;
 	}
 
-	public String toString() {
-		StringBuffer sb = new StringBuffer("Submission(");
-		sb.append("id=");
-		sb.append(id);
-		sb.append(", userId=");
-		sb.append(userId);
-		sb.append(", talkId=");
-		sb.append(talkId);
-		sb.append(", status=");
-		sb.append(status);
-		sb.append(", number=");
-		sb.append(number);
-		sb.append(")");
-		return sb.toString();
-	}
-
 }

--- a/src/test/java/org/springframework/data/couchbase/domain/User.java
+++ b/src/test/java/org/springframework/data/couchbase/domain/User.java
@@ -35,7 +35,7 @@ import org.springframework.data.couchbase.core.mapping.Document;
  */
 
 @Document
-public class User {
+public class User extends ComparableEntity {
 
 	@Version long version;
 	@Id private String id;
@@ -90,25 +90,8 @@ public class User {
 	}
 
 	@Override
-	public boolean equals(Object o) {
-		if (this == o)
-			return true;
-		if (o == null || getClass() != o.getClass())
-			return false;
-		User user = (User) o;
-		return Objects.equals(id, user.id) && Objects.equals(firstname, user.firstname)
-				&& Objects.equals(lastname, user.lastname);
-	}
-
-	@Override
 	public int hashCode() {
 		return Objects.hash(id, firstname, lastname);
 	}
 
-	@Override
-	public String toString() {
-		return "User{" + "id='" + id + '\'' + ", firstname='" + firstname + '\'' + ", lastname='" + lastname + '\''
-				+ ", createdBy='" + createdBy + '\'' + ", createdDate='" + createdDate + '\'' + ", lastModifiedBy='"
-				+ lastModifiedBy + '\'' + ", lastModifiedDate='" + lastModifiedDate + '\'' + '}';
-	}
 }

--- a/src/test/java/org/springframework/data/couchbase/domain/UserJustLastName.java
+++ b/src/test/java/org/springframework/data/couchbase/domain/UserJustLastName.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2012-2020 the original author or authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.data.couchbase.domain;
+
+import java.util.Objects;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.annotation.PersistenceConstructor;
+import org.springframework.data.couchbase.core.mapping.Document;
+
+/**
+ * User entity for tests
+ *
+ * @author Michael Nitschinger
+ * @author Michael Reiche
+ */
+
+@Document
+public class UserJustLastName extends ComparableEntity {
+
+	@Id private String id;
+	private String lastname;
+
+	public User user;
+
+	@PersistenceConstructor
+	public UserJustLastName(final String id, final String lastname) {
+		this.id = id;
+		this.lastname = lastname;
+		this.user = new User("1", "first", "last");
+	}
+
+	public String getId() {
+		return id;
+	}
+
+	public String getLastname() {
+		return lastname;
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(id, lastname);
+	}
+
+}

--- a/src/test/java/org/springframework/data/couchbase/domain/UserSubmissionProjected.java
+++ b/src/test/java/org/springframework/data/couchbase/domain/UserSubmissionProjected.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2020 the original author or authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.data.couchbase.domain;
+
+import lombok.Data;
+
+import java.util.List;
+
+import org.springframework.data.annotation.TypeAlias;
+import org.springframework.data.couchbase.core.index.CompositeQueryIndex;
+import org.springframework.data.couchbase.core.mapping.Document;
+
+/**
+ * UserSubmission entity for tests
+ *
+ * @author Michael Reiche
+ */
+@Data
+@Document
+@TypeAlias("user")
+@CompositeQueryIndex(fields = { "id", "username", "email" })
+public class UserSubmissionProjected extends ComparableEntity {
+	private String id;
+	private String username;
+	private List<String> roles;
+	private Address address;
+	private List<Course> courses;
+
+	public void setCourses(List<Course> courses) {
+		this.courses = courses;
+	}
+
+}

--- a/src/test/java/org/springframework/data/couchbase/repository/CouchbaseRepositoryQueryIntegrationTests.java
+++ b/src/test/java/org/springframework/data/couchbase/repository/CouchbaseRepositoryQueryIntegrationTests.java
@@ -56,6 +56,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
 import com.couchbase.client.core.error.IndexExistsException;
+import reactor.core.publisher.Flux;
 
 /**
  * Repository tests
@@ -75,7 +76,7 @@ public class CouchbaseRepositoryQueryIntegrationTests extends ClusterAwareIntegr
 	@Autowired UserRepository userRepository;
 
 	@BeforeEach
-	void beforeEach() {
+	public void beforeEach() {
 		try {
 			clientFactory.getCluster().queryIndexes().createPrimaryIndex(bucketName());
 		} catch (IndexExistsException ex) {
@@ -171,12 +172,8 @@ public class CouchbaseRepositoryQueryIntegrationTests extends ClusterAwareIntegr
 		String[] iatas = { "JFK", "IAD", "SFO", "SJC", "SEA", "LAX", "PHX" };
 
 		try {
-			for (int i = 0; i < iatas.length; i++) {
-				Airport airport = new Airport("airports::" + iatas[i], iatas[i] /*iata*/,
-						iatas[i].toLowerCase(Locale.ROOT) /* lcao */);
-				airportRepository.save(airport);
-			}
 
+			airportRepository.saveAll( Arrays.stream(iatas).map((iata) -> new Airport("airports::"+iata, iata, iata.toLowerCase(Locale.ROOT))).collect(Collectors.toSet()));
 			Long count = airportRepository.countFancyExpression(asList("JFK"), asList("jfk"), false);
 			assertEquals(1, count);
 
@@ -201,10 +198,7 @@ public class CouchbaseRepositoryQueryIntegrationTests extends ClusterAwareIntegr
 			assertEquals(0, airportCount);
 
 		} finally {
-			for (int i = 0; i < iatas.length; i++) {
-				Airport airport = new Airport("airports::" + iatas[i], iatas[i] /*iata*/, iatas[i] /* lcao */);
-				airportRepository.delete(airport);
-			}
+				airportRepository.deleteAllById(Arrays.stream(iatas).map((iata) -> "airports::"+iata).collect(Collectors.toSet()));
 		}
 	}
 

--- a/src/test/java/org/springframework/data/couchbase/repository/ReactiveCouchbaseRepositoryQueryIntegrationTests.java
+++ b/src/test/java/org/springframework/data/couchbase/repository/ReactiveCouchbaseRepositoryQueryIntegrationTests.java
@@ -33,7 +33,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.stream.Collectors;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Configuration;
@@ -47,13 +46,11 @@ import org.springframework.data.couchbase.domain.ReactiveUserRepository;
 import org.springframework.data.couchbase.domain.User;
 import org.springframework.data.couchbase.repository.config.EnableReactiveCouchbaseRepositories;
 import org.springframework.data.couchbase.util.Capabilities;
-import org.springframework.data.couchbase.util.ClusterAwareIntegrationTests;
 import org.springframework.data.couchbase.util.ClusterType;
 import org.springframework.data.couchbase.util.IgnoreWhen;
+import org.springframework.data.couchbase.util.JavaIntegrationTests;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
-
-import com.couchbase.client.core.error.IndexExistsException;
 
 /**
  * template class for Reactive Couchbase operations
@@ -63,21 +60,12 @@ import com.couchbase.client.core.error.IndexExistsException;
  */
 @SpringJUnitConfig(ReactiveCouchbaseRepositoryQueryIntegrationTests.Config.class)
 @IgnoreWhen(missesCapabilities = Capabilities.QUERY, clusterTypes = ClusterType.MOCKED)
-public class ReactiveCouchbaseRepositoryQueryIntegrationTests extends ClusterAwareIntegrationTests {
+public class ReactiveCouchbaseRepositoryQueryIntegrationTests extends JavaIntegrationTests {
 
 	@Autowired CouchbaseClientFactory clientFactory;
 
 	@Autowired ReactiveAirportRepository airportRepository; // intellij flags "Could not Autowire", but it runs ok.
 	@Autowired ReactiveUserRepository userRepository; // intellij flags "Could not Autowire", but it runs ok.
-
-	@BeforeEach
-	void beforeEach() {
-		try {
-			clientFactory.getCluster().queryIndexes().createPrimaryIndex(bucketName());
-		} catch (IndexExistsException ex) {
-			// ignore, all good.
-		}
-	}
 
 	@Test
 	void shouldSaveAndFindAll() {

--- a/src/test/java/org/springframework/data/couchbase/util/CollectionAwareIntegrationTests.java
+++ b/src/test/java/org/springframework/data/couchbase/util/CollectionAwareIntegrationTests.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2021 the original author or authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.couchbase.util;
+
+import static org.springframework.data.couchbase.config.BeanNames.COUCHBASE_TEMPLATE;
+import static org.springframework.data.couchbase.config.BeanNames.REACTIVE_COUCHBASE_TEMPLATE;
+
+import java.time.Duration;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.data.couchbase.core.CouchbaseTemplate;
+import org.springframework.data.couchbase.core.ReactiveCouchbaseTemplate;
+import org.springframework.data.couchbase.domain.Config;
+
+import com.couchbase.client.core.service.ServiceType;
+import com.couchbase.client.java.Bucket;
+import com.couchbase.client.java.Cluster;
+import com.couchbase.client.java.ClusterOptions;
+import com.couchbase.client.java.env.ClusterEnvironment;
+import com.couchbase.client.java.manager.collection.CollectionManager;
+import org.springframework.data.couchbase.domain.ConfigScoped;
+
+/**
+ * Provides Collection support for integration tests
+ *
+ * @Author Michael Reiche
+ */
+public class CollectionAwareIntegrationTests extends JavaIntegrationTests {
+
+	public static String scopeName = "scope_" + randomString();
+	public static String collectionName = "collection_" + randomString();
+
+	@BeforeAll
+	public static void beforeAll() {
+		callSuperBeforeAll(new Object() {});
+		ClusterEnvironment environment = environment().build();
+		Cluster cluster = Cluster.connect(seedNodes(),
+				ClusterOptions.clusterOptions(authenticator()).environment(environment));
+		Bucket bucket = cluster.bucket(config().bucketname());
+		bucket.waitUntilReady(Duration.ofSeconds(5));
+		waitForService(bucket, ServiceType.QUERY);
+		waitForQueryIndexerToHaveBucket(cluster, config().bucketname());
+		CollectionManager collectionManager = bucket.collections();
+		if (scopeName != null || collectionName != null) {
+			setupScopeCollection(cluster, scopeName, collectionName, collectionManager);
+		}
+
+		ConfigScoped.setScopeName(scopeName);
+		ApplicationContext ac = new AnnotationConfigApplicationContext(ConfigScoped.class);
+		couchbaseTemplate = (CouchbaseTemplate) ac.getBean(COUCHBASE_TEMPLATE);
+		reactiveCouchbaseTemplate = (ReactiveCouchbaseTemplate) ac.getBean(REACTIVE_COUCHBASE_TEMPLATE);
+	}
+
+	@AfterAll
+	public static void afterAll(){
+		System.out.println("CollectionAwareIntegrationTests.afterAll()");
+		ConfigScoped.setScopeName(null);
+		callSuperBeforeAll(new Object() {});
+	}
+}

--- a/src/test/java/org/springframework/data/couchbase/util/JavaIntegrationTests.java
+++ b/src/test/java/org/springframework/data/couchbase/util/JavaIntegrationTests.java
@@ -1,0 +1,359 @@
+/*
+ * Copyright (c) 2018 Couchbase, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.data.couchbase.util;
+
+import static com.couchbase.client.core.util.CbThrowables.hasCause;
+import static com.couchbase.client.core.util.CbThrowables.throwIfUnchecked;
+import static com.couchbase.client.java.AsyncUtils.block;
+import static com.couchbase.client.java.manager.query.CreatePrimaryQueryIndexOptions.createPrimaryQueryIndexOptions;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.springframework.data.couchbase.config.BeanNames.COUCHBASE_TEMPLATE;
+import static org.springframework.data.couchbase.config.BeanNames.REACTIVE_COUCHBASE_TEMPLATE;
+import static org.springframework.data.couchbase.util.Util.waitUntilCondition;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Timeout;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.data.couchbase.CouchbaseClientFactory;
+import org.springframework.data.couchbase.SimpleCouchbaseClientFactory;
+import org.springframework.data.couchbase.core.CouchbaseTemplate;
+import org.springframework.data.couchbase.core.ReactiveCouchbaseTemplate;
+
+import com.couchbase.client.core.diagnostics.PingResult;
+import com.couchbase.client.core.diagnostics.PingState;
+import com.couchbase.client.core.error.CollectionNotFoundException;
+import com.couchbase.client.core.error.CouchbaseException;
+import com.couchbase.client.core.error.DocumentNotFoundException;
+import com.couchbase.client.core.error.IndexExistsException;
+import com.couchbase.client.core.error.ParsingFailureException;
+import com.couchbase.client.core.error.QueryException;
+import com.couchbase.client.core.error.ScopeNotFoundException;
+import com.couchbase.client.core.error.UnambiguousTimeoutException;
+import com.couchbase.client.core.json.Mapper;
+import com.couchbase.client.core.service.ServiceType;
+import com.couchbase.client.java.Bucket;
+import com.couchbase.client.java.Cluster;
+import com.couchbase.client.java.ClusterOptions;
+import com.couchbase.client.java.Collection;
+import com.couchbase.client.java.CommonOptions;
+import com.couchbase.client.java.Scope;
+import com.couchbase.client.java.diagnostics.PingOptions;
+import com.couchbase.client.java.env.ClusterEnvironment;
+import com.couchbase.client.java.json.JsonObject;
+import com.couchbase.client.java.manager.collection.CollectionManager;
+import com.couchbase.client.java.manager.collection.CollectionSpec;
+import com.couchbase.client.java.manager.collection.ScopeSpec;
+import com.couchbase.client.java.manager.query.CreatePrimaryQueryIndexOptions;
+import com.couchbase.client.java.manager.search.SearchIndex;
+import com.couchbase.client.java.manager.search.UpsertSearchIndexOptions;
+import com.couchbase.client.java.query.QueryOptions;
+import com.couchbase.client.java.query.QueryResult;
+import com.couchbase.client.java.search.SearchQuery;
+import com.couchbase.client.java.search.result.SearchResult;
+import org.springframework.data.couchbase.domain.Config;
+
+/**
+ * Extends the {@link ClusterAwareIntegrationTests} with java-client specific code.
+ *
+ * @Author Michael Reiche
+ */
+// Temporarily increased timeout to (possibly) workaround MB-37011 when Developer Preview enabled
+@Timeout(value = 10, unit = TimeUnit.MINUTES) // Safety timer so tests can't block CI executors
+public class JavaIntegrationTests extends ClusterAwareIntegrationTests {
+
+	@Autowired static public CouchbaseTemplate couchbaseTemplate;
+	@Autowired static public ReactiveCouchbaseTemplate reactiveCouchbaseTemplate;
+
+	@BeforeAll
+	public static void beforeAll() {
+		callSuperBeforeAll(new Object() {});
+		try (CouchbaseClientFactory couchbaseClientFactory = new SimpleCouchbaseClientFactory(connectionString(),
+				authenticator(), bucketName())) {
+			couchbaseClientFactory.getCluster().queryIndexes().createPrimaryIndex(bucketName(),
+					CreatePrimaryQueryIndexOptions.createPrimaryQueryIndexOptions().ignoreIfExists(true));
+		} catch (IOException ioe) {
+			throw new RuntimeException(ioe);
+		}
+		ApplicationContext ac = new AnnotationConfigApplicationContext(Config.class);
+		couchbaseTemplate = (CouchbaseTemplate) ac.getBean(COUCHBASE_TEMPLATE);
+		reactiveCouchbaseTemplate = (ReactiveCouchbaseTemplate) ac.getBean(REACTIVE_COUCHBASE_TEMPLATE);
+	}
+
+	/**
+	 * Creates a {@link ClusterEnvironment.Builder} which already has the seed nodes and credentials plugged and ready to
+	 * use depending on the environment.
+	 *
+	 * @return the builder, ready to be further modified or used directly.
+	 */
+	protected static ClusterEnvironment.Builder environment() {
+		return ClusterEnvironment.builder();
+	}
+
+	/**
+	 * Returns the pre-set cluster options with the environment and authenticator configured.
+	 *
+	 * @return the cluster options ready to be used.
+	 */
+	protected static ClusterOptions clusterOptions() {
+		return ClusterOptions.clusterOptions(authenticator()).environment(environment().build());
+	}
+
+	/**
+	 * Helper method to create a primary index if it does not exist.
+	 */
+	protected static void createPrimaryIndex(final Cluster cluster, final String bucketName) {
+		cluster.queryIndexes().createPrimaryIndex(bucketName, createPrimaryQueryIndexOptions().ignoreIfExists(true));
+	}
+
+	public static void setupScopeCollection(Cluster cluster, String scopeName, String collectionName,
+			CollectionManager collectionManager) {
+		// Create the scope.collection (borrowed from CollectionManagerIntegrationTest )
+		ScopeSpec scopeSpec = ScopeSpec.create(scopeName);
+		CollectionSpec collSpec = CollectionSpec.create(collectionName, scopeName);
+
+		if (!scopeName.equals("_default")) {
+			collectionManager.createScope(scopeName);
+		}
+
+		waitUntilCondition(() -> scopeExists(collectionManager, scopeName));
+		ScopeSpec found = collectionManager.getScope(scopeName);
+		assertEquals(scopeSpec, found);
+
+		collectionManager.createCollection(collSpec);
+		waitUntilCondition(() -> collectionExists(collectionManager, collSpec));
+		waitUntilCondition(
+				() -> collectionReady(cluster.bucket(config().bucketname()).scope(scopeName).collection(collectionName)));
+
+		assertNotEquals(scopeSpec, collectionManager.getScope(scopeName));
+		assertTrue(collectionManager.getScope(scopeName).collections().contains(collSpec));
+
+		waitForQueryIndexerToHaveBucket(cluster, collectionName);
+
+		// the call to createPrimaryIndex takes about 60 seconds
+
+		try {
+			block(createPrimaryIndex(cluster, config().bucketname(), scopeName, collectionName));
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
+
+		waitUntilCondition(
+				() -> collectionReadyQuery(cluster.bucket(config().bucketname()).scope(scopeName), collectionName));
+	}
+
+	protected static void waitForQueryIndexerToHaveBucket(final Cluster cluster, final String bucketName) {
+		boolean ready = false;
+		int guard = 100;
+
+		while (!ready && guard != 0) {
+			guard -= 1;
+			String statement = "SELECT COUNT(*) > 0 as present FROM system:keyspaces where name = '" + bucketName + "';";
+
+			QueryResult queryResult = cluster.query(statement);
+			List<JsonObject> rows = queryResult.rowsAsObject();
+			if (rows.size() == 1 && rows.get(0).getBoolean("present")) {
+				ready = true;
+			}
+
+			if (!ready) {
+				try {
+					Thread.sleep(50);
+				} catch (InterruptedException e) {}
+			}
+		}
+
+		if (guard == 0) {
+			throw new IllegalStateException("Query indexer is still not aware of bucket " + bucketName);
+		}
+	}
+
+	/**
+	 * Improve test stability by waiting for a given service to report itself ready.
+	 */
+	protected static void waitForService(final Bucket bucket, final ServiceType serviceType) {
+		bucket.waitUntilReady(Duration.ofSeconds(30));
+
+		Util.waitUntilCondition(() -> {
+			PingResult pingResult = bucket.ping(PingOptions.pingOptions().serviceTypes(Collections.singleton(serviceType)));
+
+			return pingResult.endpoints().containsKey(serviceType) && pingResult.endpoints().get(serviceType).size() > 0
+					&& pingResult.endpoints().get(serviceType).get(0).state() == PingState.OK;
+		});
+	}
+
+	public static boolean collectionExists(CollectionManager mgr, CollectionSpec spec) {
+		try {
+			ScopeSpec scope = mgr.getScope(spec.scopeName());
+			return scope.collections().contains(spec);
+		} catch (CollectionNotFoundException e) {
+			return false;
+		}
+	}
+
+	public static boolean collectionReady(Collection collection) {
+		try {
+			collection.get("123");
+			return true;
+		} catch (DocumentNotFoundException dnfe) {
+			return true;
+		} catch (UnambiguousTimeoutException e) {
+			if (!e.toString().contains("COLLECTION_NOT_FOUND")) {
+				throw e;
+			}
+			return false;
+		}
+	}
+
+	public static boolean collectionReadyQuery(Scope scope, String collectionName) {
+		try {
+			scope.query("select * from `" + collectionName + "` where meta().id=\"1\"");
+			return true;
+		} catch (DocumentNotFoundException dnfe) {
+			return true;
+		} catch (ParsingFailureException e) {
+			return false;
+		}
+	}
+
+	public static boolean scopeExists(CollectionManager mgr, String scopeName) {
+		try {
+			mgr.getScope(scopeName);
+			return true;
+		} catch (ScopeNotFoundException e) {
+			return false;
+		}
+	}
+
+	public static CompletableFuture<Void> createPrimaryIndex(Cluster cluster, String bucketName, String scopeName,
+			String collectionName) {
+		CreatePrimaryQueryIndexOptions options = CreatePrimaryQueryIndexOptions.createPrimaryQueryIndexOptions();
+		options.timeout(Duration.ofSeconds(300));
+		final CreatePrimaryQueryIndexOptions.Built builtOpts = options.build();
+		final String indexName = builtOpts.indexName().orElse(null);
+
+		String keyspace = "default:`" + bucketName + "`.`" + scopeName + "`.`" + collectionName + "`";
+		String statement = "CREATE PRIMARY INDEX ";
+		if (indexName != null) {
+			statement += (indexName) + " ";
+		}
+		statement += "ON " + (keyspace); // do not quote, this might be "default:bucketName.scopeName.collectionName"
+
+		return exec(cluster, false, statement, builtOpts.with(), builtOpts).exceptionally(t -> {
+			if (builtOpts.ignoreIfExists() && hasCause(t, IndexExistsException.class)) {
+				return null;
+			}
+			throwIfUnchecked(t);
+			throw new RuntimeException(t);
+		}).thenApply(result -> null);
+	}
+
+	private static CompletableFuture<QueryResult> exec(Cluster cluster,
+			/*AsyncQueryIndexManager.QueryType queryType*/ boolean queryType, CharSequence statement,
+			Map<String, Object> with, CommonOptions<?>.BuiltCommonOptions options) {
+		return with.isEmpty() ? exec(cluster, queryType, statement, options)
+				: exec(cluster, queryType, statement + " WITH " + Mapper.encodeAsString(with), options);
+	}
+
+	private static CompletableFuture<QueryResult> exec(Cluster cluster,
+			/*AsyncQueryIndexManager.QueryType queryType,*/ boolean queryType, CharSequence statement,
+			CommonOptions<?>.BuiltCommonOptions options) {
+		QueryOptions queryOpts = toQueryOptions(options).readonly(queryType /*requireNonNull(queryType) == READ_ONLY*/);
+
+		return cluster.async().query(statement.toString(), queryOpts).exceptionally(t -> {
+			throw translateException(t);
+		});
+	}
+
+	private static QueryOptions toQueryOptions(CommonOptions<?>.BuiltCommonOptions options) {
+		QueryOptions result = QueryOptions.queryOptions();
+		options.timeout().ifPresent(result::timeout);
+		options.retryStrategy().ifPresent(result::retryStrategy);
+		return result;
+	}
+
+	private static final Map<Predicate<QueryException>, Function<QueryException, ? extends QueryException>> errorMessageMap = new LinkedHashMap<>();
+
+	private static RuntimeException translateException(Throwable t) {
+		if (t instanceof QueryException) {
+			final QueryException e = ((QueryException) t);
+
+			for (Map.Entry<Predicate<QueryException>, Function<QueryException, ? extends QueryException>> entry : errorMessageMap
+					.entrySet()) {
+				if (entry.getKey().test(e)) {
+					return entry.getValue().apply(e);
+				}
+			}
+		}
+		return (t instanceof RuntimeException) ? (RuntimeException) t : new RuntimeException(t);
+	}
+
+	public static void createFtsCollectionIndex(Cluster cluster, String indexName, String bucketName, String scopeName,
+			String collectionName) {
+		SearchIndex searchIndex = new SearchIndex(indexName, bucketName);
+		if (scopeName != null) {
+			// searchIndex = searchIndex.forScopeCollection(scopeName, collectionName);
+			throw new RuntimeException("forScopeCollection not implemented in current java client version");
+		}
+
+		cluster.searchIndexes().upsertIndex(searchIndex,
+				UpsertSearchIndexOptions.upsertSearchIndexOptions().timeout(Duration.ofSeconds(60)));
+
+		int maxTries = 5;
+		for (int i = 0; i < maxTries; i++) {
+			try {
+				SearchResult result = cluster.searchQuery(indexName, SearchQuery.queryString("junk"));
+				break;
+			} catch (CouchbaseException | IllegalStateException ex) {
+				// this is a pretty dirty hack to avoid a race where we don't know if the index is ready yet
+				System.out.println("createFtsCollectionIndex: " + i + " " + ex);
+				if (i < (maxTries - 1) && (ex.getMessage().contains("no planPIndexes for indexName")
+						|| ex.getMessage().contains("pindex_consistency mismatched partition")
+						|| ex.getMessage().contains("pindex not available"))) {
+					sleepMs(1000);
+					continue;
+				}
+				throw ex;
+			}
+		}
+	}
+
+	public static String randomString() {
+		return UUID.randomUUID().toString().substring(0, 8);
+	}
+
+	public static void sleepMs(long ms) {
+		try {
+			Thread.sleep(ms);
+		} catch (InterruptedException ie) {}
+	}
+}

--- a/src/test/java/org/springframework/data/couchbase/util/Util.java
+++ b/src/test/java/org/springframework/data/couchbase/util/Util.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2018 Couchbase, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.data.couchbase.util;
+
+import java.io.InputStream;
+import java.time.Duration;
+import java.util.function.BooleanSupplier;
+import java.util.function.Supplier;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.awaitility.Awaitility.with;
+
+/**
+ * Provides a bunch of utility APIs that help with testing.
+ */
+public class Util {
+
+  /**
+   * Waits and sleeps for a little bit of time until the given condition is met.
+   *
+   * <p>Sleeps 1ms between "false" invocations. It will wait at most one minute to prevent hanging forever in case
+   * the condition never becomes true.</p>
+   *
+   * @param supplier return true once it should stop waiting.
+   */
+  public static void waitUntilCondition(final BooleanSupplier supplier) {
+    waitUntilCondition(supplier, Duration.ofMinutes(1));
+  }
+
+  public static void waitUntilCondition(final BooleanSupplier supplier, Duration atMost) {
+    with().pollInterval(Duration.ofMillis(1)).await().atMost(atMost).until(supplier::getAsBoolean);
+  }
+
+  public static void waitUntilCondition(final BooleanSupplier supplier, Duration atMost, Duration delay) {
+    with().pollInterval(delay).await().atMost(atMost).until(supplier::getAsBoolean);
+  }
+
+  public static void waitUntilThrows(final Class<? extends Exception> clazz, final Supplier<Object> supplier) {
+    with()
+        .pollInterval(Duration.ofMillis(1))
+        .await()
+        .atMost(Duration.ofMinutes(1))
+        .until(() -> {
+          try {
+            supplier.get();
+          } catch (final Exception ex) {
+            return ex.getClass().isAssignableFrom(clazz);
+          }
+          return false;
+        });
+  }
+
+  /**
+   * Returns true if a thread with the given name is currently running.
+   *
+   * @param name the name of the thread.
+   * @return true if running, false otherwise.
+   */
+  public static boolean threadRunning(final String name) {
+    for (Thread t : Thread.getAllStackTraces().keySet()) {
+      if (t.getName().equalsIgnoreCase(name)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Reads a file from the resources folder (in the same path as the requesting test class).
+   *
+   * <p>The class will be automatically loaded relative to the namespace and converted
+   * to a string.</p>
+   *
+   * @param filename the filename of the resource.
+   * @param clazz    the reference class.
+   * @return the loaded string.
+   */
+  public static String readResource(final String filename, final Class<?> clazz) {
+    String path = "/" + clazz.getPackage().getName().replace(".", "/") + "/" + filename;
+    InputStream stream = clazz.getResourceAsStream(path);
+    java.util.Scanner s = new java.util.Scanner(stream, UTF_8.name()).useDelimiter("\\A");
+    return s.hasNext() ? s.next() : "";
+  }
+
+}


### PR DESCRIPTION
…on and distinct.

Support for projection is only for properties of the top-level entity. For instance, in UserSubmission, only the properties below can be specified in the projection. Projection support does not provide means of specifying something like address.street - you can only project (or not project) the whole address property. However, the address type in your resultType could have a subset of the properties in Address.

If the corresponding submissions in the resultType contained only the userId property

public class UserSubmission extends ComparableEntity {
	private String id;
	private String username;
	private List<String> roles;
	private Address address;
	private List<Submission> submissions;

Support for Distinct - I have appropriated the MongoDB model for Distinct.  It defines a separate DistinctOperationSupport class (within ExecutableFindByQuerySupport) which supports the distinct( distinctFields ) api and execution. The DistinctOperationSupport class has only a distinctFields member, and a 'delegate' member, which is an ExecutableFindByQuerySupport object. TBH, I don't see the advantage over simply adding a distinctFields member to ExecutableFindByQuerySupport

Amend #1 - changes as discussed in Pull Request
         - clean up test entity types

Amend #2
- Eliminate DistinctOperationSupport class. In MongoDB, only distinct on a single field is supported, so the returnType from distinct was very different from the returnType of other query operations (all(), one() etc. (but so is count(), and it doesn't need it's own class)). In Couchbase, distinct on any fields in the entity is allowed - so the returned type could be the domainType or resultType. And as(resultType) still allows any resultType to be specified. This makes it unnecessary to have combinations of interfaces such as DistinctWithProjection and DistinctWithQuery.

- Clean up the interfaces in ExecutableFindByQuery. There are two types of interfaces (a) the TerminatingFindByQuery which has the one(), oneValue() first(), firstValue(), all(), count(), exists() and stream(); and (b) the option interfaces (FindByQueryWithConsistency etc), which are essentially with-er interfaces. The changes are:
1) make all the with-er interfaces base interfaces instead of chaining them together. (I don't know why there isn't simply one interface with all the with-er methods).
2) make the ExecutableFindByQuery interface extend the Terminating interface and all the with-er interfaces.

Amend #3
- Add execution support for collections

Amend #4
- Add tests for collections. This includes a new CollectionAwareIntegrationTests class which extends a new JavaIntegratationTests class which extends the existing ClusterAwareIntegrationTests.
- Fixed up several issues collections issues that were uncovered by the tests.
- Did further cleanup of OperationSupport interfaces.

Amend #5
- Revert changes to interfaces in *Operation
- Sorted interfaces in same order for consistency (because of the chaining of interfaces, fluent methods must be called in order).

<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [ ] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [ ] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATACOUCH).
- [ ] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [ ] You submit test cases (unit or integration tests) that back your changes.
- [ ] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
