### PR TITLE
Revert Couchbase SDK to 3.0.1 on 4.1.x.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,8 +18,8 @@
     </parent>
 
     <properties>
-        <couchbase>3.1.3</couchbase>
-        <couchbase.osgi>3.1.3</couchbase.osgi>
+        <couchbase>3.0.10</couchbase>
+        <couchbase.osgi>3.0.10</couchbase.osgi>
         <springdata.commons>2.4.7-SNAPSHOT</springdata.commons>
         <java-module-name>spring.data.couchbase</java-module-name>
     </properties>


### PR DESCRIPTION
Revert Couchbase SDK to 3.0.1 on 4.1.x.

Closes #1103.
Original pull request #1107.

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATACOUCH).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
