### PR TITLE
DATACOUCH-1066 - Make QueryCriteria key a N1qlExpression.

### DIFF
--- a/src/main/java/org/springframework/data/couchbase/repository/query/N1qlCountQueryCreator.java
+++ b/src/main/java/org/springframework/data/couchbase/repository/query/N1qlCountQueryCreator.java
@@ -118,6 +118,11 @@ public class N1qlCountQueryCreator extends OldN1qlQueryCreator {
 			return delegate.first();
 		}
 
+		@Override
+		public Pageable withPage(int i) {
+			return new CountPageable(delegate.withPage(i));
+		}
+
 		public boolean hasPrevious() {
 			return delegate.hasPrevious();
 		}

--- a/src/main/java/org/springframework/data/couchbase/repository/query/N1qlQueryCreator.java
+++ b/src/main/java/org/springframework/data/couchbase/repository/query/N1qlQueryCreator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2020 the original author or authors
+ * Copyright 2012-2021 the original author or authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,10 @@
  */
 package org.springframework.data.couchbase.repository.query;
 
+import static org.springframework.data.couchbase.core.query.N1QLExpression.i;
+import static org.springframework.data.couchbase.core.query.N1QLExpression.meta;
+import static org.springframework.data.couchbase.core.query.N1QLExpression.path;
+import static org.springframework.data.couchbase.core.query.N1QLExpression.x;
 import static org.springframework.data.couchbase.core.query.QueryCriteria.where;
 
 import java.util.Iterator;
@@ -22,6 +26,7 @@ import java.util.Iterator;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.data.couchbase.core.convert.CouchbaseConverter;
 import org.springframework.data.couchbase.core.mapping.CouchbasePersistentProperty;
+import org.springframework.data.couchbase.core.query.N1QLExpression;
 import org.springframework.data.couchbase.core.query.Query;
 import org.springframework.data.couchbase.core.query.QueryCriteria;
 import org.springframework.data.domain.Sort;
@@ -36,33 +41,39 @@ import org.springframework.data.repository.query.parser.PartTree;
 /**
  * @author Michael Nitschinger
  * @author Michael Reiche
+ * @author Mauro Monti
  */
 public class N1qlQueryCreator extends AbstractQueryCreator<Query, QueryCriteria> {
+
+	private static final String META_ID_PROPERTY = "id";
+	private static final String META_CAS_PROPERTY = "cas";
 
 	private final ParameterAccessor accessor;
 	private final MappingContext<?, CouchbasePersistentProperty> context;
 	private final QueryMethod queryMethod;
 	private final CouchbaseConverter converter;
+	private final String bucketName;
 
-	public N1qlQueryCreator(final PartTree tree, final ParameterAccessor accessor, QueryMethod queryMethod,
-			CouchbaseConverter converter) {
+	public N1qlQueryCreator(final PartTree tree, final ParameterAccessor accessor, final QueryMethod queryMethod,
+			final CouchbaseConverter converter, final String bucketName) {
 		super(tree, accessor);
 		this.accessor = accessor;
 		this.context = converter.getMappingContext();
 		this.queryMethod = queryMethod;
 		this.converter = converter;
+		this.bucketName = bucketName;
 	}
 
 	@Override
 	protected QueryCriteria create(final Part part, final Iterator<Object> iterator) {
 		PersistentPropertyPath<CouchbasePersistentProperty> path = context.getPersistentPropertyPath(part.getProperty());
 		CouchbasePersistentProperty property = path.getLeafProperty();
-		return from(part, property, where(path.toDotPath(cvtr)), iterator);
+		return from(part, property, where(addMetaIfRequired(path, property)), iterator);
 	}
 
 	static Converter<? super CouchbasePersistentProperty, String> cvtr = (
-			source) -> new StringBuilder(source.getName().length() + 2).append('`').append(source.getName()).append('`')
-					.toString();
+			source) -> new StringBuilder(source.getFieldName().length() + 2).append('`').append(source.getFieldName())
+					.append('`').toString();
 
 	@Override
 	protected QueryCriteria and(final Part part, final QueryCriteria base, final Iterator<Object> iterator) {
@@ -73,7 +84,7 @@ public class N1qlQueryCreator extends AbstractQueryCreator<Query, QueryCriteria>
 		PersistentPropertyPath<CouchbasePersistentProperty> path = context.getPersistentPropertyPath(part.getProperty());
 		CouchbasePersistentProperty property = path.getLeafProperty();
 
-		return from(part, property, base.and(path.toDotPath()), iterator);
+		return from(part, property, base.and(addMetaIfRequired(path, property)), iterator);
 	}
 
 	@Override
@@ -147,6 +158,18 @@ public class N1qlQueryCreator extends AbstractQueryCreator<Query, QueryCriteria>
 			default:
 				throw new IllegalArgumentException("Unsupported keyword!");
 		}
