### PR TITLE
Omit annotations from the repository and domaintype in CrudMethodMetadata.

### DIFF
--- a/src/main/java/org/springframework/data/couchbase/repository/support/CrudMethodMetadataPostProcessor.java
+++ b/src/main/java/org/springframework/data/couchbase/repository/support/CrudMethodMetadataPostProcessor.java
@@ -145,7 +145,6 @@ class CrudMethodMetadataPostProcessor implements RepositoryProxyPostProcessor, B
 			currentInvocation.set(invocation);
 
 			try {
-
 				CrudMethodMetadata metadata = (CrudMethodMetadata) TransactionSynchronizationManager.getResource(method);
 
 				if (metadata != null) {
@@ -156,7 +155,7 @@ class CrudMethodMetadataPostProcessor implements RepositoryProxyPostProcessor, B
 
 				if (methodMetadata == null) {
 
-					methodMetadata = new DefaultCrudMethodMetadata(method, repositoryInformation);
+					methodMetadata = new DefaultCrudMethodMetadata(method);
 					CrudMethodMetadata tmp = metadataCache.putIfAbsent(method, methodMetadata);
 
 					if (tmp != null) {
@@ -187,7 +186,6 @@ class CrudMethodMetadataPostProcessor implements RepositoryProxyPostProcessor, B
 
 		private final Method method;
 		private final ScanConsistency scanConsistency;
-		private final RepositoryInformation repositoryInformation;
 		private final String scope;
 		private final String collection;
 
@@ -198,10 +196,9 @@ class CrudMethodMetadataPostProcessor implements RepositoryProxyPostProcessor, B
 		 * 
 		 * @param method must not be {@literal null}.
 		 */
-		DefaultCrudMethodMetadata(Method method, RepositoryInformation repositoryInformation) {
+		DefaultCrudMethodMetadata(Method method) {
 			Assert.notNull(method, "Method must not be null!");
 			this.method = method;
-			this.repositoryInformation = repositoryInformation;
 			String n = method.getName();
 			// internal methods
 			if (n.equals("getEntityInformation") || n.equals("getOperations") || n.equals("withOptions")
@@ -212,8 +209,7 @@ class CrudMethodMetadataPostProcessor implements RepositoryProxyPostProcessor, B
 				return;
 			}
 
-			AnnotatedElement[] annotated = new AnnotatedElement[] { method, method.getDeclaringClass(),
-					repositoryInformation.getRepositoryInterface(), repositoryInformation.getDomainType() };
+			AnnotatedElement[] annotated = new AnnotatedElement[] { method, method.getDeclaringClass()};
 			this.scanConsistency = OptionsBuilder.annotation(ScanConsistency.class, "query", QueryScanConsistency.NOT_BOUNDED,
 					annotated);
 			this.scope = OptionsBuilder.annotationString(Scope.class, CollectionIdentifier.DEFAULT_SCOPE, annotated);

--- a/src/test/java/org/springframework/data/couchbase/domain/UserColRepository.java
+++ b/src/test/java/org/springframework/data/couchbase/domain/UserColRepository.java
@@ -38,7 +38,9 @@ import com.couchbase.client.java.query.QueryScanConsistency;
 @ScanConsistency(query = QueryScanConsistency.REQUEST_PLUS)
 public interface UserColRepository extends CouchbaseRepository<UserCol, String>, DynamicProxyable<UserColRepository> {
 
-	<S extends UserCol> S save(S var1);
+	// CouchbaseRepositoryQueryCollectionIntegrationTests.testScopeCollectionAnnotationSwap() relies on this
+	// being commented out.
+	//<S extends UserCol> S save(S var1);
 
 	List<UserCol> findByFirstname(String firstname);
 


### PR DESCRIPTION
Omit annotations from the repository and domaintype in
CrudMethodMetadata as they may be different for the same method.
The annotations from the repository and domaintype are obtained directly
in CouchbaseRepositoryBase.

Closes #1168.

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATACOUCH).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
