### PR TITLE
GH-1066/GH-1072 - Support use of META() in N1QLQueryCreator and changed QueryCriteria to use N1QLExpression as key

### DIFF
--- a/src/main/java/org/springframework/data/couchbase/core/query/QueryCriteria.java
+++ b/src/main/java/org/springframework/data/couchbase/core/query/QueryCriteria.java
@@ -27,6 +27,8 @@ import com.couchbase.client.java.json.JsonValue;
 import org.springframework.data.couchbase.core.convert.CouchbaseConverter;
 import org.springframework.lang.Nullable;
 
+import static org.springframework.data.couchbase.core.query.N1QLExpression.*;
+
 /**
  * @author Michael Nitschinger
  * @author Michael Reiche
@@ -71,7 +73,14 @@ public class QueryCriteria implements QueryCriteriaDefinition {
 	}
 
 	/**
-	 * Static factory method to create a Criteria using the provided key.
+	 * Static factory method to create a Criteria using the provided String key.
+	 */
+	public static QueryCriteria where(String key) {
+		return where(x(key));
+	}
+
+	/**
+	 * Static factory method to create a Criteria using the provided N1QLExpression key.
 	 */
 	public static QueryCriteria where(N1QLExpression key) {
 		return new QueryCriteria(new ArrayList<>(), key, null, null);
@@ -83,12 +92,20 @@ public class QueryCriteria implements QueryCriteriaDefinition {
 		return qc;
 	}
 
+	public QueryCriteria and(String key) {
+		return and(x(key));
+	}
+
 	public QueryCriteria and(N1QLExpression key) {
 		return new QueryCriteria(this.criteriaChain, key, null, ChainOperator.AND);
 	}
 
 	public QueryCriteria and(QueryCriteria criteria) {
 		return new QueryCriteria(this.criteriaChain, null, criteria, ChainOperator.AND);
+	}
+
+	public QueryCriteria or(String key) {
+		return or(x(key));
 	}
 
 	public QueryCriteria or(N1QLExpression key) {

--- a/src/main/java/org/springframework/data/couchbase/core/query/QueryCriteria.java
+++ b/src/main/java/org/springframework/data/couchbase/core/query/QueryCriteria.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2020 the original author or authors
+ * Copyright 2012-2021 the original author or authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,10 +30,11 @@ import org.springframework.lang.Nullable;
 /**
  * @author Michael Nitschinger
  * @author Michael Reiche
+ * @author Mauro Monti
  */
 public class QueryCriteria implements QueryCriteriaDefinition {
 
-	private final String key;
+	private final N1QLExpression key;
 	/**
 	 * Holds the chain itself, the current operator being always the last one.
 	 */
@@ -46,15 +47,15 @@ public class QueryCriteria implements QueryCriteriaDefinition {
 	private Object[] value;
 	private String format;
 
-	QueryCriteria(List<QueryCriteria> chain, String key, Object[] value, ChainOperator chainOperator) {
+	QueryCriteria(List<QueryCriteria> chain, N1QLExpression key, Object[] value, ChainOperator chainOperator) {
 		this(chain, key, value, chainOperator, null, null);
 	}
 
-	QueryCriteria(List<QueryCriteria> chain, String key, Object value, ChainOperator chainOperator) {
+	QueryCriteria(List<QueryCriteria> chain, N1QLExpression key, Object value, ChainOperator chainOperator) {
 		this(chain, key, new Object[] { value }, chainOperator, null, null);
 	}
 
-	QueryCriteria(List<QueryCriteria> chain, String key, Object[] value, ChainOperator chainOperator, String operator,
+	QueryCriteria(List<QueryCriteria> chain, N1QLExpression key, Object[] value, ChainOperator chainOperator, String operator,
 			String format) {
 		this.criteriaChain = chain;
 		criteriaChain.add(this);
@@ -72,7 +73,7 @@ public class QueryCriteria implements QueryCriteriaDefinition {
 	/**
 	 * Static factory method to create a Criteria using the provided key.
 	 */
-	public static QueryCriteria where(String key) {
+	public static QueryCriteria where(N1QLExpression key) {
 		return new QueryCriteria(new ArrayList<>(), key, null, null);
 	}
 
@@ -82,7 +83,7 @@ public class QueryCriteria implements QueryCriteriaDefinition {
 		return qc;
 	}
 
-	public QueryCriteria and(String key) {
+	public QueryCriteria and(N1QLExpression key) {
 		return new QueryCriteria(this.criteriaChain, key, null, ChainOperator.AND);
 	}
 
@@ -90,12 +91,12 @@ public class QueryCriteria implements QueryCriteriaDefinition {
 		return new QueryCriteria(this.criteriaChain, null, criteria, ChainOperator.AND);
 	}
 
-	public QueryCriteria or(QueryCriteria criteria) {
-		return new QueryCriteria(this.criteriaChain, null, criteria, ChainOperator.OR);
+	public QueryCriteria or(N1QLExpression key) {
+		return new QueryCriteria(this.criteriaChain, key, null, ChainOperator.OR);
 	}
 
-	public QueryCriteria or(String key) {
-		return new QueryCriteria(this.criteriaChain, key, null, ChainOperator.OR);
+	public QueryCriteria or(QueryCriteria criteria) {
+		return new QueryCriteria(this.criteriaChain, null, criteria, ChainOperator.OR);
 	}
 
 	public QueryCriteria eq(@Nullable Object o) {
@@ -343,7 +344,7 @@ public class QueryCriteria implements QueryCriteriaDefinition {
 	 */
 	private StringBuilder exportSingle(StringBuilder sb, int[] paramIndexPtr, JsonValue parameters,
 			CouchbaseConverter converter) {
-		String fieldName = maybeBackTic(key);
+		String fieldName = key == null ? null : key.toString(); // maybeBackTic(key);
 		int valueLen = value == null ? 0 : value.length;
 		Object[] v = new Object[valueLen + 2];
 		v[0] = fieldName;
@@ -377,7 +378,7 @@ public class QueryCriteria implements QueryCriteriaDefinition {
 	 * @param parameters - parameters of the query. If operands are parameterized, their values are added to parameters
 	 * @return string containing part of N1QL query
 	 */
-	private String maybeWrapValue(String key, Object value, int[] paramIndexPtr, JsonValue parameters,
+	private String maybeWrapValue(N1QLExpression key, Object value, int[] paramIndexPtr, JsonValue parameters,
 			CouchbaseConverter converter) {
 		if (paramIndexPtr != null) {
 			if (paramIndexPtr[0] >= 0) {
@@ -397,10 +398,10 @@ public class QueryCriteria implements QueryCriteriaDefinition {
 				JsonObject params = (JsonObject) parameters;
 				// from StringBasedN1qlQueryParser.getNamedPlaceholderValues()
 				try {
-					params.put(key, convert(converter, value));
+					params.put(key.toString(), convert(converter, value));
 				} catch (InvalidArgumentException iae) {
 					if (value instanceof Object[]) {
-						params.put(key, JsonArray.from((Object[]) value));
+						params.put(key.toString(), JsonArray.from((Object[]) value));
 					} else {
 						throw iae;
 					}
@@ -416,7 +417,7 @@ public class QueryCriteria implements QueryCriteriaDefinition {
 		} else if (value == null) {
 			return "null";
 		} else if (value instanceof Object[]) { // convert array into sequence of comma-separated values
-			StringBuffer l = new StringBuffer();
+			StringBuilder l = new StringBuilder();
 			l.append("[");
 			Object[] array = (Object[]) value;
 			for (int i = 0; i < array.length; i++) {

--- a/src/main/java/org/springframework/data/couchbase/repository/query/N1qlQueryCreator.java
+++ b/src/main/java/org/springframework/data/couchbase/repository/query/N1qlQueryCreator.java
@@ -42,6 +42,9 @@ import org.springframework.data.repository.query.parser.PartTree;
  */
 public class N1qlQueryCreator extends AbstractQueryCreator<Query, QueryCriteria> {
 
+	private static final String META_ID_PROPERTY = "id";
+	private static final String META_CAS_PROPERTY = "cas";
+
 	private final ParameterAccessor accessor;
 	private final MappingContext<?, CouchbasePersistentProperty> context;
 	private final QueryMethod queryMethod;
@@ -156,8 +159,11 @@ public class N1qlQueryCreator extends AbstractQueryCreator<Query, QueryCriteria>
 
 	private N1QLExpression addMetaIfRequired(final PersistentPropertyPath<CouchbasePersistentProperty> persistentPropertyPath,
 											 final CouchbasePersistentProperty property) {
-		if (property.isIdProperty() || property.isVersionProperty()) {
-			return path(meta(i(bucketName)), persistentPropertyPath.toDotPath(cvtr));
+		if (property.isIdProperty()) {
+			return path(meta(i(bucketName)), i(META_ID_PROPERTY));
+		}
+		if (property.isVersionProperty()) {
+			return path(meta(i(bucketName)), i(META_CAS_PROPERTY));
 		}
 		return x(persistentPropertyPath.toDotPath(cvtr));
 	}

--- a/src/main/java/org/springframework/data/couchbase/repository/query/N1qlRepositoryQueryExecutor.java
+++ b/src/main/java/org/springframework/data/couchbase/repository/query/N1qlRepositoryQueryExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2020 the original author or authors
+ * Copyright 2012-2021 the original author or authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,6 +28,7 @@ import org.springframework.data.repository.query.parser.PartTree;
 /**
  * @author Michael Nitschinger
  * @author Michael Reiche
+ * @author Mauro Monti
  */
 public class N1qlRepositoryQueryExecutor {
 
@@ -61,7 +62,7 @@ public class N1qlRepositoryQueryExecutor {
 					QueryMethodEvaluationContextProvider.DEFAULT, namedQueries).createQuery();
 		} else {
 			final PartTree tree = new PartTree(queryMethod.getName(), domainClass);
-			query = new N1qlQueryCreator(tree, accessor, queryMethod, operations.getConverter()).createQuery();
+			query = new N1qlQueryCreator(tree, accessor, queryMethod, operations.getConverter(), operations.getBucketName()).createQuery();
 		}
 		q = (ExecutableFindByQueryOperation.ExecutableFindByQuery) operations.findByQuery(domainClass)
 				.consistentWith(buildQueryScanConsistency()).matching(query);

--- a/src/main/java/org/springframework/data/couchbase/repository/query/ReactiveN1qlRepositoryQueryExecutor.java
+++ b/src/main/java/org/springframework/data/couchbase/repository/query/ReactiveN1qlRepositoryQueryExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2020 the original author or authors
+ * Copyright 2012-2021 the original author or authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,23 +16,19 @@
 package org.springframework.data.couchbase.repository.query;
 
 import com.couchbase.client.java.query.QueryScanConsistency;
-import org.springframework.data.couchbase.core.ExecutableFindByQueryOperation;
 import org.springframework.data.couchbase.core.ReactiveFindByQueryOperation;
-import org.springframework.data.mapping.context.MappingContext;
 import org.springframework.data.repository.core.NamedQueries;
 import org.springframework.data.repository.query.*;
-import org.springframework.expression.spel.standard.SpelExpressionParser;
-import reactor.core.publisher.Flux;
 
 import org.springframework.data.couchbase.core.ReactiveCouchbaseOperations;
 import org.springframework.data.couchbase.core.query.Query;
 import org.springframework.data.repository.query.parser.PartTree;
 
-import java.util.List;
 
 /**
  * @author Michael Nitschinger
  * @author Michael Reiche
+ * @author Mauro Monti
  */
 public class ReactiveN1qlRepositoryQueryExecutor {
 
@@ -68,7 +64,7 @@ public class ReactiveN1qlRepositoryQueryExecutor {
 					QueryMethodEvaluationContextProvider.DEFAULT, namedQueries).createQuery();
 		} else {
 			final PartTree tree = new PartTree(queryMethod.getName(), domainClass);
-			query = new N1qlQueryCreator(tree, accessor, queryMethod, operations.getConverter()).createQuery();
+			query = new N1qlQueryCreator(tree, accessor, queryMethod, operations.getConverter(), operations.getBucketName()).createQuery();
 		}
 		q = (ReactiveFindByQueryOperation.ReactiveFindByQuery) operations.findByQuery(domainClass)
 				.consistentWith(buildQueryScanConsistency()).matching(query);

--- a/src/main/java/org/springframework/data/couchbase/repository/query/StringN1qlQueryCreator.java
+++ b/src/main/java/org/springframework/data/couchbase/repository/query/StringN1qlQueryCreator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 the original author or authors
+ * Copyright 2021 the original author or authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,6 @@ package org.springframework.data.couchbase.repository.query;
 import static org.springframework.data.couchbase.core.query.N1QLExpression.x;
 import static org.springframework.data.couchbase.core.query.QueryCriteria.*;
 
-import java.util.ArrayList;
 import java.util.Iterator;
 
 import com.couchbase.client.java.json.JsonArray;
@@ -30,8 +29,6 @@ import org.springframework.data.couchbase.core.query.N1QLExpression;
 import org.springframework.data.couchbase.core.query.Query;
 import org.springframework.data.couchbase.core.query.QueryCriteria;
 import org.springframework.data.couchbase.core.query.StringQuery;
-import org.springframework.data.couchbase.repository.query.support.N1qlUtils;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.mapping.PersistentPropertyPath;
 import org.springframework.data.mapping.context.MappingContext;
@@ -40,12 +37,11 @@ import org.springframework.data.repository.query.*;
 import org.springframework.data.repository.query.parser.AbstractQueryCreator;
 import org.springframework.data.repository.query.parser.Part;
 import org.springframework.data.repository.query.parser.PartTree;
-import org.springframework.expression.EvaluationContext;
 import org.springframework.expression.spel.standard.SpelExpressionParser;
-import org.springframework.util.Assert;
 
 /**
  * @author Michael Reiche
+ * @author Mauro Monti
  */
 public class StringN1qlQueryCreator extends AbstractQueryCreator<Query, QueryCriteria> {
 
@@ -106,7 +102,7 @@ public class StringN1qlQueryCreator extends AbstractQueryCreator<Query, QueryCri
 		PersistentPropertyPath<CouchbasePersistentProperty> path = context.getPersistentPropertyPath(
 				part.getProperty());
 		CouchbasePersistentProperty property = path.getLeafProperty();
-		return from(part, property, where(path.toDotPath()), iterator);
+		return from(part, property, where(x(path.toDotPath())), iterator);
 	}
 
 	@Override
@@ -119,7 +115,7 @@ public class StringN1qlQueryCreator extends AbstractQueryCreator<Query, QueryCri
 				part.getProperty());
 		CouchbasePersistentProperty property = path.getLeafProperty();
 
-		return from(part, property, base.and(path.toDotPath()), iterator);
+		return from(part, property, base.and(x(path.toDotPath())), iterator);
 	}
 
 	@Override

--- a/src/test/java/org/springframework/data/couchbase/core/CouchbaseTemplateQueryIntegrationTests.java
+++ b/src/test/java/org/springframework/data/couchbase/core/CouchbaseTemplateQueryIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2020 the original author or authors
+ * Copyright 2012-2021 the original author or authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package org.springframework.data.couchbase.core;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.springframework.data.couchbase.config.BeanNames.*;
+import static org.springframework.data.couchbase.core.query.N1QLExpression.*;
 
 import java.io.IOException;
 import java.time.Instant;
@@ -54,6 +55,7 @@ import com.couchbase.client.java.query.QueryScanConsistency;
  * @author Michael Nitschinger
  * @author Michael Reiche
  * @author Haris Alesevic
+ * @author Mauro Monti
  */
 @IgnoreWhen(missesCapabilities = Capabilities.QUERY, clusterTypes = ClusterType.MOCKED)
 class CouchbaseTemplateQueryIntegrationTests extends ClusterAwareIntegrationTests {
@@ -138,7 +140,7 @@ class CouchbaseTemplateQueryIntegrationTests extends ClusterAwareIntegrationTest
 
 		couchbaseTemplate.upsertById(User.class).all(Arrays.asList(user1, user2, specialUser));
 
-		Query specialUsers = new Query(QueryCriteria.where("firstname").like("special"));
+		Query specialUsers = new Query(QueryCriteria.where(i("firstname")).like("special"));
 		final List<User> foundUsers = couchbaseTemplate.findByQuery(User.class)
 				.consistentWith(QueryScanConsistency.REQUEST_PLUS).matching(specialUsers).all();
 
@@ -174,7 +176,7 @@ class CouchbaseTemplateQueryIntegrationTests extends ClusterAwareIntegrationTest
 		assertTrue(couchbaseTemplate.existsById().one(user2.getId()));
 		assertTrue(couchbaseTemplate.existsById().one(specialUser.getId()));
 
-		Query nonSpecialUsers = new Query(QueryCriteria.where("firstname").notLike("special"));
+		Query nonSpecialUsers = new Query(QueryCriteria.where(i("firstname")).notLike("special"));
 
 		couchbaseTemplate.removeByQuery(User.class).consistentWith(QueryScanConsistency.REQUEST_PLUS)
 				.matching(nonSpecialUsers)

--- a/src/test/java/org/springframework/data/couchbase/core/query/QueryCriteriaTests.java
+++ b/src/test/java/org/springframework/data/couchbase/core/query/QueryCriteriaTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 the original author or authors.
+ * Copyright 2017-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,56 +17,51 @@
 package org.springframework.data.couchbase.core.query;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.data.couchbase.core.query.N1QLExpression.*;
 import static org.springframework.data.couchbase.core.query.QueryCriteria.*;
+import static org.springframework.data.couchbase.repository.query.support.N1qlUtils.*;
 
 import com.couchbase.client.java.json.JsonArray;
-import com.couchbase.client.java.json.JsonObject;
 import org.junit.jupiter.api.Test;
-import org.springframework.data.couchbase.domain.User;
-import org.springframework.data.couchbase.domain.UserRepository;
-import org.springframework.data.couchbase.repository.query.N1qlQueryCreator;
-import org.springframework.data.repository.query.parser.PartTree;
 
-import java.lang.reflect.Method;
-import java.util.Arrays;
-import java.util.LinkedList;
-import java.util.List;
-
+/**
+ * @author Mauro Monti
+ */
 class QueryCriteriaTests {
 
 	@Test
 	void testSimpleCriteria() {
-		QueryCriteria c = where("name").is("Bubba");
+		QueryCriteria c = where(i("name")).is("Bubba");
 		assertEquals("`name` = \"Bubba\"", c.export());
 	}
 
 	@Test
 	public void testNullValue() {
-		QueryCriteria c = where("name").is(null);
+		QueryCriteria c = where(i("name")).is(null);
 		assertEquals("`name` = null", c.export());
 	}
 
 	@Test
 	void testSimpleNumber() {
-		QueryCriteria c = where("name").is(5);
+		QueryCriteria c = where(i("name")).is(5);
 		assertEquals("`name` = 5", c.export());
 	}
 
 	@Test
 	void testNotEqualCriteria() {
-		QueryCriteria c = where("name").ne("Bubba");
+		QueryCriteria c = where(i("name")).ne("Bubba");
 		assertEquals("`name` != \"Bubba\"", c.export());
 	}
 
 	@Test
 	void testChainedCriteria() {
-		QueryCriteria c = where("name").is("Bubba").and("age").lt(21).or("country").is("Austria");
+		QueryCriteria c = where(i("name")).is("Bubba").and(i("age")).lt(21).or(i("country")).is("Austria");
 		assertEquals("`name` = \"Bubba\" and `age` < 21 or `country` = \"Austria\"", c.export());
 	}
 
 	@Test
 	void testNestedAndCriteria() {
-		QueryCriteria c = where("name").is("Bubba").and(where("age").gt(12).or("country").is("Austria"));
+		QueryCriteria c = where(i("name")).is("Bubba").and(where(i("age")).gt(12).or(i("country")).is("Austria"));
 		JsonArray parameters = JsonArray.create();
 		assertEquals("`name` = $1 and (`age` > $2 or `country` = $3)", c.export(new int[1], parameters, null));
 		assertEquals("[\"Bubba\",12,\"Austria\"]", parameters.toString());
@@ -74,7 +69,7 @@ class QueryCriteriaTests {
 
 	@Test
 	void testNestedOrCriteria() {
-		QueryCriteria c = where("name").is("Bubba").or(where("age").gt(12).or("country").is("Austria"));
+		QueryCriteria c = where(i("name")).is("Bubba").or(where(i("age")).gt(12).or(i("country")).is("Austria"));
 		JsonArray parameters = JsonArray.create();
 		assertEquals("`name` = $1 or (`age` > $2 or `country` = $3)", c.export(new int[1], parameters, null));
 		assertEquals("[\"Bubba\",12,\"Austria\"]", parameters.toString());
@@ -82,45 +77,45 @@ class QueryCriteriaTests {
 
 	@Test
 	void testNestedNotIn() {
-		QueryCriteria c = where("name").is("Bubba").or(where("age").gt(12).or("country").is("Austria"))
-				.and(where("state").notIn(new String[] { "Alabama", "Florida" }));
+		QueryCriteria c = where(i("name")).is("Bubba").or(where(i("age")).gt(12).or(i("country")).is("Austria"))
+				.and(where(i("state")).notIn(new String[] { "Alabama", "Florida" }));
 		assertEquals("`name` = \"Bubba\" or (`age` > 12 or `country` = \"Austria\") and "
 				+ "(not( (`state` in ( [\"Alabama\",\"Florida\"] )) ))", c.export());
 	}
 
 	@Test
 	void testLt() {
-		QueryCriteria c = where("name").lt("Couch");
+		QueryCriteria c = where(i("name")).lt("Couch");
 		assertEquals("`name` < \"Couch\"", c.export());
 	}
 
 	@Test
 	void testLte() {
-		QueryCriteria c = where("name").lte("Couch");
+		QueryCriteria c = where(i("name")).lte("Couch");
 		assertEquals("`name` <= \"Couch\"", c.export());
 	}
 
 	@Test
 	void testGt() {
-		QueryCriteria c = where("name").gt("Couch");
+		QueryCriteria c = where(i("name")).gt("Couch");
 		assertEquals("`name` > \"Couch\"", c.export());
 	}
 
 	@Test
 	void testGte() {
-		QueryCriteria c = where("name").gte("Couch");
+		QueryCriteria c = where(i("name")).gte("Couch");
 		assertEquals("`name` >= \"Couch\"", c.export());
 	}
 
 	@Test
 	void testNe() {
-		QueryCriteria c = where("name").ne("Couch");
+		QueryCriteria c = where(i("name")).ne("Couch");
 		assertEquals("`name` != \"Couch\"", c.export());
 	}
 
 	@Test
 	void testStartingWith() {
-		QueryCriteria c = where("name").startingWith("Cou");
+		QueryCriteria c = where(i("name")).startingWith("Cou");
 		assertEquals("`name` like (\"Cou\"||\"%\")", c.export());
 	}
 
@@ -128,99 +123,99 @@ class QueryCriteriaTests {
 	       * startingWith()  cannot be a QueryCriteria
 	@Test
 	void testStartingWithExpr() {
-		QueryCriteria c = where("name").startingWith(where("name").plus("xxx"));
+		QueryCriteria c = where(i("name")).startingWith(where(i("name")).plus("xxx"));
 		assertEquals("`name` like (((`name` || "xxx") || ""%""))", c.export());
 	}
 	      */
 
 	@Test
 	void testEndingWith() {
-		QueryCriteria c = where("name").endingWith("ouch");
+		QueryCriteria c = where(i("name")).endingWith("ouch");
 		assertEquals("`name` like (\"%\"||\"ouch\")", c.export());
 	}
 
 	@Test
 	void testEndingWithExpr() {
-		QueryCriteria c = where("name").endingWith(where("name").plus("xxx"));
+		QueryCriteria c = where(i("name")).endingWith(where(i("name")).plus("xxx"));
 		assertEquals("`name` like (\"%\"||((`name` || \"xxx\")))", c.export());
 	}
 
 	@Test
 	void testRegex() {
-		QueryCriteria c = where("name").regex("C.*h");
+		QueryCriteria c = where(i("name")).regex("C.*h");
 		assertEquals("regexp_like(`name`, \"C.*h\")", c.export());
 	}
 
 	@Test
 	void testContaining() {
-		QueryCriteria c = where("name").containing("ouch");
+		QueryCriteria c = where(i("name")).containing("ouch");
 		assertEquals("contains(`name`, \"ouch\")", c.export());
 	}
 
 	@Test
 	void testNotContaining() {
-		QueryCriteria c = where("name").notContaining("Elvis");
+		QueryCriteria c = where(i("name")).notContaining("Elvis");
 		assertEquals("not( (contains(`name`, \"Elvis\")) )", c.export());
 	}
 
 	@Test
 	void testLike() {
-		QueryCriteria c = where("name").like("%ouch%");
+		QueryCriteria c = where(i("name")).like("%ouch%");
 		assertEquals("`name` like \"%ouch%\"", c.export());
 	}
 
 	@Test
 	void testNotLike() {
-		QueryCriteria c = where("name").notLike("%Elvis%");
+		QueryCriteria c = where(i("name")).notLike("%Elvis%");
 		assertEquals("not(`name` like \"%Elvis%\")", c.export());
 	}
 
 	@Test
 	void testIsNull() {
-		QueryCriteria c = where("name").isNull();
+		QueryCriteria c = where(i("name")).isNull();
 		assertEquals("`name` is null", c.export());
 	}
 
 	@Test
 	void testIsNotNull() {
-		QueryCriteria c = where("name").isNotNull();
+		QueryCriteria c = where(i("name")).isNotNull();
 		assertEquals("`name` is not null", c.export());
 	}
 
 	@Test
 	void testIsMissing() {
-		QueryCriteria c = where("name").isMissing();
+		QueryCriteria c = where(i("name")).isMissing();
 		assertEquals("`name` is missing", c.export());
 	}
 
 	@Test
 	void testIsNotMissing() {
-		QueryCriteria c = where("name").isNotMissing();
+		QueryCriteria c = where(i("name")).isNotMissing();
 		assertEquals("`name` is not missing", c.export());
 	}
 
 	@Test
 	void testIsValued() {
-		QueryCriteria c = where("name").isValued();
+		QueryCriteria c = where(i("name")).isValued();
 		assertEquals("`name` is valued", c.export());
 	}
 
 	@Test
 	void testIsNotValued() {
-		QueryCriteria c = where("name").isNotValued();
+		QueryCriteria c = where(i("name")).isNotValued();
 		assertEquals("`name` is not valued", c.export());
 	}
 
 	@Test
 	void testBetween() {
-		QueryCriteria c = where("name").between("Davis", "Gump");
+		QueryCriteria c = where(i("name")).between("Davis", "Gump");
 		assertEquals("`name` between \"Davis\" and \"Gump\"", c.export());
 	}
 
 	@Test
 	void testIn() {
 		String[] args = new String[] { "gump", "davis" };
-		QueryCriteria c = where("name").in(args);
+		QueryCriteria c = where(i("name")).in(args);
 		assertEquals("`name` in ( [\"gump\",\"davis\"] )", c.export());
 		JsonArray parameters = JsonArray.create();
 		assertEquals("`name` in ( $1 )", c.export(new int[1], parameters, null));
@@ -230,7 +225,7 @@ class QueryCriteriaTests {
 	@Test
 	void testNotIn() {
 		String[] args = new String[] { "gump", "davis" };
-		QueryCriteria c = where("name").notIn(args);
+		QueryCriteria c = where(i("name")).notIn(args);
 		assertEquals("not( (`name` in ( [\"gump\",\"davis\"] )) )", c.export());
 		JsonArray parameters = JsonArray.create();
 		assertEquals("not( (`name` in ( $1 )) )", c.export(new int[1], parameters, null));
@@ -239,14 +234,30 @@ class QueryCriteriaTests {
 
 	@Test
 	void testTrue() {
-		QueryCriteria c = where("name").TRUE();
+		QueryCriteria c = where(i("name")).TRUE();
 		assertEquals("`name`", c.export());
 	}
 
 	@Test
 	void testFalse() {
-		QueryCriteria c = where("name").FALSE();
+		QueryCriteria c = where(i("name")).FALSE();
 		assertEquals("not( (`name`) )", c.export());
+	}
+
+	@Test // https://github.com/spring-projects/spring-data-couchbase/issues/1066
+	void testCriteriaCorrectlyEscapedWhenUsingMetaOnLHS() {
+		final String bucketName = "sample-bucket";
+		final String version = "1611287177404088320";
+		QueryCriteria criteria = QueryCriteria.where(path(meta(escapedBucket(bucketName)), "cas")).eq(x(version));
+		assertEquals("META(`" + bucketName + "`).cas = " + x(version), criteria.export());
+	}
+
+	@Test // https://github.com/spring-projects/spring-data-couchbase/issues/1066
+	void testCriteriaCorrectlyEscapedWhenUsingMetaOnRHS() {
+		final String bucketName = "sample-bucket";
+		final String version = "1611287177404088320";
+		QueryCriteria criteria = QueryCriteria.where(x(version)).eq(path(meta(escapedBucket(bucketName)), "cas"));
+		assertEquals(x(version) + " = META(`" + bucketName + "`).cas", criteria.export());
 	}
 
 	private String arrayToString(Object[] array) {

--- a/src/test/java/org/springframework/data/couchbase/domain/UserRepository.java
+++ b/src/test/java/org/springframework/data/couchbase/domain/UserRepository.java
@@ -47,4 +47,6 @@ public interface UserRepository extends CouchbaseRepository<User, String> {
 
 	@Query("#{#n1ql.selectEntity} where #{#n1ql.filter} and (firstname = $first or lastname = $last)")
 	List<User> getByFirstnameOrLastname(@Param("first") String firstname, @Param("last") String lastname);
+
+	List<User> findByIdIsNotNullAndFirstnameEquals(String firstname);
 }

--- a/src/test/java/org/springframework/data/couchbase/domain/UserRepository.java
+++ b/src/test/java/org/springframework/data/couchbase/domain/UserRepository.java
@@ -49,4 +49,6 @@ public interface UserRepository extends CouchbaseRepository<User, String> {
 	List<User> getByFirstnameOrLastname(@Param("first") String firstname, @Param("last") String lastname);
 
 	List<User> findByIdIsNotNullAndFirstnameEquals(String firstname);
+
+	List<User> findByVersionEqualsAndFirstnameEquals(Long version, String firstname);
 }

--- a/src/test/java/org/springframework/data/couchbase/repository/query/N1qlQueryCreatorTests.java
+++ b/src/test/java/org/springframework/data/couchbase/repository/query/N1qlQueryCreatorTests.java
@@ -158,6 +158,19 @@ class N1qlQueryCreatorTests {
 		assertEquals(query.export()," WHERE " + where(x("META(`"+bucketName+"`).`id`")).isNotNull().and(i("firstname")).is("Oliver").export());
 	}
 
+	@Test // https://github.com/spring-projects/spring-data-couchbase/issues/1072
+	void createsQueryFindByVersionEqualsAndAndFirstname() throws Exception {
+		String input = "findByVersionEqualsAndFirstnameEquals";
+		PartTree tree = new PartTree(input, User.class);
+		Method method = UserRepository.class.getMethod(input, Long.class, String.class);
+
+		N1qlQueryCreator creator = new N1qlQueryCreator(tree, getAccessor(getParameters(method), 1611287177404088320L, "Oliver"), null, converter,
+				bucketName);
+		Query query = creator.createQuery();
+
+		assertEquals(query.export()," WHERE " + where(x("META(`"+bucketName+"`).`cas`")).is(1611287177404088320L).and(i("firstname")).is("Oliver").export());
+	}
+
 	private ParameterAccessor getAccessor(Parameters<?, ?> params, Object... values) {
 		return new ParametersParameterAccessor(params, values);
 	}


### PR DESCRIPTION
This commit fixes the generated query by N1QLQueryCreator when the criteria includes an id or a version property, adding a  META($bucket) function

It also removes the need of maybeBacktics() in QueryCriteria defining N1QLExpression as key instead of String. 
Public methods where(), and() and or() with String key delegate to the same with N1QLExpression as argument.

Related tickets:
- https://github.com/spring-projects/spring-data-couchbase/issues/1072
- https://github.com/spring-projects/spring-data-couchbase/issues/1066

<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [ ] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATACOUCH).
- [X] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [X] You submit test cases (unit or integration tests) that back your changes.
- [X] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
