### PR TITLE
DATACOUCH-1041 - Add withCas() method to RemoveById.

### DIFF
--- a/src/main/java/org/springframework/data/couchbase/core/ExecutableRemoveByIdOperation.java
+++ b/src/main/java/org/springframework/data/couchbase/core/ExecutableRemoveByIdOperation.java
@@ -50,6 +50,11 @@ public interface ExecutableRemoveByIdOperation {
 
 	}
 
-	interface ExecutableRemoveById extends RemoveByIdWithDurability {}
+	interface RemoveByIdWithCas extends RemoveByIdWithDurability {
+
+		RemoveByIdWithDurability withCas(Long cas);
+	}
+
+	interface ExecutableRemoveById extends RemoveByIdWithCas {}
 
 }

--- a/src/main/java/org/springframework/data/couchbase/core/ExecutableRemoveByIdOperationSupport.java
+++ b/src/main/java/org/springframework/data/couchbase/core/ExecutableRemoveByIdOperationSupport.java
@@ -35,7 +35,8 @@ public class ExecutableRemoveByIdOperationSupport implements ExecutableRemoveByI
 
 	@Override
 	public ExecutableRemoveById removeById() {
-		return new ExecutableRemoveByIdSupport(template, null, PersistTo.NONE, ReplicateTo.NONE, DurabilityLevel.NONE);
+		return new ExecutableRemoveByIdSupport(template, null, PersistTo.NONE, ReplicateTo.NONE, DurabilityLevel.NONE,
+				null);
 	}
 
 	static class ExecutableRemoveByIdSupport implements ExecutableRemoveById {
@@ -45,17 +46,19 @@ public class ExecutableRemoveByIdOperationSupport implements ExecutableRemoveByI
 		private final PersistTo persistTo;
 		private final ReplicateTo replicateTo;
 		private final DurabilityLevel durabilityLevel;
+		private final Long cas;
 		private final ReactiveRemoveByIdSupport reactiveRemoveByIdSupport;
 
 		ExecutableRemoveByIdSupport(final CouchbaseTemplate template, final String collection, final PersistTo persistTo,
-				final ReplicateTo replicateTo, final DurabilityLevel durabilityLevel) {
+				final ReplicateTo replicateTo, final DurabilityLevel durabilityLevel, Long cas) {
 			this.template = template;
 			this.collection = collection;
 			this.persistTo = persistTo;
 			this.replicateTo = replicateTo;
 			this.durabilityLevel = durabilityLevel;
+			this.cas = cas;
 			this.reactiveRemoveByIdSupport = new ReactiveRemoveByIdSupport(template.reactive(), collection, persistTo,
-					replicateTo, durabilityLevel);
+					replicateTo, durabilityLevel, cas);
 		}
 
 		@Override
@@ -71,20 +74,26 @@ public class ExecutableRemoveByIdOperationSupport implements ExecutableRemoveByI
 		@Override
 		public TerminatingRemoveById inCollection(final String collection) {
 			Assert.hasText(collection, "Collection must not be null nor empty.");
-			return new ExecutableRemoveByIdSupport(template, collection, persistTo, replicateTo, durabilityLevel);
+			return new ExecutableRemoveByIdSupport(template, collection, persistTo, replicateTo, durabilityLevel, null);
 		}
 
 		@Override
 		public RemoveByIdWithCollection withDurability(final DurabilityLevel durabilityLevel) {
 			Assert.notNull(durabilityLevel, "Durability Level must not be null.");
-			return new ExecutableRemoveByIdSupport(template, collection, persistTo, replicateTo, durabilityLevel);
+			return new ExecutableRemoveByIdSupport(template, collection, persistTo, replicateTo, durabilityLevel, null);
 		}
 
 		@Override
 		public RemoveByIdWithCollection withDurability(final PersistTo persistTo, final ReplicateTo replicateTo) {
 			Assert.notNull(persistTo, "PersistTo must not be null.");
 			Assert.notNull(replicateTo, "ReplicateTo must not be null.");
-			return new ExecutableRemoveByIdSupport(template, collection, persistTo, replicateTo, durabilityLevel);
+			return new ExecutableRemoveByIdSupport(template, collection, persistTo, replicateTo, durabilityLevel, null);
+		}
+
+		@Override
+		public RemoveByIdWithCas withCas(final Long cas) {
+			Assert.notNull(cas, "CAS must not be null.");
+			return new ExecutableRemoveByIdSupport(template, collection, persistTo, replicateTo, durabilityLevel, cas);
 		}
 
 	}

