### PR TITLE
DATACOUCH-1055 - Queries on field annotated props have orig name.

### DIFF
--- a/src/main/java/org/springframework/data/couchbase/repository/query/N1qlQueryCreator.java
+++ b/src/main/java/org/springframework/data/couchbase/repository/query/N1qlQueryCreator.java
@@ -61,8 +61,8 @@ public class N1qlQueryCreator extends AbstractQueryCreator<Query, QueryCriteria>
 	}
 
 	static Converter<? super CouchbasePersistentProperty, String> cvtr = (
-			source) -> new StringBuilder(source.getName().length() + 2).append('`').append(source.getName()).append('`')
-					.toString();
+			source) -> new StringBuilder(source.getFieldName().length() + 2).append('`').append(source.getFieldName())
+					.append('`').toString();
 
 	@Override
 	protected QueryCriteria and(final Part part, final QueryCriteria base, final Iterator<Object> iterator) {

--- a/src/test/java/org/springframework/data/couchbase/domain/Person.java
+++ b/src/test/java/org/springframework/data/couchbase/domain/Person.java
@@ -18,7 +18,6 @@ package org.springframework.data.couchbase.domain;
 import java.util.Optional;
 import java.util.UUID;
 
-import com.couchbase.client.core.deps.com.fasterxml.jackson.annotation.JsonProperty;
 import org.springframework.data.annotation.CreatedBy;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedBy;
@@ -53,6 +52,7 @@ public class Person extends AbstractEntity {
 		this();
 		setFirstname(firstname);
 		setLastname(lastname);
+		setMiddlename("Nick");
 	}
 
 	public Person(int id, String firstname, String lastname) {

--- a/src/test/java/org/springframework/data/couchbase/domain/PersonRepository.java
+++ b/src/test/java/org/springframework/data/couchbase/domain/PersonRepository.java
@@ -15,15 +15,16 @@
  */
 package org.springframework.data.couchbase.domain;
 
-import com.couchbase.client.java.query.QueryScanConsistency;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
 import org.springframework.data.couchbase.repository.Query;
 import org.springframework.data.couchbase.repository.ScanConsistency;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.query.Param;
 
-import java.util.List;
-import java.util.Optional;
-import java.util.UUID;
+import com.couchbase.client.java.query.QueryScanConsistency;
 
 /**
  * @author Michael Reiche
@@ -107,6 +108,9 @@ public interface PersonRepository extends CrudRepository<Person, String> {
 
 	void deleteAll();
 
-	@ScanConsistency(query=QueryScanConsistency.REQUEST_PLUS)
+	@ScanConsistency(query = QueryScanConsistency.REQUEST_PLUS)
 	List<Person> findByAddressStreet(String street);
+
+	@ScanConsistency(query = QueryScanConsistency.REQUEST_PLUS)
+	List<Person> findByMiddlename(String nickName);
 }

--- a/src/test/java/org/springframework/data/couchbase/repository/query/N1qlQueryCreatorTests.java
+++ b/src/test/java/org/springframework/data/couchbase/repository/query/N1qlQueryCreatorTests.java
@@ -15,17 +15,13 @@
  */
 package org.springframework.data.couchbase.repository.query;
 
-import static org.junit.jupiter.api.Assertions.*;
-import static org.springframework.data.couchbase.core.query.QueryCriteria.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.data.couchbase.core.query.QueryCriteria.where;
 
 import java.lang.reflect.Method;
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
 
-import com.couchbase.client.java.json.JsonArray;
-import com.couchbase.client.java.json.JsonObject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.data.couchbase.core.convert.CouchbaseConverter;
@@ -34,11 +30,19 @@ import org.springframework.data.couchbase.core.mapping.CouchbaseMappingContext;
 import org.springframework.data.couchbase.core.mapping.CouchbasePersistentEntity;
 import org.springframework.data.couchbase.core.mapping.CouchbasePersistentProperty;
 import org.springframework.data.couchbase.core.query.Query;
+import org.springframework.data.couchbase.domain.Person;
+import org.springframework.data.couchbase.domain.PersonRepository;
 import org.springframework.data.couchbase.domain.User;
 import org.springframework.data.couchbase.domain.UserRepository;
 import org.springframework.data.mapping.context.MappingContext;
-import org.springframework.data.repository.query.*;
+import org.springframework.data.repository.query.DefaultParameters;
+import org.springframework.data.repository.query.ParameterAccessor;
+import org.springframework.data.repository.query.Parameters;
+import org.springframework.data.repository.query.ParametersParameterAccessor;
 import org.springframework.data.repository.query.parser.PartTree;
+
+import com.couchbase.client.java.json.JsonArray;
+import com.couchbase.client.java.json.JsonObject;
 
 /**
  * @author Michael Nitschinger
@@ -66,6 +70,19 @@ class N1qlQueryCreatorTests {
 		Query query = creator.createQuery();
 
 		assertEquals(query.export(), " WHERE " + where("firstname").is("Oliver").export());
+	}
+
+	@Test
+	void createsQueryFieldAnnotationCorrectly() throws Exception {
+		String input = "findByMiddlename";
+		PartTree tree = new PartTree(input, Person.class);
+		Method method = PersonRepository.class.getMethod(input, String.class);
+
+		N1qlQueryCreator creator = new N1qlQueryCreator(tree, getAccessor(getParameters(method), "Oliver"), null,
+				converter);
+		Query query = creator.createQuery();
+
+		assertEquals(query.export(), " WHERE " + where("nickname").is("Oliver").export());
 	}
 
 	@Test


### PR DESCRIPTION

Queries on field annotated properties have original name.

They should use getFieldName() which will use the annotated if it exists.

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATACOUCH).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
