### PR TITLE
Fix N1qlExpression keys.

### DIFF
--- a/src/main/java/org/springframework/data/couchbase/core/query/N1QLExpression.java
+++ b/src/main/java/org/springframework/data/couchbase/core/query/N1QLExpression.java
@@ -262,13 +262,14 @@ public class N1QLExpression {
 	public N1QLExpression keys(Iterable<? extends Serializable> ids) {
 		StringBuilder sb = new StringBuilder();
 		Iterator<?> it = ids.iterator();
-		// TODO: really? Lets do better.
+		sb.append("[");
 		while (it.hasNext()) {
-			sb.append(i(it.next().toString()));
+			sb.append(s(it.next().toString()));
 			if (it.hasNext()) {
 				sb.append(",");
 			}
 		}
+		sb.append("]");
 		return infix("USE KEYS", toString(), sb.toString());
 	}
 

--- a/src/test/java/org/springframework/data/couchbase/core/query/QueryCriteriaTests.java
+++ b/src/test/java/org/springframework/data/couchbase/core/query/QueryCriteriaTests.java
@@ -28,6 +28,8 @@ import org.junit.jupiter.api.Test;
 
 import com.couchbase.client.java.json.JsonArray;
 
+import java.util.Arrays;
+
 /**
  * @author Mauro Monti
  */
@@ -250,6 +252,15 @@ class QueryCriteriaTests {
 		QueryCriteria c = where(i("name")).FALSE();
 		assertEquals("not( (`name`) )", c.export());
 	}
+
+	@Test
+	void testKeys() {
+		N1QLExpression expression = N1QLExpression.x("");
+		assertEquals(" USE KEYS [\"a\",\"b\"]", expression.keys(Arrays.asList("a", "b")).toString());
+		assertEquals(" USE KEYS [\"a\"]", expression.keys(Arrays.asList("a")).toString());
+		assertEquals(" USE KEYS []", expression.keys(Arrays.asList()).toString());
+	}
+
 
 	@Test // https://github.com/spring-projects/spring-data-couchbase/issues/1066
 	void testCriteriaCorrectlyEscapedWhenUsingMetaOnLHS() {


### PR DESCRIPTION
Fix syntax for USE KEYS [ ... ]

Closes #1064.
Original pull request: #1113.

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATACOUCH).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
