### PR TITLE
DefaultCouchbaseTypeMapper uses TypeAlias annotation if present.

### DIFF
--- a/src/main/java/org/springframework/data/couchbase/core/convert/DefaultCouchbaseTypeMapper.java
+++ b/src/main/java/org/springframework/data/couchbase/core/convert/DefaultCouchbaseTypeMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2020 the original author or authors
+ * Copyright 2012-2021 the original author or authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,10 +16,13 @@
 
 package org.springframework.data.couchbase.core.convert;
 
+import java.util.Collections;
+
 import org.springframework.data.convert.DefaultTypeMapper;
 import org.springframework.data.convert.TypeAliasAccessor;
 import org.springframework.data.couchbase.core.mapping.CouchbaseDocument;
 import org.springframework.data.mapping.Alias;
+import org.springframework.data.mapping.context.MappingContext;
 import org.springframework.data.util.TypeInformation;
 
 /**
@@ -27,6 +30,7 @@ import org.springframework.data.util.TypeInformation;
  *
  * @author Michael Nitschinger
  * @author Mark Paluch
+ * @author Michael Reiche
  */
 public class DefaultCouchbaseTypeMapper extends DefaultTypeMapper<CouchbaseDocument> implements CouchbaseTypeMapper {
 
@@ -43,7 +47,8 @@ public class DefaultCouchbaseTypeMapper extends DefaultTypeMapper<CouchbaseDocum
 	 * @param typeKey the typeKey to use.
 	 */
 	public DefaultCouchbaseTypeMapper(final String typeKey) {
-		super(new CouchbaseDocumentTypeAliasAccessor(typeKey));
+		super(new CouchbaseDocumentTypeAliasAccessor(typeKey), (MappingContext) null,
+				Collections.singletonList(new TypeAwareTypeInformationMapper()));
 		this.typeKey = typeKey;
 	}
 

--- a/src/main/java/org/springframework/data/couchbase/core/convert/TypeAwareTypeInformationMapper.java
+++ b/src/main/java/org/springframework/data/couchbase/core/convert/TypeAwareTypeInformationMapper.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2012-2021 the original author or authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.couchbase.core.convert;
+
+import org.springframework.data.annotation.TypeAlias;
+import org.springframework.data.convert.SimpleTypeInformationMapper;
+import org.springframework.data.mapping.Alias;
+import org.springframework.data.util.TypeInformation;
+
+/**
+ * TypeAwareTypeInformationMapper - leverages @TypeAlias
+ *
+ * @author Michael Reiche
+ */
+public class TypeAwareTypeInformationMapper extends SimpleTypeInformationMapper {
+
+	@Override
+	public Alias createAliasFor(TypeInformation<?> type) {
+		TypeAlias[] typeAlias = type.getType().getAnnotationsByType(TypeAlias.class);
+
+		if (typeAlias.length == 1) {
+			return Alias.of(typeAlias[0].value());
+		}
+
+		return super.createAliasFor(type);
+	}
+}

--- a/src/test/java/org/springframework/data/couchbase/domain/Airport.java
+++ b/src/test/java/org/springframework/data/couchbase/domain/Airport.java
@@ -18,6 +18,7 @@ package org.springframework.data.couchbase.domain;
 
 import org.springframework.data.annotation.Id;
 import org.springframework.data.annotation.PersistenceConstructor;
+import org.springframework.data.annotation.TypeAlias;
 import org.springframework.data.couchbase.core.mapping.Document;
 
 /**
@@ -27,6 +28,7 @@ import org.springframework.data.couchbase.core.mapping.Document;
  * @author Michael Reiche
  */
 @Document
+@TypeAlias("airport")
 public class Airport extends ComparableEntity {
 	@Id String id;
 


### PR DESCRIPTION
DefaultCouchbaseTypeMapper uses TypeAlias annotation if present.
Test case also uncovered that TypeAlias was being ignored for
string queries.

Closes #1119.

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATACOUCH).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
