### PR TITLE
Improve framework for custom mapping couchbase converter.

### DIFF
--- a/src/main/java/org/springframework/data/couchbase/config/AbstractCouchbaseConfiguration.java
+++ b/src/main/java/org/springframework/data/couchbase/config/AbstractCouchbaseConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2020 the original author or authors
+ * Copyright 2012-2021 the original author or authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -49,7 +49,6 @@ import org.springframework.util.ClassUtils;
 import org.springframework.util.StringUtils;
 
 import com.couchbase.client.core.deps.com.fasterxml.jackson.databind.DeserializationFeature;
-import com.couchbase.client.core.deps.com.fasterxml.jackson.databind.Module;
 import com.couchbase.client.core.encryption.CryptoManager;
 import com.couchbase.client.core.env.Authenticator;
 import com.couchbase.client.core.env.PasswordAuthenticator;
@@ -60,7 +59,6 @@ import com.couchbase.client.java.encryption.databind.jackson.EncryptionModule;
 import com.couchbase.client.java.env.ClusterEnvironment;
 import com.couchbase.client.java.json.JacksonTransformers;
 import com.couchbase.client.java.json.JsonValueModule;
-import com.couchbase.client.java.json.RepackagedJsonValueModule;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
@@ -74,8 +72,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
  */
 @Configuration
 public abstract class AbstractCouchbaseConfiguration {
-
-	@Autowired ObjectMapper couchbaseObjectMapper;
 
 	/**
 	 * The connection string which allows the SDK to connect to the cluster.
@@ -144,7 +140,7 @@ public abstract class AbstractCouchbaseConfiguration {
 		if (!nonShadowedJacksonPresent()) {
 			throw new CouchbaseException("non-shadowed Jackson not present");
 		}
-		builder.jsonSerializer(JacksonJsonSerializer.create(couchbaseObjectMapper));
+		builder.jsonSerializer(JacksonJsonSerializer.create(couchbaseObjectMapper()));
 		configureEnvironment(builder);
 		return builder.build();
 	}

--- a/src/main/java/org/springframework/data/couchbase/core/convert/AbstractCouchbaseConverter.java
+++ b/src/main/java/org/springframework/data/couchbase/core/convert/AbstractCouchbaseConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2020 the original author or authors
+ * Copyright 2012-2021 the original author or authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,6 @@
 package org.springframework.data.couchbase.core.convert;
 
 import java.util.Collections;
-import java.util.Optional;
 
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.core.convert.ConversionService;
@@ -68,7 +67,8 @@ public abstract class AbstractCouchbaseConverter implements CouchbaseConverter, 
 	}
 
 	/**
-	 * Set the custom conversions.
+	 * Set the custom conversions. Note that updating conversions requires a subsequent call to register them with the
+	 * conversionService: conversions.registerConvertersIn(conversionService)
 	 *
 	 * @param conversions the conversions.
 	 */

--- a/src/main/java/org/springframework/data/couchbase/repository/query/StringBasedN1qlQueryParser.java
+++ b/src/main/java/org/springframework/data/couchbase/repository/query/StringBasedN1qlQueryParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 the original author or authors.
+ * Copyright 2017-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -124,9 +124,6 @@ public class StringBasedN1qlQueryParser {
 	private final CouchbaseConverter couchbaseConverter;
 	private final Collection<String> parameterNames = new HashSet<String>();
 	public final N1QLExpression parsedExpression;
-
-	private GenericConversionService conversionService = new DefaultConversionService();
-	private CustomConversions conversions = new CouchbaseCustomConversions(Collections.emptyList());
 
 	public StringBasedN1qlQueryParser(String statement, CouchbaseQueryMethod queryMethod, String bucketName,
 			CouchbaseConverter couchbaseConverter, String typeField, String typeValue, ParameterAccessor accessor,


### PR DESCRIPTION
1) change examples in Config to show creating repository mappings using
existing MappingCouchbaseConverter (which have customConversions /
BeanNames.COUCHBASE_CUSTOM_CONVERSIONS and applicationContext)
instead of creating their own and then adding the customConversion and
applicationContext.

2) remove unused members fro StringBasedN1qlQueryParser

Closes #1141.

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATACOUCH).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [ ] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
