### PR TITLE
DATACOUCH-958 - Restore auditorAwareRef and dateTimeProviderRef to em…

### DIFF
--- a/src/main/java/org/springframework/data/couchbase/repository/auditing/EnableCouchbaseAuditing.java
+++ b/src/main/java/org/springframework/data/couchbase/repository/auditing/EnableCouchbaseAuditing.java
@@ -44,7 +44,7 @@ public @interface EnableCouchbaseAuditing {
 	/**
 	 * Configures the {@link AuditorAware} bean to be used to lookup the current principal.
 	 */
-	String auditorAwareRef() default "auditorAwareRef";
+	String auditorAwareRef() default "";
 
 	/**
 	 * Configures whether the creation and modification dates are set. Defaults to {@literal true}.
@@ -60,5 +60,5 @@ public @interface EnableCouchbaseAuditing {
 	 * Configures a {@link DateTimeProvider} bean name that allows customizing the {@link org.joda.time.DateTime} to be
 	 * used for setting creation and modification dates.
 	 */
-	String dateTimeProviderRef() default "dateTimeProviderRef";
+	String dateTimeProviderRef() default "";
 }

--- a/src/test/java/org/springframework/data/couchbase/domain/Config.java
+++ b/src/test/java/org/springframework/data/couchbase/domain/Config.java
@@ -47,7 +47,7 @@ import com.couchbase.client.java.json.JacksonTransformers;
  */
 @Configuration
 @EnableCouchbaseRepositories
-@EnableCouchbaseAuditing // this activates auditing
+@EnableCouchbaseAuditing(auditorAwareRef="auditorAwareRef", dateTimeProviderRef="dateTimeProviderRef")  // this activates auditing
 public class Config extends AbstractCouchbaseConfiguration {
 	String bucketname = "travel-sample";
 	String username = "Administrator";

--- a/src/test/java/org/springframework/data/couchbase/domain/ConfigScoped.java
+++ b/src/test/java/org/springframework/data/couchbase/domain/ConfigScoped.java
@@ -17,7 +17,6 @@
 package org.springframework.data.couchbase.domain;
 
 import org.springframework.context.annotation.Configuration;
-import org.springframework.data.couchbase.repository.auditing.EnableCouchbaseAuditing;
 import org.springframework.data.couchbase.repository.config.EnableCouchbaseRepositories;
 
 /**
@@ -28,7 +27,6 @@ import org.springframework.data.couchbase.repository.config.EnableCouchbaseRepos
  */
 @Configuration
 @EnableCouchbaseRepositories
-@EnableCouchbaseAuditing // this activates auditing
 public class ConfigScoped extends Config {
 
 	static String scopeName = null;


### PR DESCRIPTION
…pty.

Restore auditorAwareRef and dateTimeProviderRef to empty. To us them, they will need to be specified in
@EnableCouchbaseAuditing( auditorAwareRef="auditorAwareRef", dateTimeProviderRef="dateTimeProviderRef")

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATACOUCH).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