+	}
+
+	private N1QLExpression addMetaIfRequired(
+			final PersistentPropertyPath<CouchbasePersistentProperty> persistentPropertyPath,
+			final CouchbasePersistentProperty property) {
+		if (property.isIdProperty()) {
+			return path(meta(i(bucketName)), i(META_ID_PROPERTY));
+		}
+		if (property.isVersionProperty()) {
+			return path(meta(i(bucketName)), i(META_CAS_PROPERTY));
+		}
+		return x(persistentPropertyPath.toDotPath(cvtr));
 	}
 
 }

--- a/src/main/java/org/springframework/data/couchbase/repository/query/N1qlRepositoryQueryExecutor.java
+++ b/src/main/java/org/springframework/data/couchbase/repository/query/N1qlRepositoryQueryExecutor.java
@@ -70,7 +70,7 @@ public class N1qlRepositoryQueryExecutor {
 					SPEL_PARSER, evaluationContextProvider, namedQueries).createQuery();
 		} else {
 			final PartTree tree = new PartTree(queryMethod.getName(), domainClass);
-			query = new N1qlQueryCreator(tree, accessor, queryMethod, operations.getConverter()).createQuery();
+			query = new N1qlQueryCreator(tree, accessor, queryMethod, operations.getConverter(), operations.getBucketName()).createQuery();
 		}
 
 		ExecutableFindByQueryOperation.ExecutableFindByQuery<?> operation = (ExecutableFindByQueryOperation.ExecutableFindByQuery<?>) operations

