### PR TITLE
Add QueryCriteria arrayContaining.

### DIFF
--- a/src/main/java/org/springframework/data/couchbase/core/query/QueryCriteria.java
+++ b/src/main/java/org/springframework/data/couchbase/core/query/QueryCriteria.java
@@ -192,6 +192,13 @@ public class QueryCriteria implements QueryCriteriaDefinition {
 		return this;
 	}
 
+	public QueryCriteria arrayContaining(@Nullable Object o) {
+		operator = "ARRAY_CONTAINING";
+		value = new Object[] { o };
+		format = "array_containing(%1$s, %3$s)";
+		return this;
+	}
+
 	public QueryCriteria notContaining(@Nullable Object o) {
 		value = new QueryCriteria[] { wrap(containing(o)) };
 		operator = "NOT";

--- a/src/test/java/org/springframework/data/couchbase/core/query/QueryCriteriaTests.java
+++ b/src/test/java/org/springframework/data/couchbase/core/query/QueryCriteriaTests.java
@@ -123,14 +123,11 @@ class QueryCriteriaTests {
 		assertEquals("`name` like (\"Cou\"||\"%\")", c.export());
 	}
 
-	/* cannot do this properly yet because in arg to when() in
-	       * startingWith()  cannot be a QueryCriteria
 	@Test
 	void testStartingWithExpr() {
 		QueryCriteria c = where(i("name")).startingWith(where(i("name")).plus("xxx"));
-		assertEquals("`name` like (((`name` || "xxx") || ""%""))", c.export());
+		assertEquals("`name` like (((`name` || \"xxx\"))||\"%\")", c.export());
 	}
-	      */
 
 	@Test
 	void testEndingWith() {
@@ -160,6 +157,12 @@ class QueryCriteriaTests {
 	void testNotContaining() {
 		QueryCriteria c = where(i("name")).notContaining("Elvis");
 		assertEquals("not( (contains(`name`, \"Elvis\")) )", c.export());
+	}
+
+	@Test
+	void testArrayContaining() {
+		QueryCriteria c = where(i("name")).arrayContaining("Elvis");
+		assertEquals("array_containing(`name`, \"Elvis\")", c.export());
 	}
 
 	@Test


### PR DESCRIPTION
Add QueryCriteria arrayContaining which maps to n1ql array_containing.

Closes #1073.
Original pull request #1109.

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATACOUCH).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
