### PR TITLE
DATACOUCH-1053 - Parameterize operation intefaces with id-type.

### DIFF
--- a/src/main/java/org/springframework/data/couchbase/core/CouchbaseTemplate.java
+++ b/src/main/java/org/springframework/data/couchbase/core/CouchbaseTemplate.java
@@ -69,13 +69,12 @@ public class CouchbaseTemplate implements CouchbaseOperations, ApplicationContex
 		return new ExecutableReplaceByIdOperationSupport(this).replaceById(domainType);
 	}
 
-	@Override
-	public <T> ExecutableFindById<T> findById(Class<T> domainType) {
+	public <T,I> ExecutableFindById<T,I> findById(Class<T> domainType) {
 		return new ExecutableFindByIdOperationSupport(this).findById(domainType);
 	}
 
 	@Override
-	public <T> ExecutableFindFromReplicasById<T> findFromReplicasById(Class<T> domainType) {
+	public <T,I> ExecutableFindFromReplicasById<T,I> findFromReplicasById(Class<T> domainType) {
 		return new ExecutableFindFromReplicasByIdOperationSupport(this).findFromReplicasById(domainType);
 	}
 

--- a/src/main/java/org/springframework/data/couchbase/core/ExecutableExistsByIdOperation.java
+++ b/src/main/java/org/springframework/data/couchbase/core/ExecutableExistsByIdOperation.java
@@ -26,9 +26,9 @@ public interface ExecutableExistsByIdOperation {
 	/**
 	 * Checks if the document exists in the bucket.
 	 */
-	ExecutableExistsById existsById();
+	<T,I> ExecutableExistsById<T,I> existsById();
 
-	interface TerminatingExistsById extends OneAndAllExists {
+	interface TerminatingExistsById<T,I> extends OneAndAllExists<T,I> {
 
 		/**
 		 * Performs the operation on the ID given.
@@ -36,7 +36,7 @@ public interface ExecutableExistsByIdOperation {
 		 * @param id the ID to perform the operation on.
 		 * @return true if the document exists, false otherwise.
 		 */
-		boolean one(String id);
+		boolean one(I id);
 
 		/**
 		 * Performs the operation on the collection of ids.
@@ -44,20 +44,20 @@ public interface ExecutableExistsByIdOperation {
 		 * @param ids the ids to check.
 		 * @return a map consisting of the document IDs as the keys and if they exist as the value.
 		 */
-		Map<String, Boolean> all(Collection<String> ids);
+		Map<I, Boolean> all(Collection<I> ids);
 
 	}
 
-	interface ExistsByIdWithCollection extends TerminatingExistsById, WithCollection {
+	interface ExistsByIdWithCollection<T,I> extends TerminatingExistsById<T,I>, WithCollection<T> {
 
 		/**
 		 * Allows to specify a different collection than the default one configured.
 		 *
 		 * @param collection the collection to use in this scope.
 		 */
-		TerminatingExistsById inCollection(String collection);
+		TerminatingExistsById<T,I> inCollection(String collection);
 	}
 
-	interface ExecutableExistsById extends ExistsByIdWithCollection {}
+	interface ExecutableExistsById<T,I> extends ExistsByIdWithCollection<T,I> {}
 
 }

--- a/src/main/java/org/springframework/data/couchbase/core/ExecutableExistsByIdOperationSupport.java
+++ b/src/main/java/org/springframework/data/couchbase/core/ExecutableExistsByIdOperationSupport.java
@@ -35,10 +35,10 @@ public class ExecutableExistsByIdOperationSupport implements ExecutableExistsByI
 		return new ExecutableExistsByIdSupport(template, null);
 	}
 
-	static class ExecutableExistsByIdSupport implements ExecutableExistsById {
+	static class ExecutableExistsByIdSupport<T,I> implements ExecutableExistsById<T,I> {
 
 		private final CouchbaseTemplate template;
-		private final ReactiveExistsByIdSupport reactiveSupport;
+		private final ReactiveExistsByIdSupport<T,I> reactiveSupport;
 
 		ExecutableExistsByIdSupport(final CouchbaseTemplate template, final String collection) {
 			this.template = template;
@@ -46,12 +46,12 @@ public class ExecutableExistsByIdOperationSupport implements ExecutableExistsByI
 		}
 
 		@Override
-		public boolean one(final String id) {
+		public boolean one(final I id) {
 			return reactiveSupport.one(id).block();
 		}
 
 		@Override
-		public Map<String, Boolean> all(final Collection<String> ids) {
+		public Map<I, Boolean> all(final Collection<I> ids) {
 			return reactiveSupport.all(ids).block();
 		}
 

--- a/src/main/java/org/springframework/data/couchbase/core/ExecutableFindByAnalyticsOperation.java
+++ b/src/main/java/org/springframework/data/couchbase/core/ExecutableFindByAnalyticsOperation.java
@@ -37,7 +37,7 @@ public interface ExecutableFindByAnalyticsOperation {
 	 */
 	<T> ExecutableFindByAnalytics<T> findByAnalytics(Class<T> domainType);
 
-	interface TerminatingFindByAnalytics<T> extends OneAndAll<T> {
+	interface TerminatingFindByAnalytics<T> {
 
 		/**
 		 * Get exactly zero or one result.

--- a/src/main/java/org/springframework/data/couchbase/core/ExecutableFindByIdOperation.java
+++ b/src/main/java/org/springframework/data/couchbase/core/ExecutableFindByIdOperation.java
@@ -28,9 +28,9 @@ public interface ExecutableFindByIdOperation {
 	 *
 	 * @param domainType the entity type to use for the results.
 	 */
-	<T> ExecutableFindById<T> findById(Class<T> domainType);
+	<T,I> ExecutableFindById<T,I> findById(Class<T> domainType);
 
-	interface TerminatingFindById<T> extends OneAndAllId<T> {
+	interface TerminatingFindById<T,I> extends OneAndAllId<T,I> {
 
 		/**
 		 * Finds one document based on the given ID.
@@ -38,7 +38,7 @@ public interface ExecutableFindByIdOperation {
 		 * @param id the document ID.
 		 * @return the entity if found.
 		 */
-		T one(String id);
+		T one(I id);
 
 		/**
 		 * Finds a list of documents based on the given IDs.
@@ -46,32 +46,32 @@ public interface ExecutableFindByIdOperation {
 		 * @param ids the document ID ids.
 		 * @return the list of found entities.
 		 */
-		Collection<? extends T> all(Collection<String> ids);
+		Collection<? extends T> all(Collection<I> ids);
 
 	}
 
-	interface FindByIdWithCollection<T> extends TerminatingFindById<T>, WithCollection<T> {
+	interface FindByIdWithCollection<T,I> extends TerminatingFindById<T,I>, WithCollection<T> {
 
 		/**
 		 * Allows to specify a different collection than the default one configured.
 		 *
 		 * @param collection the collection to use in this scope.
 		 */
-		TerminatingFindById<T> inCollection(String collection);
+		TerminatingFindById<T,I> inCollection(String collection);
 
 	}
 
-	interface FindByIdWithProjection<T> extends FindByIdWithCollection<T>, WithProjectionId<T> {
+	interface FindByIdWithProjection<T,I> extends FindByIdWithCollection<T,I>, WithProjectionId<T,I> {
 
 		/**
 		 * Load only certain fields for the document.
 		 *
 		 * @param fields the projected fields to load.
 		 */
-		FindByIdWithCollection<T> project(String... fields);
+		FindByIdWithCollection<T,I> project(String... fields);
 
 	}
 
-	interface ExecutableFindById<T> extends FindByIdWithProjection<T> {}
+	interface ExecutableFindById<T,I> extends FindByIdWithProjection<T,I> {}
 
 }

--- a/src/main/java/org/springframework/data/couchbase/core/ExecutableFindByIdOperationSupport.java
+++ b/src/main/java/org/springframework/data/couchbase/core/ExecutableFindByIdOperationSupport.java
@@ -31,17 +31,17 @@ public class ExecutableFindByIdOperationSupport implements ExecutableFindByIdOpe
 	}
 
 	@Override
-	public <T> ExecutableFindById<T> findById(Class<T> domainType) {
-		return new ExecutableFindByIdSupport<>(template, domainType, null, null);
+	public <T,I> ExecutableFindById<T,I> findById(Class<T> domainType) {
+		return new ExecutableFindByIdSupport<T,I>(template, domainType, null, null);
 	}
 
-	static class ExecutableFindByIdSupport<T> implements ExecutableFindById<T> {
+	static class ExecutableFindByIdSupport<T,I> implements ExecutableFindById<T,I> {
 
 		private final CouchbaseTemplate template;
 		private final Class<T> domainType;
 		private final String collection;
 		private final List<String> fields;
-		private final ReactiveFindByIdSupport<T> reactiveSupport;
+		private final ReactiveFindByIdSupport<T,I> reactiveSupport;
 
 		ExecutableFindByIdSupport(CouchbaseTemplate template, Class<T> domainType, String collection, List<String> fields) {
 			this.template = template;
@@ -52,23 +52,23 @@ public class ExecutableFindByIdOperationSupport implements ExecutableFindByIdOpe
 		}
 
 		@Override
-		public T one(final String id) {
+		public T one(final I id) {
 			return reactiveSupport.one(id).block();
 		}
 
 		@Override
-		public Collection<? extends T> all(final Collection<String> ids) {
+		public Collection<? extends T> all(final Collection<I> ids) {
 			return reactiveSupport.all(ids).collectList().block();
 		}
 
 		@Override
-		public TerminatingFindById<T> inCollection(final String collection) {
+		public TerminatingFindById<T,I> inCollection(final String collection) {
 			Assert.hasText(collection, "Collection must not be null nor empty.");
 			return new ExecutableFindByIdSupport<>(template, domainType, collection, fields);
 		}
 
 		@Override
-		public FindByIdWithCollection<T> project(String... fields) {
+		public FindByIdWithCollection<T,I> project(String... fields) {
 			Assert.notEmpty(fields, "Fields must not be null nor empty.");
 			return new ExecutableFindByIdSupport<>(template, domainType, collection, Arrays.asList(fields));
 		}

--- a/src/main/java/org/springframework/data/couchbase/core/ExecutableFindFromReplicasByIdOperation.java
+++ b/src/main/java/org/springframework/data/couchbase/core/ExecutableFindFromReplicasByIdOperation.java
@@ -22,21 +22,21 @@ import org.springframework.data.couchbase.core.support.WithCollection;
 
 public interface ExecutableFindFromReplicasByIdOperation {
 
-	<T> ExecutableFindFromReplicasById<T> findFromReplicasById(Class<T> domainType);
+	<T,I> ExecutableFindFromReplicasById<T,I> findFromReplicasById(Class<T> domainType);
 
-	interface TerminatingFindFromReplicasById<T> extends AnyId<T> {
+	interface TerminatingFindFromReplicasById<T,I> extends AnyId<T,I> {
 
-		T any(String id);
+		T any(I id);
 
-		Collection<? extends T> any(Collection<String> ids);
+		Collection<? extends T> any(Collection<I> ids);
 
 	}
 
-	interface FindFromReplicasByIdWithCollection<T> extends TerminatingFindFromReplicasById<T>, WithCollection<T> {
+	interface FindFromReplicasByIdWithCollection<T,I> extends TerminatingFindFromReplicasById<T,I>, WithCollection<T> {
 
-		TerminatingFindFromReplicasById<T> inCollection(String collection);
+		TerminatingFindFromReplicasById<T,I> inCollection(String collection);
 	}
 
-	interface ExecutableFindFromReplicasById<T> extends FindFromReplicasByIdWithCollection<T> {}
+	interface ExecutableFindFromReplicasById<T,I> extends FindFromReplicasByIdWithCollection<T,I> {}
 
 }

--- a/src/main/java/org/springframework/data/couchbase/core/ExecutableFindFromReplicasByIdOperationSupport.java
+++ b/src/main/java/org/springframework/data/couchbase/core/ExecutableFindFromReplicasByIdOperationSupport.java
@@ -29,17 +29,17 @@ public class ExecutableFindFromReplicasByIdOperationSupport implements Executabl
 	}
 
 	@Override
-	public <T> ExecutableFindFromReplicasById<T> findFromReplicasById(Class<T> domainType) {
+	public <T,I> ExecutableFindFromReplicasById<T,I> findFromReplicasById(Class<T> domainType) {
 		return new ExecutableFindFromReplicasByIdSupport<>(template, domainType, domainType, null);
 	}
 
-	static class ExecutableFindFromReplicasByIdSupport<T> implements ExecutableFindFromReplicasById<T> {
+	static class ExecutableFindFromReplicasByIdSupport<T,I> implements ExecutableFindFromReplicasById<T,I> {
 
 		private final CouchbaseTemplate template;
 		private final Class<?> domainType;
 		private final Class<T> returnType;
 		private final String collection;
-		private final ReactiveFindFromReplicasByIdSupport<T> reactiveSupport;
+		private final ReactiveFindFromReplicasByIdSupport<T,I> reactiveSupport;
 
 		ExecutableFindFromReplicasByIdSupport(CouchbaseTemplate template, Class<?> domainType, Class<T> returnType,
 				String collection) {
@@ -52,17 +52,17 @@ public class ExecutableFindFromReplicasByIdOperationSupport implements Executabl
 		}
 
 		@Override
-		public T any(String id) {
+		public T any(I id) {
 			return reactiveSupport.any(id).block();
 		}
 
 		@Override
-		public Collection<? extends T> any(Collection<String> ids) {
+		public Collection<? extends T> any(Collection<I> ids) {
 			return reactiveSupport.any(ids).collectList().block();
 		}
 
 		@Override
-		public TerminatingFindFromReplicasById<T> inCollection(final String collection) {
+		public TerminatingFindFromReplicasById<T,I> inCollection(final String collection) {
 			Assert.hasText(collection, "Collection must not be null nor empty.");
 			return new ExecutableFindFromReplicasByIdSupport<>(template, domainType, returnType, collection);
 		}

--- a/src/main/java/org/springframework/data/couchbase/core/ExecutableInsertByIdOperation.java
+++ b/src/main/java/org/springframework/data/couchbase/core/ExecutableInsertByIdOperation.java
@@ -27,9 +27,9 @@ import com.couchbase.client.java.kv.ReplicateTo;
 
 public interface ExecutableInsertByIdOperation {
 
-	<T> ExecutableInsertById<T> insertById(Class<T> domainType);
+	<T> ExecutableInsertById<T>insertById(Class<T> domainType);
 
-	interface TerminatingInsertById<T> extends OneAndAllEntity<T> {
+	interface TerminatingInsertById<T>  extends OneAndAllEntity<T>  {
 
 		@Override
 		T one(T object);

--- a/src/main/java/org/springframework/data/couchbase/core/ExecutableRemoveByIdOperation.java
+++ b/src/main/java/org/springframework/data/couchbase/core/ExecutableRemoveByIdOperation.java
@@ -27,29 +27,29 @@ import com.couchbase.client.java.kv.ReplicateTo;
 
 public interface ExecutableRemoveByIdOperation {
 
-	ExecutableRemoveById removeById();
+	<T,I> ExecutableRemoveById<T,I> removeById();
 
-	interface TerminatingRemoveById extends OneAndAllId<RemoveResult> {
+	interface TerminatingRemoveById<T,I> extends OneAndAllId<RemoveResult,I> {
 
-		RemoveResult one(String id);
+		RemoveResult<I> one(I id);
 
-		List<RemoveResult> all(Collection<String> ids);
+		List<RemoveResult<I>> all(Collection<I> ids);
 
 	}
 
-	interface RemoveByIdWithCollection extends TerminatingRemoveById, WithCollection<RemoveResult> {
+	interface RemoveByIdWithCollection<T,I> extends TerminatingRemoveById<T,I>, WithCollection<RemoveResult> {
 
 		TerminatingRemoveById inCollection(String collection);
 	}
 
-	interface RemoveByIdWithDurability extends RemoveByIdWithCollection, WithDurability<RemoveResult> {
+	interface RemoveByIdWithDurability<T,I> extends RemoveByIdWithCollection<T,I>, WithDurability<RemoveResult> {
 
-		RemoveByIdWithCollection withDurability(DurabilityLevel durabilityLevel);
+		RemoveByIdWithCollection<T,I> withDurability(DurabilityLevel durabilityLevel);
 
-		RemoveByIdWithCollection withDurability(PersistTo persistTo, ReplicateTo replicateTo);
+		RemoveByIdWithCollection<T,I> withDurability(PersistTo persistTo, ReplicateTo replicateTo);
 
 	}
 
-	interface ExecutableRemoveById extends RemoveByIdWithDurability {}
+	interface ExecutableRemoveById<T,I> extends RemoveByIdWithDurability<T,I> {}
 
 }

--- a/src/main/java/org/springframework/data/couchbase/core/ExecutableRemoveByIdOperationSupport.java
+++ b/src/main/java/org/springframework/data/couchbase/core/ExecutableRemoveByIdOperationSupport.java
@@ -38,14 +38,14 @@ public class ExecutableRemoveByIdOperationSupport implements ExecutableRemoveByI
 		return new ExecutableRemoveByIdSupport(template, null, PersistTo.NONE, ReplicateTo.NONE, DurabilityLevel.NONE);
 	}
 
-	static class ExecutableRemoveByIdSupport implements ExecutableRemoveById {
+	static class ExecutableRemoveByIdSupport<T,I> implements ExecutableRemoveById<T,I> {
 
 		private final CouchbaseTemplate template;
 		private final String collection;
 		private final PersistTo persistTo;
 		private final ReplicateTo replicateTo;
 		private final DurabilityLevel durabilityLevel;
-		private final ReactiveRemoveByIdSupport reactiveRemoveByIdSupport;
+		private final ReactiveRemoveByIdSupport<RemoveResult,I> reactiveRemoveByIdSupport;
 
 		ExecutableRemoveByIdSupport(final CouchbaseTemplate template, final String collection, final PersistTo persistTo,
 				final ReplicateTo replicateTo, final DurabilityLevel durabilityLevel) {
@@ -54,17 +54,17 @@ public class ExecutableRemoveByIdOperationSupport implements ExecutableRemoveByI
 			this.persistTo = persistTo;
 			this.replicateTo = replicateTo;
 			this.durabilityLevel = durabilityLevel;
-			this.reactiveRemoveByIdSupport = new ReactiveRemoveByIdSupport(template.reactive(), collection, persistTo,
+			this.reactiveRemoveByIdSupport = new ReactiveRemoveByIdSupport<RemoveResult,I>(template.reactive(), collection, persistTo,
 					replicateTo, durabilityLevel);
 		}
 
 		@Override
-		public RemoveResult one(final String id) {
+		public RemoveResult<I> one(final I id) {
 			return reactiveRemoveByIdSupport.one(id).block();
 		}
 
 		@Override
-		public List<RemoveResult> all(final Collection<String> ids) {
+		public List<RemoveResult<I>> all(final Collection<I> ids) {
 			return reactiveRemoveByIdSupport.all(ids).collectList().block();
 		}
 

--- a/src/main/java/org/springframework/data/couchbase/core/ReactiveCouchbaseTemplate.java
+++ b/src/main/java/org/springframework/data/couchbase/core/ReactiveCouchbaseTemplate.java
@@ -55,7 +55,7 @@ public class ReactiveCouchbaseTemplate implements ReactiveCouchbaseOperations, A
 	}
 
 	@Override
-	public <T> ReactiveFindById<T> findById(Class<T> domainType) {
+	public <T,I> ReactiveFindById<T,I> findById(Class<T> domainType) {
 		return new ReactiveFindByIdOperationSupport(this).findById(domainType);
 	}
 
@@ -75,7 +75,7 @@ public class ReactiveCouchbaseTemplate implements ReactiveCouchbaseOperations, A
 	}
 
 	@Override
-	public <T> ReactiveFindFromReplicasById<T> findFromReplicasById(Class<T> domainType) {
+	public <T,I> ReactiveFindFromReplicasById<T,I> findFromReplicasById(Class<T> domainType) {
 		return new ReactiveFindFromReplicasByIdOperationSupport(this).findFromReplicasById(domainType);
 	}
 

--- a/src/main/java/org/springframework/data/couchbase/core/ReactiveExistsByIdOperation.java
+++ b/src/main/java/org/springframework/data/couchbase/core/ReactiveExistsByIdOperation.java
@@ -28,9 +28,9 @@ public interface ReactiveExistsByIdOperation {
 	/**
 	 * Checks if the document exists in the bucket.
 	 */
-	ReactiveExistsById existsById();
+	<T,I> ReactiveExistsById<T,I> existsById();
 
-	interface TerminatingExistsById extends OneAndAllExistsReactive {
+	interface TerminatingExistsById<T,I> extends OneAndAllExistsReactive<T,I> {
 
 		/**
 		 * Performs the operation on the ID given.
@@ -38,7 +38,7 @@ public interface ReactiveExistsByIdOperation {
 		 * @param id the ID to perform the operation on.
 		 * @return true if the document exists, false otherwise.
 		 */
-		Mono<Boolean> one(String id);
+		Mono<Boolean> one(I id);
 
 		/**
 		 * Performs the operation on the collection of ids.
@@ -46,21 +46,21 @@ public interface ReactiveExistsByIdOperation {
 		 * @param ids the ids to check.
 		 * @return a map consisting of the document IDs as the keys and if they exist as the value.
 		 */
-		Mono<Map<String, Boolean>> all(Collection<String> ids);
+		Mono<Map<I, Boolean>> all(Collection<I> ids);
 
 	}
 
-	interface ExistsByIdWithCollection extends TerminatingExistsById, WithCollection {
+	interface ExistsByIdWithCollection<T,I> extends TerminatingExistsById<T,I>, WithCollection<T> {
 
 		/**
 		 * Allows to specify a different collection than the default one configured.
 		 *
 		 * @param collection the collection to use in this scope.
 		 */
-		TerminatingExistsById inCollection(String collection);
+		TerminatingExistsById<T,I> inCollection(String collection);
 
 	}
 
-	interface ReactiveExistsById extends ExistsByIdWithCollection {}
+	interface ReactiveExistsById<T,I> extends ExistsByIdWithCollection<T,I> {}
 
 }

--- a/src/main/java/org/springframework/data/couchbase/core/ReactiveExistsByIdOperationSupport.java
+++ b/src/main/java/org/springframework/data/couchbase/core/ReactiveExistsByIdOperationSupport.java
@@ -38,11 +38,11 @@ public class ReactiveExistsByIdOperationSupport implements ReactiveExistsByIdOpe
 	}
 
 	@Override
-	public ReactiveExistsById existsById() {
+	public <T,I> ReactiveExistsById<T,I> existsById() {
 		return new ReactiveExistsByIdSupport(template, null);
 	}
 
-	static class ReactiveExistsByIdSupport implements ReactiveExistsById {
+	static class ReactiveExistsByIdSupport<T,I> implements ReactiveExistsById<T,I> {
 
 		private final ReactiveCouchbaseTemplate template;
 		private final String collection;
@@ -53,9 +53,9 @@ public class ReactiveExistsByIdOperationSupport implements ReactiveExistsByIdOpe
 		}
 
 		@Override
-		public Mono<Boolean> one(final String id) {
+		public Mono<Boolean> one(final I id) {
 			return Mono.just(id).flatMap(
-					docId -> template.getCollection(collection).reactive().exists(id, existsOptions()).map(ExistsResult::exists))
+					docId -> template.getCollection(collection).reactive().exists(id.toString(), existsOptions()).map(ExistsResult::exists))
 					.onErrorMap(throwable -> {
 						if (throwable instanceof RuntimeException) {
 							return template.potentiallyConvertRuntimeException((RuntimeException) throwable);
@@ -66,7 +66,7 @@ public class ReactiveExistsByIdOperationSupport implements ReactiveExistsByIdOpe
 		}
 
 		@Override
-		public Mono<Map<String, Boolean>> all(final Collection<String> ids) {
+		public Mono<Map<I, Boolean>> all(final Collection<I> ids) {
 			return Flux.fromIterable(ids).flatMap(id -> one(id).map(result -> Tuples.of(id, result)))
 					.collectMap(Tuple2::getT1, Tuple2::getT2);
 		}

--- a/src/main/java/org/springframework/data/couchbase/core/ReactiveFindByIdOperation.java
+++ b/src/main/java/org/springframework/data/couchbase/core/ReactiveFindByIdOperation.java
@@ -31,9 +31,9 @@ public interface ReactiveFindByIdOperation {
 	 *
 	 * @param domainType the entity type to use for the results.
 	 */
-	<T> ReactiveFindById<T> findById(Class<T> domainType);
+	<T,I> ReactiveFindById<T,I> findById(Class<T> domainType);
 
-	interface TerminatingFindById<T> extends OneAndAllIdReactive<T> {
+	interface TerminatingFindById<T,I> extends OneAndAllIdReactive<T,I> {
 
 		/**
 		 * Finds one document based on the given ID.
@@ -41,7 +41,7 @@ public interface ReactiveFindByIdOperation {
 		 * @param id the document ID.
 		 * @return the entity if found.
 		 */
-		Mono<T> one(String id);
+		Mono<T> one(I id);
 
 		/**
 		 * Finds a list of documents based on the given IDs.
@@ -49,31 +49,31 @@ public interface ReactiveFindByIdOperation {
 		 * @param ids the document ID ids.
 		 * @return the list of found entities.
 		 */
-		Flux<? extends T> all(Collection<String> ids);
+		Flux<? extends T> all(Collection<I> ids);
 
 	}
 
-	interface FindByIdWithCollection<T> extends TerminatingFindById<T>, WithCollection<T> {
+	interface FindByIdWithCollection<T,I> extends TerminatingFindById<T,I>, WithCollection<T> {
 
 		/**
 		 * Allows to specify a different collection than the default one configured.
 		 *
 		 * @param collection the collection to use in this scope.
 		 */
-		TerminatingFindById<T> inCollection(String collection);
+		TerminatingFindById<T,I> inCollection(String collection);
 	}
 
-	interface FindByIdWithProjection<T> extends FindByIdWithCollection<T>, WithProjectionId<T> {
+	interface FindByIdWithProjection<T,I> extends FindByIdWithCollection<T,I>, WithProjectionId<T,I> {
 
 		/**
 		 * Load only certain fields for the document.
 		 *
 		 * @param fields the projected fields to load.
 		 */
-		FindByIdWithCollection<T> project(String... fields);
+		FindByIdWithCollection<T,I> project(String... fields);
 
 	}
 
-	interface ReactiveFindById<T> extends FindByIdWithProjection<T> {}
+	interface ReactiveFindById<T,I> extends FindByIdWithProjection<T,I> {}
 
 }

--- a/src/main/java/org/springframework/data/couchbase/core/ReactiveFindByQueryOperation.java
+++ b/src/main/java/org/springframework/data/couchbase/core/ReactiveFindByQueryOperation.java
@@ -48,7 +48,7 @@ public interface ReactiveFindByQueryOperation {
 	/**
 	 * Compose find execution by calling one of the terminating methods.
 	 */
-	interface TerminatingFindByQuery<T> extends OneAndAllReactive<T> {
+	interface TerminatingFindByQuery<T>  {
 
 		/**
 		 * Get exactly zero or one result.

--- a/src/main/java/org/springframework/data/couchbase/core/ReactiveFindFromReplicasByIdOperation.java
+++ b/src/main/java/org/springframework/data/couchbase/core/ReactiveFindFromReplicasByIdOperation.java
@@ -25,21 +25,21 @@ import org.springframework.data.couchbase.core.support.WithCollection;
 
 public interface ReactiveFindFromReplicasByIdOperation {
 
-	<T> ReactiveFindFromReplicasById<T> findFromReplicasById(Class<T> domainType);
+	<T,I> ReactiveFindFromReplicasById<T,I> findFromReplicasById(Class<T> domainType);
 
-	interface TerminatingFindFromReplicasById<T> extends AnyIdReactive<T> {
+	interface TerminatingFindFromReplicasById<T,I> extends AnyIdReactive<T,I> {
 
-		Mono<T> any(String id);
+		Mono<T> any(I id);
 
-		Flux<? extends T> any(Collection<String> ids);
+		Flux<? extends T> any(Collection<I> ids);
 
 	}
 
-	interface FindFromReplicasByIdWithCollection<T> extends TerminatingFindFromReplicasById<T>, WithCollection<T> {
+	interface FindFromReplicasByIdWithCollection<T,I> extends TerminatingFindFromReplicasById<T,I>, WithCollection<T> {
 
-		TerminatingFindFromReplicasById<T> inCollection(String collection);
+		TerminatingFindFromReplicasById<T,I> inCollection(String collection);
 	}
 
-	interface ReactiveFindFromReplicasById<T> extends FindFromReplicasByIdWithCollection<T> {}
+	interface ReactiveFindFromReplicasById<T,I> extends FindFromReplicasByIdWithCollection<T,I> {}
 
 }

--- a/src/main/java/org/springframework/data/couchbase/core/ReactiveRemoveByIdOperation.java
+++ b/src/main/java/org/springframework/data/couchbase/core/ReactiveRemoveByIdOperation.java
@@ -29,29 +29,29 @@ import com.couchbase.client.java.kv.ReplicateTo;
 
 public interface ReactiveRemoveByIdOperation {
 
-	ReactiveRemoveById removeById();
+	<T,I> ReactiveRemoveById<T,I> removeById();
 
-	interface TerminatingRemoveById extends OneAndAllIdReactive<RemoveResult> {
+	interface TerminatingRemoveById<T,I> extends OneAndAllIdReactive<RemoveResult<I>,I> {
 
-		Mono<RemoveResult> one(String id);
+		Mono<RemoveResult<I>> one(I id);
 
-		Flux<RemoveResult> all(Collection<String> ids);
-
-	}
-
-	interface RemoveByIdWithCollection extends TerminatingRemoveById, WithCollection<RemoveResult> {
-
-		TerminatingRemoveById inCollection(String collection);
-	}
-
-	interface RemoveByIdWithDurability extends RemoveByIdWithCollection, WithDurability<RemoveResult> {
-
-		RemoveByIdWithCollection withDurability(DurabilityLevel durabilityLevel);
-
-		RemoveByIdWithCollection withDurability(PersistTo persistTo, ReplicateTo replicateTo);
+		Flux<RemoveResult<I>> all(Collection<I> ids);
 
 	}
 
-	interface ReactiveRemoveById extends RemoveByIdWithDurability {}
+	interface RemoveByIdWithCollection<T,I> extends TerminatingRemoveById<T,I>, WithCollection<RemoveResult> {
+
+		TerminatingRemoveById<T,I> inCollection(String collection);
+	}
+
+	interface RemoveByIdWithDurability<T,I> extends RemoveByIdWithCollection<T,I>, WithDurability<RemoveResult> {
+
+		RemoveByIdWithCollection<T,I> withDurability(DurabilityLevel durabilityLevel);
+
+		RemoveByIdWithCollection<T,I> withDurability(PersistTo persistTo, ReplicateTo replicateTo);
+
+	}
+
+	interface ReactiveRemoveById<T,I> extends RemoveByIdWithDurability<T,I> {}
 
 }

--- a/src/main/java/org/springframework/data/couchbase/core/ReactiveRemoveByIdOperationSupport.java
+++ b/src/main/java/org/springframework/data/couchbase/core/ReactiveRemoveByIdOperationSupport.java
@@ -40,7 +40,7 @@ public class ReactiveRemoveByIdOperationSupport implements ReactiveRemoveByIdOpe
 		return new ReactiveRemoveByIdSupport(template, null, PersistTo.NONE, ReplicateTo.NONE, DurabilityLevel.NONE);
 	}
 
-	static class ReactiveRemoveByIdSupport implements ReactiveRemoveById {
+	static class ReactiveRemoveByIdSupport<T,I> implements ReactiveRemoveById<RemoveResult,I> {
 
 		private final ReactiveCouchbaseTemplate template;
 		private final String collection;
@@ -58,9 +58,9 @@ public class ReactiveRemoveByIdOperationSupport implements ReactiveRemoveByIdOpe
 		}
 
 		@Override
-		public Mono<RemoveResult> one(final String id) {
+		public Mono<RemoveResult<I>> one(final I id) {
 			return Mono.just(id).flatMap(docId -> template.getCollection(collection).reactive()
-					.remove(id, buildRemoveOptions()).map(r -> RemoveResult.from(docId, r))).onErrorMap(throwable -> {
+					.remove(id.toString(), buildRemoveOptions()).map(r -> RemoveResult.from(docId, r))).onErrorMap(throwable -> {
 						if (throwable instanceof RuntimeException) {
 							return template.potentiallyConvertRuntimeException((RuntimeException) throwable);
 						} else {
@@ -70,7 +70,7 @@ public class ReactiveRemoveByIdOperationSupport implements ReactiveRemoveByIdOpe
 		}
 
 		@Override
-		public Flux<RemoveResult> all(final Collection<String> ids) {
+		public Flux<RemoveResult<I>> all(final Collection<I> ids) {
 			return Flux.fromIterable(ids).flatMap(this::one);
 		}
 

--- a/src/main/java/org/springframework/data/couchbase/core/RemoveResult.java
+++ b/src/main/java/org/springframework/data/couchbase/core/RemoveResult.java
@@ -22,23 +22,23 @@ import java.util.Optional;
 import com.couchbase.client.core.msg.kv.MutationToken;
 import com.couchbase.client.java.kv.MutationResult;
 
-public class RemoveResult {
+public class RemoveResult<I> {
 
-	private final String id;
+	private final I id;
 	private final long cas;
 	private final Optional<MutationToken> mutationToken;
 
-	public RemoveResult(String id, long cas, Optional<MutationToken> mutationToken) {
+	public RemoveResult(I id, long cas, Optional<MutationToken> mutationToken) {
 		this.id = id;
 		this.cas = cas;
 		this.mutationToken = mutationToken;
 	}
 
-	public static RemoveResult from(final String id, final MutationResult result) {
-		return new RemoveResult(id, result.cas(), result.mutationToken());
+	public static <I> RemoveResult<I> from(final I id, final MutationResult result) {
+		return new RemoveResult<I>(id, result.cas(), result.mutationToken());
 	}
 
-	public String getId() {
+	public I getId() {
 		return id;
 	}
 

--- a/src/main/java/org/springframework/data/couchbase/core/support/AnyId.java
+++ b/src/main/java/org/springframework/data/couchbase/core/support/AnyId.java
@@ -23,9 +23,9 @@ import java.util.Collection;
  * @author Michael Reiche
  * @param <T> - the entity class
  */
-public interface AnyId<T> {
+public interface AnyId<T,I> {
 
-	T any(String id);
+	T any(I id);
 
-	Collection<? extends T> any(Collection<String> ids);
+	Collection<? extends T> any(Collection<I> ids);
 }

--- a/src/main/java/org/springframework/data/couchbase/core/support/AnyIdReactive.java
+++ b/src/main/java/org/springframework/data/couchbase/core/support/AnyIdReactive.java
@@ -27,8 +27,8 @@ import java.util.Collection;
  * @param <T> - the entity class
  */
 
-public interface AnyIdReactive<T> {
-	Mono<T> any(String id);
+public interface AnyIdReactive<T,I> {
+	Mono<T> any(I id);
 
-	Flux<? extends T> any(Collection<String> ids);
+	Flux<? extends T> any(Collection<I> ids);
 }

--- a/src/main/java/org/springframework/data/couchbase/core/support/OneAndAllExists.java
+++ b/src/main/java/org/springframework/data/couchbase/core/support/OneAndAllExists.java
@@ -27,8 +27,8 @@ import java.util.stream.Stream;
  *
  * @param <T> - the entity class
  */
-public interface OneAndAllExists {
-  boolean one(String id);
+public interface OneAndAllExists<T,I> {
+  boolean one(I id);
 
-  Map<String,Boolean> all(Collection<String> ids);
+  Map<I,Boolean> all(Collection<I> ids);
 }

--- a/src/main/java/org/springframework/data/couchbase/core/support/OneAndAllExistsReactive.java
+++ b/src/main/java/org/springframework/data/couchbase/core/support/OneAndAllExistsReactive.java
@@ -27,8 +27,8 @@ import java.util.Map;
  *
  * @param <T> - the entity class
  */
-public interface OneAndAllExistsReactive {
-  Mono<Boolean> one(String id);
+public interface OneAndAllExistsReactive<T,I> {
+  Mono<Boolean> one(I id);
 
-  Mono<Map<String,Boolean>> all(Collection<String> ids);
+  Mono<Map<I,Boolean>> all(Collection<I> ids);
 }

--- a/src/main/java/org/springframework/data/couchbase/core/support/OneAndAllId.java
+++ b/src/main/java/org/springframework/data/couchbase/core/support/OneAndAllId.java
@@ -24,9 +24,9 @@ import java.util.Collection;
  *
  * @param <T> - the entity class
  */
-public interface OneAndAllId<T> {
+public interface OneAndAllId<T,I> {
 
-	T one(String id);
+	T one(I id);
 
-  Collection<? extends T> all(Collection<String> ids);
+  Collection<? extends T> all(Collection<I> ids);
 }

--- a/src/main/java/org/springframework/data/couchbase/core/support/OneAndAllIdReactive.java
+++ b/src/main/java/org/springframework/data/couchbase/core/support/OneAndAllIdReactive.java
@@ -27,8 +27,8 @@ import java.util.Collection;
  * @param <T> - the entity class
  */
 
-public interface OneAndAllIdReactive<T> {
-	Mono<T> one(String id);
+public interface OneAndAllIdReactive<T,I> {
+	Mono<T> one(I id);
 
-	Flux<? extends T> all(Collection<String> ids);
+	Flux<? extends T> all(Collection<I> ids);
 }

--- a/src/main/java/org/springframework/data/couchbase/core/support/OneAndAllReactive.java
+++ b/src/main/java/org/springframework/data/couchbase/core/support/OneAndAllReactive.java
@@ -29,7 +29,7 @@ import java.util.stream.Stream;
  * @param <T> - the entity class
  */
 
-public interface OneAndAllReactive<T> {
+public interface OneAndAllReactive<T,I> {
 	Mono<T> one();
 
 	Mono<T> first();

--- a/src/main/java/org/springframework/data/couchbase/core/support/WithProjection.java
+++ b/src/main/java/org/springframework/data/couchbase/core/support/WithProjection.java
@@ -21,7 +21,7 @@ package org.springframework.data.couchbase.core.support;
  * @author Michael Reiche
  * @param <R> - the entity class
  */
-public interface WithProjection<R> {
+public interface WithProjection<R,I> {
 	Object as(Class<R> returnType);
 
 }

--- a/src/main/java/org/springframework/data/couchbase/core/support/WithProjectionId.java
+++ b/src/main/java/org/springframework/data/couchbase/core/support/WithProjectionId.java
@@ -21,7 +21,7 @@ package org.springframework.data.couchbase.core.support;
  * @author Michael Reiche
  * @param <R> - the entity class
  */
-public interface WithProjectionId<R> {
+public interface WithProjectionId<R,I> {
 	Object project(String[] fields);
 
 }

--- a/src/main/java/org/springframework/data/couchbase/repository/support/SimpleCouchbaseRepository.java
+++ b/src/main/java/org/springframework/data/couchbase/repository/support/SimpleCouchbaseRepository.java
@@ -101,7 +101,7 @@ public class SimpleCouchbaseRepository<T, ID> implements CouchbaseRepository<T, 
 	@Override
 	public List<T> findAllById(Iterable<ID> ids) {
 		Assert.notNull(ids, "The given Iterable of ids must not be null!");
-		List<String> convertedIds = Streamable.of(ids).stream().map(Objects::toString).collect(Collectors.toList());
+		List<Object> convertedIds = Streamable.of(ids).stream().map(Objects::toString).collect(Collectors.toList());
 		Collection<? extends T> all = couchbaseOperations.findById(entityInformation.getJavaType()).all(convertedIds);
 		return Streamable.of(all).stream().collect(StreamUtils.toUnmodifiableList());
 	}
@@ -127,13 +127,13 @@ public class SimpleCouchbaseRepository<T, ID> implements CouchbaseRepository<T, 
 	@Override
 	public void deleteAllById(Iterable<? extends ID> ids) {
 		Assert.notNull(ids, "The given Iterable of ids must not be null!");
-		couchbaseOperations.removeById().all(Streamable.of(ids).map(Objects::toString).toList());
+		couchbaseOperations.removeById().all(Streamable.of(ids).map(Objects::toString).map(id -> (Object)id).toList());
 	}
 
 	@Override
 	public void deleteAll(Iterable<? extends T> entities) {
 		Assert.notNull(entities, "The given Iterable of entities must not be null!");
-		couchbaseOperations.removeById().all(Streamable.of(entities).map(entityInformation::getId).toList());
+		couchbaseOperations.removeById().all(Streamable.of(entities).map(entityInformation::getId).map(id -> (Object)id).toList());
 	}
 
 	@Override

--- a/src/main/java/org/springframework/data/couchbase/repository/support/SimpleReactiveCouchbaseRepository.java
+++ b/src/main/java/org/springframework/data/couchbase/repository/support/SimpleReactiveCouchbaseRepository.java
@@ -139,7 +139,7 @@ public class SimpleReactiveCouchbaseRepository<T, ID> implements ReactiveCouchba
 	@Override
 	public Flux<T> findAllById(Iterable<ID> ids) {
 		Assert.notNull(ids, "The given Iterable of ids must not be null!");
-		List<String> convertedIds = Streamable.of(ids).stream().map(Objects::toString).collect(Collectors.toList());
+		List<Object> convertedIds = Streamable.of(ids).stream().map(Objects::toString).collect(Collectors.toList());
 		return (Flux<T>) operations.findById(entityInformation.getJavaType()).all(convertedIds);
 	}
 
@@ -168,12 +168,12 @@ public class SimpleReactiveCouchbaseRepository<T, ID> implements ReactiveCouchba
 
 	@Override
 	public Mono<Void> deleteAllById(Iterable<? extends ID> ids) {
-		return operations.removeById().all(Streamable.of(ids).map(Object::toString).toList()).then();
+		return operations.removeById().all(Streamable.of(ids).map(Object::toString).map(id -> (Object)id).toList()).then();
 	}
 
 	@Override
 	public Mono<Void> deleteAll(Iterable<? extends T> entities) {
-		return operations.removeById().all(Streamable.of(entities).map(entityInformation::getId).toList()).then();
+		return operations.removeById().all(Streamable.of(entities).map(entityInformation::getId).map(id -> (Object)id).toList()).then();
 	}
 
 	@Override

--- a/src/test/java/org/springframework/data/couchbase/core/CouchbaseTemplateKeyValueIntegrationTests.java
+++ b/src/test/java/org/springframework/data/couchbase/core/CouchbaseTemplateKeyValueIntegrationTests.java
@@ -98,8 +98,8 @@ class CouchbaseTemplateKeyValueIntegrationTests extends JavaIntegrationTests {
 		for (OneAndAllEntity<User> operator : new OneAndAllEntity[] { couchbaseTemplate.insertById(clazz),
 				couchbaseTemplate.replaceById(clazz), couchbaseTemplate.upsertById(clazz) }) {
 			// create an entity of type clazz
-			Constructor cons = clazz.getConstructor(String.class, String.class, String.class);
-			User user = (User) cons.newInstance("" + operator.getClass().getSimpleName() + "_" + clazz.getSimpleName(),
+			Constructor cons = clazz.getConstructor(UUID.class, String.class, String.class);
+			User user = (User) cons.newInstance(UUID.randomUUID(),
 					"firstname", "lastname");
 
 			if (clazz.equals(User.class)) { // User.java doesn't have an durability annotation
@@ -139,7 +139,7 @@ class CouchbaseTemplateKeyValueIntegrationTests extends JavaIntegrationTests {
 
 				// create an entity of type clazz
 				Constructor cons = clazz.getConstructor(String.class, String.class, String.class);
-				User user = (User) cons.newInstance("" + operator.getClass().getSimpleName() + "_" + clazz.getSimpleName(),
+				User user = (User) cons.newInstance(UUID.randomUUID().toString(),
 						"firstname", "lastname");
 
 				if (clazz.equals(User.class)) { // User.java doesn't have an expiry annotation

--- a/src/test/java/org/springframework/data/couchbase/core/CouchbaseTemplateQueryIntegrationTests.java
+++ b/src/test/java/org/springframework/data/couchbase/core/CouchbaseTemplateQueryIntegrationTests.java
@@ -109,9 +109,9 @@ class CouchbaseTemplateQueryIntegrationTests extends JavaIntegrationTests {
 			couchbaseTemplate.removeByQuery(User.class).all();
 		}
 
-		User usery = couchbaseTemplate.findById(User.class).one("userx");
+		User usery = couchbaseTemplate.findById(User.class).one(UUID.randomUUID());
 		assertNull(usery, "usery should be null");
-		User userz = reactiveCouchbaseTemplate.findById(User.class).one("userx").block();
+		User userz = reactiveCouchbaseTemplate.findById(User.class).one(UUID.randomUUID()).block();
 		assertNull(userz, "uz should be null");
 
 	}

--- a/src/test/java/org/springframework/data/couchbase/core/CustomTypeKeyIntegrationTests.java
+++ b/src/test/java/org/springframework/data/couchbase/core/CustomTypeKeyIntegrationTests.java
@@ -57,7 +57,7 @@ public class CustomTypeKeyIntegrationTests extends ClusterAwareIntegrationTests 
 		User modified = operations.upsertById(User.class).one(user);
 		assertEquals(user, modified);
 
-		GetResult getResult = clientFactory.getCollection(null).get(user.getId());
+		GetResult getResult = clientFactory.getCollection(null).get(user.getId().toString());
 		assertEquals("org.springframework.data.couchbase.domain.User",
 				getResult.contentAsObject().getString(CUSTOM_TYPE_KEY));
 		assertFalse(getResult.contentAsObject().containsKey(DefaultCouchbaseTypeMapper.DEFAULT_TYPE_KEY));

--- a/src/test/java/org/springframework/data/couchbase/core/mapping/MappingCouchbaseConverterTests.java
+++ b/src/test/java/org/springframework/data/couchbase/core/mapping/MappingCouchbaseConverterTests.java
@@ -195,9 +195,10 @@ public class MappingCouchbaseConverterTests {
 
 	@Test
 	void readsID() {
-		CouchbaseDocument document = new CouchbaseDocument("001");
+		UUID id = UUID.randomUUID();
+		CouchbaseDocument document = new CouchbaseDocument(id.toString());
 		User user = converter.read(User.class, document);
-		assertThat(user.getId()).isEqualTo("001");
+		assertThat(user.getId()).isEqualTo(id);
 	}
 
 	@Test

--- a/src/test/java/org/springframework/data/couchbase/domain/ReactiveUserRepository.java
+++ b/src/test/java/org/springframework/data/couchbase/domain/ReactiveUserRepository.java
@@ -21,8 +21,10 @@ import reactor.core.publisher.Flux;
 import org.springframework.data.repository.reactive.ReactiveSortingRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.UUID;
+
 @Repository
-public interface ReactiveUserRepository extends ReactiveSortingRepository<User, String> {
+public interface ReactiveUserRepository extends ReactiveSortingRepository<User, UUID> {
 
 	Flux<User> findByFirstname(String firstname);
 

--- a/src/test/java/org/springframework/data/couchbase/domain/User.java
+++ b/src/test/java/org/springframework/data/couchbase/domain/User.java
@@ -17,6 +17,7 @@
 package org.springframework.data.couchbase.domain;
 
 import java.util.Objects;
+import java.util.UUID;
 
 import org.springframework.data.annotation.CreatedBy;
 import org.springframework.data.annotation.CreatedDate;
@@ -38,7 +39,7 @@ import org.springframework.data.couchbase.core.mapping.Document;
 public class User extends ComparableEntity {
 
 	@Version long version;
-	@Id private String id;
+	@Id private UUID id;
 	private String firstname;
 	private String lastname;
 	@CreatedBy private String createdBy;
@@ -46,14 +47,20 @@ public class User extends ComparableEntity {
 	@LastModifiedBy private String lastModifiedBy;
 	@LastModifiedDate private long lastModifiedDate;
 
-	@PersistenceConstructor
-	public User(final String id, final String firstname, final String lastname) {
+
+	public User(final UUID id, final String firstname, final String lastname) {
 		this.id = id;
 		this.firstname = firstname;
 		this.lastname = lastname;
 	}
 
-	public String getId() {
+	@PersistenceConstructor
+	public User(final String id, final String firstname, final String lastname) {
+		this.id = UUID.fromString(id);
+		this.firstname = firstname;
+		this.lastname = lastname;
+	}
+	public UUID getId() {
 		return id;
 	}
 

--- a/src/test/java/org/springframework/data/couchbase/domain/UserJustLastName.java
+++ b/src/test/java/org/springframework/data/couchbase/domain/UserJustLastName.java
@@ -17,6 +17,7 @@
 package org.springframework.data.couchbase.domain;
 
 import java.util.Objects;
+import java.util.UUID;
 
 import org.springframework.data.annotation.Id;
 import org.springframework.data.annotation.PersistenceConstructor;
@@ -41,7 +42,7 @@ public class UserJustLastName extends ComparableEntity {
 	public UserJustLastName(final String id, final String lastname) {
 		this.id = id;
 		this.lastname = lastname;
-		this.user = new User("1", "first", "last");
+		this.user = new User(UUID.randomUUID(), "first", "last");
 	}
 
 	public String getId() {

--- a/src/test/java/org/springframework/data/couchbase/domain/UserRepository.java
+++ b/src/test/java/org/springframework/data/couchbase/domain/UserRepository.java
@@ -17,6 +17,7 @@
 package org.springframework.data.couchbase.domain;
 
 import java.util.List;
+import java.util.UUID;
 
 import org.springframework.data.couchbase.repository.CouchbaseRepository;
 import com.couchbase.client.java.json.JsonArray;
@@ -32,7 +33,7 @@ import org.springframework.stereotype.Repository;
  * @author Michael Reiche
  */
 @Repository
-public interface UserRepository extends CouchbaseRepository<User, String> {
+public interface UserRepository extends CouchbaseRepository<User, UUID> {
 
 	List<User> findByFirstname(String firstname);
 

--- a/src/test/java/org/springframework/data/couchbase/repository/CouchbaseRepositoryKeyValueIntegrationTests.java
+++ b/src/test/java/org/springframework/data/couchbase/repository/CouchbaseRepositoryKeyValueIntegrationTests.java
@@ -122,35 +122,35 @@ public class CouchbaseRepositoryKeyValueIntegrationTests extends ClusterAwareInt
 		assertTrue(found.isPresent());
 		found.ifPresent(l -> assertEquals(library, l));
 
-		assertTrue(userRepository.existsById(library.getId()));
+		assertTrue(libraryRepository.existsById(library.getId()));
 		libraryRepository.delete(library);
 
-		assertFalse(userRepository.existsById(library.getId()));
+		assertFalse(libraryRepository.existsById(library.getId()));
 	}
 
 	@Test
 	@IgnoreWhen(clusterTypes = ClusterType.MOCKED)
 	void saveAndFindByWithNestedId() {
-		UserSubmission user = new UserSubmission();
-		user.setId(UUID.randomUUID().toString());
-		user.setSubmissions(
-				Arrays.asList(new Submission(UUID.randomUUID().toString(), user.getId(), "tid", "status", 123)));
-		user.setCourses(Arrays.asList(new Course(UUID.randomUUID().toString(), user.getId(), "581")));
+		UserSubmission userSubmission = new UserSubmission();
+		userSubmission.setId(UUID.randomUUID().toString());
+		userSubmission.setSubmissions(
+				Arrays.asList(new Submission(UUID.randomUUID().toString(), userSubmission.getId(), "tid", "status", 123)));
+		userSubmission.setCourses(Arrays.asList(new Course(UUID.randomUUID().toString(), userSubmission.getId(), "581")));
 
 		// this currently fails when using mocked in integration.properties with status "UNKNOWN"
-		assertFalse(userRepository.existsById(user.getId()));
+		assertFalse(userSubmissionRepository.existsById(userSubmission.getId()));
 
-		userSubmissionRepository.save(user);
+		userSubmissionRepository.save(userSubmission);
 
-		Optional<UserSubmission> found = userSubmissionRepository.findById(user.getId());
+		Optional<UserSubmission> found = userSubmissionRepository.findById(userSubmission.getId());
 		assertTrue(found.isPresent());
-		found.ifPresent(u -> assertEquals(user, u));
+		found.ifPresent(u -> assertEquals(userSubmission, u));
 
-		assertTrue(userRepository.existsById(user.getId()));
-		assertEquals(user.getSubmissions().get(0).getId(), found.get().getSubmissions().get(0).getId());
-		assertEquals(user.getCourses().get(0).getId(), found.get().getCourses().get(0).getId());
-		assertEquals(user, found.get());
-		userSubmissionRepository.delete(user);
+		assertTrue(userSubmissionRepository.existsById(userSubmission.getId()));
+		assertEquals(userSubmission.getSubmissions().get(0).getId(), found.get().getSubmissions().get(0).getId());
+		assertEquals(userSubmission.getCourses().get(0).getId(), found.get().getCourses().get(0).getId());
+		assertEquals(userSubmission, found.get());
+		userSubmissionRepository.delete(userSubmission);
 	}
 
 	@Configuration

--- a/src/test/java/org/springframework/data/couchbase/repository/CouchbaseRepositoryQueryIntegrationTests.java
+++ b/src/test/java/org/springframework/data/couchbase/repository/CouchbaseRepositoryQueryIntegrationTests.java
@@ -24,6 +24,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
+import java.util.UUID;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -158,7 +159,7 @@ public class CouchbaseRepositoryQueryIntegrationTests extends ClusterAwareIntegr
 
 	@Test
 	public void testCas() {
-		User user = new User("1", "Dave", "Wilson");
+		User user = new User(UUID.randomUUID(), "Dave", "Wilson");
 		userRepository.save(user);
 		user.setVersion(user.getVersion() - 1);
 		assertThrows(DataIntegrityViolationException.class, () -> userRepository.save(user));

--- a/src/test/java/org/springframework/data/couchbase/repository/ReactiveCouchbaseRepositoryQueryIntegrationTests.java
+++ b/src/test/java/org/springframework/data/couchbase/repository/ReactiveCouchbaseRepositoryQueryIntegrationTests.java
@@ -27,6 +27,7 @@ import reactor.test.StepVerifier;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -112,7 +113,7 @@ public class ReactiveCouchbaseRepositoryQueryIntegrationTests extends JavaIntegr
 
 	@Test
 	public void testCas() {
-		User user = new User("1", "Dave", "Wilson");
+		User user = new User(UUID.randomUUID(), "Dave", "Wilson");
 		userRepository.save(user).block();
 		user.setVersion(user.getVersion() - 1);
 		assertThrows(DataIntegrityViolationException.class, () -> userRepository.save(user).block());


### PR DESCRIPTION
Currently the operation interfaces are parameterized only with entity-type. The id-type must be String.  This requires that the id-type in the repository parameters is String. This changeset allows any type of id.
This would also allow one(IDTYPE id) and one(ENTITYTYPE entity) apis in the same interface and also all(Collection<IDTYPE> ids) and all(Collection<ENTITYTYPE> entities) in RemoveById which would provide means to include the CAS.

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATACOUCH).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
