### PR TITLE
N1ql query should project getFieldName() instead of getName().

### DIFF
--- a/src/main/java/org/springframework/data/couchbase/repository/query/StringBasedN1qlQueryParser.java
+++ b/src/main/java/org/springframework/data/couchbase/repository/query/StringBasedN1qlQueryParser.java
@@ -214,7 +214,7 @@ public class StringBasedN1qlQueryParser {
 				if (path != null && path.length() != 0) {
 					sb.append(path);
 				}
-				sb.append(prop.getName());
+				sb.append(prop.getFieldName());
 				sb.append('`');
 				// }
 			}

--- a/src/test/java/org/springframework/data/couchbase/repository/CouchbaseRepositoryQueryIntegrationTests.java
+++ b/src/test/java/org/springframework/data/couchbase/repository/CouchbaseRepositoryQueryIntegrationTests.java
@@ -160,8 +160,11 @@ public class CouchbaseRepositoryQueryIntegrationTests extends ClusterAwareIntegr
 			person = new Person(1, "first", "last");
 			person.setMiddlename("Nick"); // middlename is stored as nickname
 			personRepository.save(person);
-			List<Person> persons2 = personRepository.findByMiddlename("Nick");
-			assertEquals(1, persons2.size());
+			Person person2 = personRepository.findById(person.getId().toString()).get();
+			assertEquals(person.getMiddlename(), person2.getMiddlename());
+			List<Person> persons3 = personRepository.findByMiddlename("Nick");
+			assertEquals(1, persons3.size());
+			assertEquals(person.getMiddlename(), persons3.get(0).getMiddlename());
 		} finally {
 			personRepository.deleteById(person.getId().toString());
 		}


### PR DESCRIPTION
Project getFieldName() instead of getName() since getFieldName() is what is stored in the document.
The decoder handles populating getName() entity property with the getFieldName() json property.

Closes #1184.

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATACOUCH).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