--- a/src/main/java/org/springframework/data/couchbase/repository/query/PartTreeCouchbaseQuery.java
+++ b/src/main/java/org/springframework/data/couchbase/repository/query/PartTreeCouchbaseQuery.java
@@ -72,7 +72,8 @@ public class PartTreeCouchbaseQuery extends AbstractCouchbaseQuery {
 	@Override
 	protected Query createQuery(ParametersParameterAccessor accessor) {
 
-		N1qlQueryCreator creator = new N1qlQueryCreator(tree, accessor, getQueryMethod(), converter);
+		N1qlQueryCreator creator = new N1qlQueryCreator(tree, accessor, getQueryMethod(), converter,
+				getOperations().getBucketName());
 		Query query = creator.createQuery();
 
 		if (tree.isLimiting()) {
@@ -88,7 +89,8 @@ public class PartTreeCouchbaseQuery extends AbstractCouchbaseQuery {
 	 */
 	@Override
 	protected Query createCountQuery(ParametersParameterAccessor accessor) {
-		return new N1qlQueryCreator(tree, accessor, getQueryMethod(), converter).createQuery();
+		return new N1qlQueryCreator(tree, accessor, getQueryMethod(), converter, getOperations().getBucketName())
+				.createQuery();
 	}
 
 	/*

--- a/src/main/java/org/springframework/data/couchbase/repository/query/ReactivePartTreeCouchbaseQuery.java
+++ b/src/main/java/org/springframework/data/couchbase/repository/query/ReactivePartTreeCouchbaseQuery.java
@@ -73,7 +73,8 @@ public class ReactivePartTreeCouchbaseQuery extends AbstractReactiveCouchbaseQue
 	@Override
 	protected Query createQuery(ParametersParameterAccessor accessor) {
 
-		N1qlQueryCreator creator = new N1qlQueryCreator(tree, accessor, getQueryMethod(), converter);
+		N1qlQueryCreator creator = new N1qlQueryCreator(tree, accessor, getQueryMethod(), converter,
+				getOperations().getBucketName());
 		Query query = creator.createQuery();
 
 		if (tree.isLimiting()) {
@@ -91,7 +92,8 @@ public class ReactivePartTreeCouchbaseQuery extends AbstractReactiveCouchbaseQue
 	 */
 	@Override
 	protected Query createCountQuery(ParametersParameterAccessor accessor) {
-		Query query = new N1qlQueryCreator(tree, accessor, getQueryMethod(), converter).createQuery();
+		Query query = new N1qlQueryCreator(tree, accessor, getQueryMethod(), converter, getOperations().getBucketName())
+				.createQuery();
 		if (LOG.isDebugEnabled()) {
 			LOG.debug("Created query {} for * fields.", query.export());
 		}

--- a/src/main/java/org/springframework/data/couchbase/repository/query/ReactiveStringBasedCouchbaseQuery.java
+++ b/src/main/java/org/springframework/data/couchbase/repository/query/ReactiveStringBasedCouchbaseQuery.java
@@ -79,6 +79,7 @@ public class ReactiveStringBasedCouchbaseQuery extends AbstractReactiveCouchbase
 		StringN1qlQueryCreator creator = new StringN1qlQueryCreator(accessor, getQueryMethod(),
 				getOperations().getConverter(), getOperations().getBucketName(), expressionParser, evaluationContextProvider,
 				namedQueries);
+
 		Query query = creator.createQuery();
 
 		if (LOG.isDebugEnabled()) {

--- a/src/main/java/org/springframework/data/couchbase/repository/query/StringN1qlQueryCreator.java
+++ b/src/main/java/org/springframework/data/couchbase/repository/query/StringN1qlQueryCreator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 the original author or authors
+ * Copyright 2021 the original author or authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,9 +15,11 @@
  */
 package org.springframework.data.couchbase.repository.query;
 
-import com.couchbase.client.java.json.JsonArray;
-import com.couchbase.client.java.json.JsonObject;
-import com.couchbase.client.java.json.JsonValue;
+import static org.springframework.data.couchbase.core.query.N1QLExpression.x;
+import static org.springframework.data.couchbase.core.query.QueryCriteria.where;
+
+import java.util.Iterator;
+
 import org.springframework.data.couchbase.core.convert.CouchbaseConverter;
 import org.springframework.data.couchbase.core.mapping.CouchbasePersistentProperty;
 import org.springframework.data.couchbase.core.query.N1QLExpression;
@@ -36,12 +38,13 @@ import org.springframework.data.repository.query.parser.Part;
 import org.springframework.data.repository.query.parser.PartTree;
 import org.springframework.expression.spel.standard.SpelExpressionParser;
 
-import java.util.Iterator;
-
-import static org.springframework.data.couchbase.core.query.QueryCriteria.where;
+import com.couchbase.client.java.json.JsonArray;
+import com.couchbase.client.java.json.JsonObject;
+import com.couchbase.client.java.json.JsonValue;
 
 /**
  * @author Michael Reiche
+ * @author Mauro Monti
  */
 public class StringN1qlQueryCreator extends AbstractQueryCreator<Query, QueryCriteria> {
 
@@ -98,10 +101,9 @@ public class StringN1qlQueryCreator extends AbstractQueryCreator<Query, QueryCri
 
 	@Override
 	protected QueryCriteria create(final Part part, final Iterator<Object> iterator) {
-		PersistentPropertyPath<CouchbasePersistentProperty> path = context.getPersistentPropertyPath(
-				part.getProperty());
+		PersistentPropertyPath<CouchbasePersistentProperty> path = context.getPersistentPropertyPath(part.getProperty());
 		CouchbasePersistentProperty property = path.getLeafProperty();
-		return from(part, property, where(path.toDotPath()), iterator);
+		return from(part, property, where(x(path.toDotPath())), iterator);
 	}
 
 	@Override
@@ -110,11 +112,10 @@ public class StringN1qlQueryCreator extends AbstractQueryCreator<Query, QueryCri
 			return create(part, iterator);
 		}
 
-		PersistentPropertyPath<CouchbasePersistentProperty> path = context.getPersistentPropertyPath(
-				part.getProperty());
+		PersistentPropertyPath<CouchbasePersistentProperty> path = context.getPersistentPropertyPath(part.getProperty());
 		CouchbasePersistentProperty property = path.getLeafProperty();
 
-		return from(part, property, base.and(path.toDotPath()), iterator);
+		return from(part, property, base.and(x(path.toDotPath())), iterator);
 	}
 
 	@Override
@@ -139,10 +140,10 @@ public class StringN1qlQueryCreator extends AbstractQueryCreator<Query, QueryCri
 
 		final Part.Type type = part.getType();
 		switch (type) {
-		case SIMPLE_PROPERTY:
-			return criteria; // this will be the dummy from PartTree
-		default:
-			throw new IllegalArgumentException("Unsupported keyword!");
+			case SIMPLE_PROPERTY:
+				return criteria; // this will be the dummy from PartTree
+			default:
+				throw new IllegalArgumentException("Unsupported keyword!");
 		}
 	}
 

--- a/src/test/java/org/springframework/data/couchbase/core/CouchbaseTemplateQueryIntegrationTests.java
+++ b/src/test/java/org/springframework/data/couchbase/core/CouchbaseTemplateQueryIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2020 the original author or authors
+ * Copyright 2012-2021 the original author or authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.springframework.data.couchbase.config.BeanNames.COUCHBASE_TEMPLATE;
 import static org.springframework.data.couchbase.config.BeanNames.REACTIVE_COUCHBASE_TEMPLATE;
+import static org.springframework.data.couchbase.core.query.N1QLExpression.i;
 
 import java.time.Instant;
 import java.time.temporal.TemporalAccessor;
@@ -60,6 +61,7 @@ import com.couchbase.client.java.query.QueryScanConsistency;
  * @author Michael Nitschinger
  * @author Michael Reiche
  * @author Haris Alesevic
+ * @author Mauro Monti
  */
 @IgnoreWhen(missesCapabilities = Capabilities.QUERY, clusterTypes = ClusterType.MOCKED)
 class CouchbaseTemplateQueryIntegrationTests extends JavaIntegrationTests {
@@ -124,7 +126,7 @@ class CouchbaseTemplateQueryIntegrationTests extends JavaIntegrationTests {
 
 		couchbaseTemplate.upsertById(User.class).all(Arrays.asList(user1, user2, specialUser));
 
-		Query specialUsers = new Query(QueryCriteria.where("firstname").like("special"));
+		Query specialUsers = new Query(QueryCriteria.where(i("firstname")).like("special"));
 		final List<User> foundUsers = couchbaseTemplate.findByQuery(User.class)
 				.withConsistency(QueryScanConsistency.REQUEST_PLUS).matching(specialUsers).all();
 
@@ -206,7 +208,7 @@ class CouchbaseTemplateQueryIntegrationTests extends JavaIntegrationTests {
 		assertTrue(couchbaseTemplate.existsById().one(user2.getId()));
 		assertTrue(couchbaseTemplate.existsById().one(specialUser.getId()));
 
-		Query nonSpecialUsers = new Query(QueryCriteria.where("firstname").notLike("special"));
+		Query nonSpecialUsers = new Query(QueryCriteria.where(i("firstname")).notLike("special"));
 
 		couchbaseTemplate.removeByQuery(User.class).withConsistency(QueryScanConsistency.REQUEST_PLUS)
 				.matching(nonSpecialUsers).all();

--- a/src/test/java/org/springframework/data/couchbase/core/query/QueryCriteriaTests.java
+++ b/src/test/java/org/springframework/data/couchbase/core/query/QueryCriteriaTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 the original author or authors.
+ * Copyright 2017-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,57 +16,56 @@
 
 package org.springframework.data.couchbase.core.query;
 
-import static org.junit.jupiter.api.Assertions.*;
-import static org.springframework.data.couchbase.core.query.QueryCriteria.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.data.couchbase.core.query.N1QLExpression.i;
+import static org.springframework.data.couchbase.core.query.N1QLExpression.meta;
+import static org.springframework.data.couchbase.core.query.N1QLExpression.path;
+import static org.springframework.data.couchbase.core.query.N1QLExpression.x;
+import static org.springframework.data.couchbase.core.query.QueryCriteria.where;
+import static org.springframework.data.couchbase.repository.query.support.N1qlUtils.escapedBucket;
+
+import org.junit.jupiter.api.Test;
 
 import com.couchbase.client.java.json.JsonArray;
-import com.couchbase.client.java.json.JsonObject;
-import org.junit.jupiter.api.Test;
-import org.springframework.data.couchbase.domain.User;
-import org.springframework.data.couchbase.domain.UserRepository;
-import org.springframework.data.couchbase.repository.query.N1qlQueryCreator;
-import org.springframework.data.repository.query.parser.PartTree;
 
-import java.lang.reflect.Method;
-import java.util.Arrays;
-import java.util.LinkedList;
-import java.util.List;
-
+/**
+ * @author Mauro Monti
+ */
 class QueryCriteriaTests {
 
 	@Test
 	void testSimpleCriteria() {
-		QueryCriteria c = where("name").is("Bubba");
+		QueryCriteria c = where(i("name")).is("Bubba");
 		assertEquals("`name` = \"Bubba\"", c.export());
 	}
 
 	@Test
 	public void testNullValue() {
-		QueryCriteria c = where("name").is(null);
+		QueryCriteria c = where(i("name")).is(null);
 		assertEquals("`name` = null", c.export());
 	}
 
 	@Test
 	void testSimpleNumber() {
-		QueryCriteria c = where("name").is(5);
+		QueryCriteria c = where(i("name")).is(5);
 		assertEquals("`name` = 5", c.export());
 	}
 
 	@Test
 	void testNotEqualCriteria() {
-		QueryCriteria c = where("name").ne("Bubba");
+		QueryCriteria c = where(i("name")).ne("Bubba");
 		assertEquals("`name` != \"Bubba\"", c.export());
 	}
 
 	@Test
 	void testChainedCriteria() {
-		QueryCriteria c = where("name").is("Bubba").and("age").lt(21).or("country").is("Austria");
+		QueryCriteria c = where(i("name")).is("Bubba").and(i("age")).lt(21).or(i("country")).is("Austria");
 		assertEquals("`name` = \"Bubba\" and `age` < 21 or `country` = \"Austria\"", c.export());
 	}
 
 	@Test
 	void testNestedAndCriteria() {
-		QueryCriteria c = where("name").is("Bubba").and(where("age").gt(12).or("country").is("Austria"));
+		QueryCriteria c = where(i("name")).is("Bubba").and(where(i("age")).gt(12).or(i("country")).is("Austria"));
 		JsonArray parameters = JsonArray.create();
 		assertEquals("`name` = $1 and (`age` > $2 or `country` = $3)", c.export(new int[1], parameters, null));
 		assertEquals("[\"Bubba\",12,\"Austria\"]", parameters.toString());
@@ -74,7 +73,7 @@ class QueryCriteriaTests {
 
 	@Test
 	void testNestedOrCriteria() {
-		QueryCriteria c = where("name").is("Bubba").or(where("age").gt(12).or("country").is("Austria"));
+		QueryCriteria c = where(i("name")).is("Bubba").or(where(i("age")).gt(12).or(i("country")).is("Austria"));
 		JsonArray parameters = JsonArray.create();
 		assertEquals("`name` = $1 or (`age` > $2 or `country` = $3)", c.export(new int[1], parameters, null));
 		assertEquals("[\"Bubba\",12,\"Austria\"]", parameters.toString());
@@ -82,45 +81,45 @@ class QueryCriteriaTests {
 
 	@Test
 	void testNestedNotIn() {
-		QueryCriteria c = where("name").is("Bubba").or(where("age").gt(12).or("country").is("Austria"))
-				.and(where("state").notIn(new String[] { "Alabama", "Florida" }));
+		QueryCriteria c = where(i("name")).is("Bubba").or(where(i("age")).gt(12).or(i("country")).is("Austria"))
+				.and(where(i("state")).notIn(new String[] { "Alabama", "Florida" }));
 		assertEquals("`name` = \"Bubba\" or (`age` > 12 or `country` = \"Austria\") and "
 				+ "(not( (`state` in ( [\"Alabama\",\"Florida\"] )) ))", c.export());
 	}
 
 	@Test
 	void testLt() {
-		QueryCriteria c = where("name").lt("Couch");
+		QueryCriteria c = where(i("name")).lt("Couch");
 		assertEquals("`name` < \"Couch\"", c.export());
 	}
 
 	@Test
 	void testLte() {
-		QueryCriteria c = where("name").lte("Couch");
+		QueryCriteria c = where(i("name")).lte("Couch");
 		assertEquals("`name` <= \"Couch\"", c.export());
 	}
 
 	@Test
 	void testGt() {
-		QueryCriteria c = where("name").gt("Couch");
+		QueryCriteria c = where(i("name")).gt("Couch");
 		assertEquals("`name` > \"Couch\"", c.export());
 	}
 
 	@Test
 	void testGte() {
-		QueryCriteria c = where("name").gte("Couch");
+		QueryCriteria c = where(i("name")).gte("Couch");
 		assertEquals("`name` >= \"Couch\"", c.export());
 	}
 
 	@Test
 	void testNe() {
-		QueryCriteria c = where("name").ne("Couch");
+		QueryCriteria c = where(i("name")).ne("Couch");
 		assertEquals("`name` != \"Couch\"", c.export());
 	}
 
 	@Test
 	void testStartingWith() {
-		QueryCriteria c = where("name").startingWith("Cou");
+		QueryCriteria c = where(i("name")).startingWith("Cou");
 		assertEquals("`name` like (\"Cou\"||\"%\")", c.export());
 	}
 
@@ -128,99 +127,99 @@ class QueryCriteriaTests {
 	       * startingWith()  cannot be a QueryCriteria
 	@Test
 	void testStartingWithExpr() {
-		QueryCriteria c = where("name").startingWith(where("name").plus("xxx"));
+		QueryCriteria c = where(i("name")).startingWith(where(i("name")).plus("xxx"));
 		assertEquals("`name` like (((`name` || "xxx") || ""%""))", c.export());
 	}
 	      */
 
 	@Test
 	void testEndingWith() {
-		QueryCriteria c = where("name").endingWith("ouch");
+		QueryCriteria c = where(i("name")).endingWith("ouch");
 		assertEquals("`name` like (\"%\"||\"ouch\")", c.export());
 	}
 
 	@Test
 	void testEndingWithExpr() {
-		QueryCriteria c = where("name").endingWith(where("name").plus("xxx"));
+		QueryCriteria c = where(i("name")).endingWith(where(i("name")).plus("xxx"));
 		assertEquals("`name` like (\"%\"||((`name` || \"xxx\")))", c.export());
 	}
 
 	@Test
 	void testRegex() {
-		QueryCriteria c = where("name").regex("C.*h");
+		QueryCriteria c = where(i("name")).regex("C.*h");
 		assertEquals("regexp_like(`name`, \"C.*h\")", c.export());
 	}
 
 	@Test
 	void testContaining() {
-		QueryCriteria c = where("name").containing("ouch");
+		QueryCriteria c = where(i("name")).containing("ouch");
 		assertEquals("contains(`name`, \"ouch\")", c.export());
 	}
 
 	@Test
 	void testNotContaining() {
-		QueryCriteria c = where("name").notContaining("Elvis");
+		QueryCriteria c = where(i("name")).notContaining("Elvis");
 		assertEquals("not( (contains(`name`, \"Elvis\")) )", c.export());
 	}
 
 	@Test
 	void testLike() {
-		QueryCriteria c = where("name").like("%ouch%");
+		QueryCriteria c = where(i("name")).like("%ouch%");
 		assertEquals("`name` like \"%ouch%\"", c.export());
 	}
 
 	@Test
 	void testNotLike() {
-		QueryCriteria c = where("name").notLike("%Elvis%");
+		QueryCriteria c = where(i("name")).notLike("%Elvis%");
 		assertEquals("not(`name` like \"%Elvis%\")", c.export());
 	}
 
 	@Test
 	void testIsNull() {
-		QueryCriteria c = where("name").isNull();
+		QueryCriteria c = where(i("name")).isNull();
 		assertEquals("`name` is null", c.export());
 	}
 
 	@Test
 	void testIsNotNull() {
-		QueryCriteria c = where("name").isNotNull();
+		QueryCriteria c = where(i("name")).isNotNull();
 		assertEquals("`name` is not null", c.export());
 	}
 
 	@Test
 	void testIsMissing() {
-		QueryCriteria c = where("name").isMissing();
+		QueryCriteria c = where(i("name")).isMissing();
 		assertEquals("`name` is missing", c.export());
 	}
 
 	@Test
 	void testIsNotMissing() {
-		QueryCriteria c = where("name").isNotMissing();
+		QueryCriteria c = where(i("name")).isNotMissing();
 		assertEquals("`name` is not missing", c.export());
 	}
 
 	@Test
 	void testIsValued() {
-		QueryCriteria c = where("name").isValued();
+		QueryCriteria c = where(i("name")).isValued();
 		assertEquals("`name` is valued", c.export());
 	}
 
 	@Test
 	void testIsNotValued() {
-		QueryCriteria c = where("name").isNotValued();
+		QueryCriteria c = where(i("name")).isNotValued();
 		assertEquals("`name` is not valued", c.export());
 	}
 
 	@Test
 	void testBetween() {
-		QueryCriteria c = where("name").between("Davis", "Gump");
+		QueryCriteria c = where(i("name")).between("Davis", "Gump");
 		assertEquals("`name` between \"Davis\" and \"Gump\"", c.export());
 	}
 
 	@Test
 	void testIn() {
 		String[] args = new String[] { "gump", "davis" };
-		QueryCriteria c = where("name").in(args);
+		QueryCriteria c = where(i("name")).in(args);
 		assertEquals("`name` in ( [\"gump\",\"davis\"] )", c.export());
 		JsonArray parameters = JsonArray.create();
 		assertEquals("`name` in ( $1 )", c.export(new int[1], parameters, null));
@@ -230,7 +229,7 @@ class QueryCriteriaTests {
 	@Test
 	void testNotIn() {
 		String[] args = new String[] { "gump", "davis" };
-		QueryCriteria c = where("name").notIn(args);
+		QueryCriteria c = where(i("name")).notIn(args);
 		assertEquals("not( (`name` in ( [\"gump\",\"davis\"] )) )", c.export());
 		JsonArray parameters = JsonArray.create();
 		assertEquals("not( (`name` in ( $1 )) )", c.export(new int[1], parameters, null));
@@ -239,14 +238,30 @@ class QueryCriteriaTests {
 
 	@Test
 	void testTrue() {
-		QueryCriteria c = where("name").TRUE();
+		QueryCriteria c = where(i("name")).TRUE();
 		assertEquals("`name`", c.export());
 	}
 
 	@Test
 	void testFalse() {
-		QueryCriteria c = where("name").FALSE();
+		QueryCriteria c = where(i("name")).FALSE();
 		assertEquals("not( (`name`) )", c.export());
+	}
+
+	@Test // https://github.com/spring-projects/spring-data-couchbase/issues/1066
+	void testCriteriaCorrectlyEscapedWhenUsingMetaOnLHS() {
+		final String bucketName = "sample-bucket";
+		final String version = "1611287177404088320";
+		QueryCriteria criteria = QueryCriteria.where(path(meta(escapedBucket(bucketName)), "cas")).eq(x(version));
+		assertEquals("META(`" + bucketName + "`).cas = " + x(version), criteria.export());
+	}
+
+	@Test // https://github.com/spring-projects/spring-data-couchbase/issues/1066
+	void testCriteriaCorrectlyEscapedWhenUsingMetaOnRHS() {
+		final String bucketName = "sample-bucket";
+		final String version = "1611287177404088320";
+		QueryCriteria criteria = QueryCriteria.where(x(version)).eq(path(meta(escapedBucket(bucketName)), "cas"));
+		assertEquals(x(version) + " = META(`" + bucketName + "`).cas", criteria.export());
 	}
 
 	private String arrayToString(Object[] array) {

--- a/src/test/java/org/springframework/data/couchbase/domain/UserRepository.java
+++ b/src/test/java/org/springframework/data/couchbase/domain/UserRepository.java
@@ -19,11 +19,11 @@ package org.springframework.data.couchbase.domain;
 import java.util.List;
 
 import org.springframework.data.couchbase.repository.CouchbaseRepository;
-import com.couchbase.client.java.json.JsonArray;
 import org.springframework.data.couchbase.repository.Query;
-import org.springframework.data.repository.PagingAndSortingRepository;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import com.couchbase.client.java.json.JsonArray;
 
 /**
  * User Repository for tests
@@ -47,4 +47,8 @@ public interface UserRepository extends CouchbaseRepository<User, String> {
 
 	@Query("#{#n1ql.selectEntity} where #{#n1ql.filter} and (firstname = $first or lastname = $last)")
 	List<User> getByFirstnameOrLastname(@Param("first") String firstname, @Param("last") String lastname);
+
+	List<User> findByIdIsNotNullAndFirstnameEquals(String firstname);
+
+	List<User> findByVersionEqualsAndFirstnameEquals(Long version, String firstname);
 }

--- a/src/test/java/org/springframework/data/couchbase/repository/CouchbaseRepositoryQueryIntegrationTests.java
+++ b/src/test/java/org/springframework/data/couchbase/repository/CouchbaseRepositoryQueryIntegrationTests.java
@@ -16,9 +16,12 @@
 
 package org.springframework.data.couchbase.repository;
 
-import static java.util.Arrays.*;
-import static org.assertj.core.api.Assertions.*;
-import static org.junit.jupiter.api.Assertions.*;
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -49,14 +52,12 @@ import org.springframework.data.couchbase.util.Capabilities;
 import org.springframework.data.couchbase.util.ClusterAwareIntegrationTests;
 import org.springframework.data.couchbase.util.ClusterType;
 import org.springframework.data.couchbase.util.IgnoreWhen;
-import org.springframework.data.util.StreamUtils;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
 import com.couchbase.client.core.error.IndexExistsException;
-import reactor.core.publisher.Flux;
 
 /**
  * Repository tests
@@ -173,7 +174,9 @@ public class CouchbaseRepositoryQueryIntegrationTests extends ClusterAwareIntegr
 
 		try {
 
-			airportRepository.saveAll( Arrays.stream(iatas).map((iata) -> new Airport("airports::"+iata, iata, iata.toLowerCase(Locale.ROOT))).collect(Collectors.toSet()));
+			airportRepository.saveAll(
+					Arrays.stream(iatas).map((iata) -> new Airport("airports::" + iata, iata, iata.toLowerCase(Locale.ROOT)))
+							.collect(Collectors.toSet()));
 			Long count = airportRepository.countFancyExpression(asList("JFK"), asList("jfk"), false);
 			assertEquals(1, count);
 
@@ -198,7 +201,8 @@ public class CouchbaseRepositoryQueryIntegrationTests extends ClusterAwareIntegr
 			assertEquals(0, airportCount);
 
 		} finally {
-				airportRepository.deleteAllById(Arrays.stream(iatas).map((iata) -> "airports::"+iata).collect(Collectors.toSet()));
+			airportRepository
+					.deleteAllById(Arrays.stream(iatas).map((iata) -> "airports::" + iata).collect(Collectors.toSet()));
 		}
 	}
 
@@ -295,7 +299,6 @@ public class CouchbaseRepositoryQueryIntegrationTests extends ClusterAwareIntegr
 
 			airportRepository.deleteAllById(asList(vienna.getId(), losAngeles.getId()));
 
-
 			assertThat(airportRepository.findAll()).containsExactly(frankfurt);
 		} finally {
 			airportRepository.deleteAll();
@@ -305,9 +308,7 @@ public class CouchbaseRepositoryQueryIntegrationTests extends ClusterAwareIntegr
 	private void sleep(int millis) {
 		try {
 			Thread.sleep(millis); // so they are executed out-of-order
-		} catch (InterruptedException ie) {
-			;
-		}
+		} catch (InterruptedException ie) {}
 	}
 
 	@Configuration


### PR DESCRIPTION
This is a merge of mmonti's changeset into master. The changeset was made
on top of 4.1.x instead of master so it has a little catching up to do.

Closes #1066

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATACOUCH).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