--- a/src/main/java/org/springframework/data/couchbase/core/ReactiveRemoveByIdOperation.java
+++ b/src/main/java/org/springframework/data/couchbase/core/ReactiveRemoveByIdOperation.java
@@ -42,6 +42,7 @@ public interface ReactiveRemoveByIdOperation {
 	interface RemoveByIdWithCollection extends TerminatingRemoveById, WithCollection<RemoveResult> {
 
 		TerminatingRemoveById inCollection(String collection);
+
 	}
 
 	interface RemoveByIdWithDurability extends RemoveByIdWithCollection, WithDurability<RemoveResult> {
@@ -52,6 +53,12 @@ public interface ReactiveRemoveByIdOperation {
 
 	}
 
-	interface ReactiveRemoveById extends RemoveByIdWithDurability {}
+	interface RemoveByIdWithCas extends RemoveByIdWithDurability {
+
+		RemoveByIdWithDurability withCas(Long cas);
+
+	}
+
+	interface ReactiveRemoveById extends RemoveByIdWithCas {}
 
 }

--- a/src/main/java/org/springframework/data/couchbase/core/ReactiveRemoveByIdOperationSupport.java
+++ b/src/main/java/org/springframework/data/couchbase/core/ReactiveRemoveByIdOperationSupport.java
@@ -37,7 +37,7 @@ public class ReactiveRemoveByIdOperationSupport implements ReactiveRemoveByIdOpe
 
 	@Override
 	public ReactiveRemoveById removeById() {
-		return new ReactiveRemoveByIdSupport(template, null, PersistTo.NONE, ReplicateTo.NONE, DurabilityLevel.NONE);
+		return new ReactiveRemoveByIdSupport(template, null, PersistTo.NONE, ReplicateTo.NONE, DurabilityLevel.NONE, null);
 	}
 
 	static class ReactiveRemoveByIdSupport implements ReactiveRemoveById {
@@ -47,14 +47,16 @@ public class ReactiveRemoveByIdOperationSupport implements ReactiveRemoveByIdOpe
 		private final PersistTo persistTo;
 		private final ReplicateTo replicateTo;
 		private final DurabilityLevel durabilityLevel;
+		private final Long cas;
 
 		ReactiveRemoveByIdSupport(final ReactiveCouchbaseTemplate template, final String collection,
-				final PersistTo persistTo, final ReplicateTo replicateTo, final DurabilityLevel durabilityLevel) {
+				final PersistTo persistTo, final ReplicateTo replicateTo, final DurabilityLevel durabilityLevel, Long cas) {
 			this.template = template;
 			this.collection = collection;
 			this.persistTo = persistTo;
 			this.replicateTo = replicateTo;
 			this.durabilityLevel = durabilityLevel;
+			this.cas = cas;
 		}
 
 		@Override
@@ -81,28 +83,36 @@ public class ReactiveRemoveByIdOperationSupport implements ReactiveRemoveByIdOpe
 			} else if (durabilityLevel != DurabilityLevel.NONE) {
 				options.durability(durabilityLevel);
 			}
+			if (cas != null) {
+				options.cas(cas);
+			}
 			return options;
+		}
+
+		@Override
+		public RemoveByIdWithDurability inCollection(final String collection) {
+			Assert.hasText(collection, "Collection must not be null nor empty.");
+			return new ReactiveRemoveByIdSupport(template, collection, persistTo, replicateTo, durabilityLevel, null);
 		}
 
 		@Override
 		public RemoveByIdWithCollection withDurability(final DurabilityLevel durabilityLevel) {
 			Assert.notNull(durabilityLevel, "Durability Level must not be null.");
-			return new ReactiveRemoveByIdSupport(template, collection, persistTo, replicateTo, durabilityLevel);
+			return new ReactiveRemoveByIdSupport(template, collection, persistTo, replicateTo, durabilityLevel, null);
 		}
 
 		@Override
 		public RemoveByIdWithCollection withDurability(final PersistTo persistTo, final ReplicateTo replicateTo) {
 			Assert.notNull(persistTo, "PersistTo must not be null.");
 			Assert.notNull(replicateTo, "ReplicateTo must not be null.");
-			return new ReactiveRemoveByIdSupport(template, collection, persistTo, replicateTo, durabilityLevel);
+			return new ReactiveRemoveByIdSupport(template, collection, persistTo, replicateTo, durabilityLevel, null);
 		}
 
 		@Override
-		public RemoveByIdWithDurability inCollection(final String collection) {
-			Assert.hasText(collection, "Collection must not be null nor empty.");
-			return new ReactiveRemoveByIdSupport(template, collection, persistTo, replicateTo, durabilityLevel);
+		public RemoveByIdWithDurability withCas(final Long cas) {
+			Assert.notNull(cas, "CAS must not be null.");
+			return new ReactiveRemoveByIdSupport(template, collection, persistTo, replicateTo, durabilityLevel, cas);
 		}
-
 	}
 
 }


### PR DESCRIPTION

Add withCas() method to RemoveById as the cas in the entity cannot be used as the entity is not pass in the API.  The other option was to add methods like one(T entity) and all(Collection<T>), but those class with one(String id) and all(Collection<String> ids).

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATACOUCH).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
