### PR TITLE
DATACOUCH-550 - Revert Refactored CouchbasePersistentEntityIndexCreator.

### DIFF
--- a/src/main/java/org/springframework/data/couchbase/core/CouchbaseTemplate.java
+++ b/src/main/java/org/springframework/data/couchbase/core/CouchbaseTemplate.java
@@ -19,10 +19,17 @@ package org.springframework.data.couchbase.core;
 import org.springframework.beans.BeansException;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
+import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.data.couchbase.CouchbaseClientFactory;
 import org.springframework.data.couchbase.core.convert.CouchbaseConverter;
 import org.springframework.data.couchbase.core.convert.translation.JacksonTranslationService;
 import org.springframework.data.couchbase.core.convert.translation.TranslationService;
+import org.springframework.data.couchbase.core.index.CouchbasePersistentEntityIndexCreator;
+import org.springframework.data.couchbase.core.mapping.CouchbaseMappingContext;
+import org.springframework.data.couchbase.core.mapping.CouchbasePersistentEntity;
+import org.springframework.data.couchbase.core.mapping.CouchbasePersistentProperty;
+import org.springframework.data.mapping.context.MappingContext;
+import org.springframework.lang.Nullable;
 
 import com.couchbase.client.java.Collection;
 
@@ -40,7 +47,9 @@ public class CouchbaseTemplate implements CouchbaseOperations, ApplicationContex
 	private final CouchbaseClientFactory clientFactory;
 	private final CouchbaseConverter converter;
 	private final CouchbaseTemplateSupport templateSupport;
+	private final MappingContext<? extends CouchbasePersistentEntity<?>, CouchbasePersistentProperty> mappingContext;
 	private final ReactiveCouchbaseTemplate reactiveCouchbaseTemplate;
+	private @Nullable CouchbasePersistentEntityIndexCreator indexCreator;
 
 	public CouchbaseTemplate(final CouchbaseClientFactory clientFactory, final CouchbaseConverter converter) {
 		this(clientFactory, converter, new JacksonTranslationService());
@@ -52,6 +61,14 @@ public class CouchbaseTemplate implements CouchbaseOperations, ApplicationContex
 		this.converter = converter;
 		this.templateSupport = new CouchbaseTemplateSupport(converter, translationService);
 		this.reactiveCouchbaseTemplate = new ReactiveCouchbaseTemplate(clientFactory, converter, translationService);
+
+		this.mappingContext = this.converter.getMappingContext();
+		if (mappingContext instanceof CouchbaseMappingContext) {
+			CouchbaseMappingContext cmc = (CouchbaseMappingContext) mappingContext;
+			if (cmc.isAutoIndexCreation()) {
+				indexCreator = new CouchbasePersistentEntityIndexCreator(cmc, this);
+			}
+		}
 	}
 
 	@Override
@@ -140,7 +157,28 @@ public class CouchbaseTemplate implements CouchbaseOperations, ApplicationContex
 
 	@Override
 	public void setApplicationContext(final ApplicationContext applicationContext) throws BeansException {
+		prepareIndexCreator(applicationContext);
 		templateSupport.setApplicationContext(applicationContext);
 		reactiveCouchbaseTemplate.setApplicationContext(applicationContext);
+	}
+
+	private void prepareIndexCreator(final ApplicationContext context) {
+		String[] indexCreators = context.getBeanNamesForType(CouchbasePersistentEntityIndexCreator.class);
+
+		for (String creator : indexCreators) {
+			CouchbasePersistentEntityIndexCreator creatorBean = context.getBean(creator,
+					CouchbasePersistentEntityIndexCreator.class);
+			if (creatorBean.isIndexCreatorFor(mappingContext)) {
+				return;
+			}
+		}
+
+		if (context instanceof ConfigurableApplicationContext && indexCreator != null) {
+			((ConfigurableApplicationContext) context).addApplicationListener(indexCreator);
+			if (mappingContext instanceof CouchbaseMappingContext) {
+				CouchbaseMappingContext cmc = (CouchbaseMappingContext) mappingContext;
+				cmc.setIndexCreator(indexCreator);
+			}
+		}
 	}
 }

--- a/src/test/java/org/springframework/data/couchbase/core/CustomTypeKeyIntegrationTests.java
+++ b/src/test/java/org/springframework/data/couchbase/core/CustomTypeKeyIntegrationTests.java
@@ -48,7 +48,7 @@ public class CustomTypeKeyIntegrationTests extends ClusterAwareIntegrationTests 
 
 	@Test
 	void saveSimpleEntityCorrectlyWithDifferentTypeKey() {
-		clientFactory.getBucket().waitUntilReady(Duration.ofSeconds(5));
+		clientFactory.getBucket().waitUntilReady(Duration.ofSeconds(10));
 
 		User user = new User(UUID.randomUUID().toString(), "firstname", "lastname");
 		// When using 'mocked', this call runs fine when the test class is ran by itself,


### PR DESCRIPTION


This reverts commit 80bae4bf67c8deb78fa9cef5c685335b62f16efd.

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATACOUCH).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
