### PR TITLE
Use queryScanConsistency on reactive deleteAll().

### DIFF
--- a/src/main/java/org/springframework/data/couchbase/repository/support/SimpleReactiveCouchbaseRepository.java
+++ b/src/main/java/org/springframework/data/couchbase/repository/support/SimpleReactiveCouchbaseRepository.java
@@ -16,7 +16,7 @@
 
 package org.springframework.data.couchbase.repository.support;
 
-import static org.springframework.data.couchbase.repository.support.Util.*;
+import static org.springframework.data.couchbase.repository.support.Util.hasNonZeroVersionProperty;
 
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -26,7 +26,6 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 
 import org.reactivestreams.Publisher;
-
 import org.springframework.data.couchbase.core.CouchbaseOperations;
 import org.springframework.data.couchbase.core.ReactiveCouchbaseOperations;
 import org.springframework.data.couchbase.core.query.Query;
@@ -189,7 +188,8 @@ public class SimpleReactiveCouchbaseRepository<T, ID> implements ReactiveCouchba
 
 	@Override
 	public Mono<Void> deleteAll() {
-		return operations.removeByQuery(entityInformation.getJavaType()).all().then();
+		return operations.removeByQuery(entityInformation.getJavaType()).withConsistency(buildQueryScanConsistency()).all()
+				.then();
 	}
 
 	/**

--- a/src/test/java/org/springframework/data/couchbase/domain/ReactiveAirportRepository.java
+++ b/src/test/java/org/springframework/data/couchbase/domain/ReactiveAirportRepository.java
@@ -46,6 +46,10 @@ public interface ReactiveAirportRepository extends ReactiveSortingRepository<Air
 	Flux<Airport> findAll();
 
 	@Override
+	@ScanConsistency(query = QueryScanConsistency.REQUEST_PLUS)
+	Mono<Void> deleteAll();
+
+	@Override
 	Mono<Airport> save(Airport a);
 
 	@ScanConsistency(query = QueryScanConsistency.REQUEST_PLUS)

--- a/src/test/java/org/springframework/data/couchbase/repository/ReactiveCouchbaseRepositoryQueryIntegrationTests.java
+++ b/src/test/java/org/springframework/data/couchbase/repository/ReactiveCouchbaseRepositoryQueryIntegrationTests.java
@@ -195,6 +195,25 @@ public class ReactiveCouchbaseRepositoryQueryIntegrationTests extends JavaIntegr
 		}
 	}
 
+	@Test
+	void deleteAll() {
+
+		Airport vienna = new Airport("airports::vie", "vie", "LOWW");
+		Airport frankfurt = new Airport("airports::fra", "fra", "EDDF");
+		Airport losAngeles = new Airport("airports::lax", "lax", "KLAX");
+
+		try {
+			airportRepository.saveAll(asList(vienna, frankfurt, losAngeles)).as(StepVerifier::create)
+					.expectNext(vienna, frankfurt, losAngeles).verifyComplete();
+
+			airportRepository.deleteAll().as(StepVerifier::create).verifyComplete();
+
+			airportRepository.findAll().as(StepVerifier::create).verifyComplete();
+		} finally {
+			airportRepository.deleteAll().block();
+		}
+	}
+
 	@Configuration
 	@EnableReactiveCouchbaseRepositories("org.springframework.data.couchbase")
 	static class Config extends AbstractCouchbaseConfiguration {


### PR DESCRIPTION
It was present on non-Reactive, but missing from reactive.

Closes #1096.
Original pull request #1108.

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATACOUCH).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
