### PR TITLE
Remove unnecessary auditorAwareRef from test config.

### DIFF
--- a/src/test/java/org/springframework/data/couchbase/core/CouchbaseTemplateQueryCollectionIntegrationTests.java
+++ b/src/test/java/org/springframework/data/couchbase/core/CouchbaseTemplateQueryCollectionIntegrationTests.java
@@ -150,7 +150,7 @@ class CouchbaseTemplateQueryCollectionIntegrationTests extends CollectionAwareIn
 
 			for (User u : foundUsers) {
 				assertTrue(u.equals(user1) || u.equals(user2));
-				assertEquals(auditUser, u.getCreator());
+				assertEquals(auditUser, u.getCreatedBy());
 				assertEquals(auditMillis, u.getCreatedDate());
 				assertEquals(auditUser, u.getLastModifiedBy());
 				assertEquals(auditMillis, u.getLastModifiedDate());

--- a/src/test/java/org/springframework/data/couchbase/core/CouchbaseTemplateQueryIntegrationTests.java
+++ b/src/test/java/org/springframework/data/couchbase/core/CouchbaseTemplateQueryIntegrationTests.java
@@ -99,7 +99,7 @@ class CouchbaseTemplateQueryIntegrationTests extends JavaIntegrationTests {
 
 			for (User u : foundUsers) {
 				assertTrue(u.equals(user1) || u.equals(user2));
-				assertEquals(auditUser, u.getCreator());
+				assertEquals(auditUser, u.getCreatedBy());
 				assertEquals(auditMillis, u.getCreatedDate());
 				assertEquals(auditUser, u.getLastModifiedBy());
 				assertEquals(auditMillis, u.getLastModifiedDate());

--- a/src/test/java/org/springframework/data/couchbase/core/query/ReactiveCouchbaseTemplateQueryCollectionIntegrationTests.java
+++ b/src/test/java/org/springframework/data/couchbase/core/query/ReactiveCouchbaseTemplateQueryCollectionIntegrationTests.java
@@ -148,7 +148,7 @@ class ReactiveCouchbaseTemplateQueryCollectionIntegrationTests extends Collectio
 
 			for (User u : foundUsers) {
 				assertTrue(u.equals(user1) || u.equals(user2));
-				assertEquals(auditUser, u.getCreator());
+				assertEquals(auditUser, u.getCreatedBy());
 				assertEquals(auditMillis, u.getCreatedDate());
 				assertEquals(auditUser, u.getLastModifiedBy());
 				assertEquals(auditMillis, u.getLastModifiedDate());

--- a/src/test/java/org/springframework/data/couchbase/domain/Config.java
+++ b/src/test/java/org/springframework/data/couchbase/domain/Config.java
@@ -54,9 +54,8 @@ import com.couchbase.client.java.json.JacksonTransformers;
 @Configuration
 @EnableCouchbaseRepositories
 @EnableReactiveCouchbaseRepositories
-@EnableCouchbaseAuditing(auditorAwareRef = "auditorAwareRef", dateTimeProviderRef = "dateTimeProviderRef")
-@EnableReactiveCouchbaseAuditing(auditorAwareRef = "reactiveAuditorAwareRef",
-		dateTimeProviderRef = "dateTimeProviderRef")
+@EnableCouchbaseAuditing(dateTimeProviderRef = "dateTimeProviderRef")
+@EnableReactiveCouchbaseAuditing(dateTimeProviderRef = "dateTimeProviderRef")
 
 public class Config extends AbstractCouchbaseConfiguration {
 	String bucketname = "travel-sample";
@@ -128,11 +127,11 @@ public class Config extends AbstractCouchbaseConfiguration {
 		try {
 			// comment out references to 'protected' and 'mybucket' - they are only to show how multi-bucket would work
 			// ReactiveCouchbaseTemplate personTemplate = myReactiveCouchbaseTemplate(myCouchbaseClientFactory("protected"),
-			//		(MappingCouchbaseConverter) (baseMapping.getDefault().getConverter()));
+			// (MappingCouchbaseConverter) (baseMapping.getDefault().getConverter()));
 			// baseMapping.mapEntity(Person.class, personTemplate); // Person goes in "protected" bucket
 			// ReactiveCouchbaseTemplate userTemplate = myReactiveCouchbaseTemplate(myCouchbaseClientFactory("mybucket"),
-			//		(MappingCouchbaseConverter) (baseMapping.getDefault().getConverter()));
-			//baseMapping.mapEntity(User.class, userTemplate); // User goes in "mybucket"
+			// (MappingCouchbaseConverter) (baseMapping.getDefault().getConverter()));
+			// baseMapping.mapEntity(User.class, userTemplate); // User goes in "mybucket"
 			// everything else goes in getBucketName() ( which is travel-sample )
 		} catch (Exception e) {
 			throw e;
@@ -144,11 +143,11 @@ public class Config extends AbstractCouchbaseConfiguration {
 		try {
 			// comment out references to 'protected' and 'mybucket' - they are only to show how multi-bucket would work
 			// CouchbaseTemplate personTemplate = myCouchbaseTemplate(myCouchbaseClientFactory("protected"),
-			// 		(MappingCouchbaseConverter) (baseMapping.getDefault().getConverter()));
+			// (MappingCouchbaseConverter) (baseMapping.getDefault().getConverter()));
 			// baseMapping.mapEntity(Person.class, personTemplate); // Person goes in "protected" bucket
 			// MappingCouchbaseConverter cvtr = (MappingCouchbaseConverter)baseMapping.getDefault().getConverter();
 			// CouchbaseTemplate userTemplate = myCouchbaseTemplate(myCouchbaseClientFactory("mybucket"),
-			// 		(MappingCouchbaseConverter) (baseMapping.getDefault().getConverter()));
+			// (MappingCouchbaseConverter) (baseMapping.getDefault().getConverter()));
 			// baseMapping.mapEntity(User.class, userTemplate); // User goes in "mybucket"
 			// everything else goes in getBucketName() ( which is travel-sample )
 		} catch (Exception e) {

--- a/src/test/java/org/springframework/data/couchbase/domain/NaiveAuditorAware.java
+++ b/src/test/java/org/springframework/data/couchbase/domain/NaiveAuditorAware.java
@@ -32,7 +32,7 @@ import org.springframework.data.domain.AuditorAware;
  */
 public class NaiveAuditorAware implements AuditorAware<String> {
 
-	static public final String AUDITOR = "auditor";
+	static public final String AUDITOR = "nonreactive_auditor";
 	private Optional<String> auditor = Optional.of(AUDITOR);
 
 	@Override

--- a/src/test/java/org/springframework/data/couchbase/domain/User.java
+++ b/src/test/java/org/springframework/data/couchbase/domain/User.java
@@ -71,8 +71,16 @@ public class User extends ComparableEntity {
 		return createdDate;
 	}
 
-	public String getCreator() {
+	public void setCreatedDate(long createdDate) {
+		this.createdDate = createdDate;
+	}
+
+	public String getCreatedBy() {
 		return createdBy;
+	}
+
+	public void setCreatedBy(String createdBy) {
+		this.createdBy = createdBy;
 	}
 
 	public long getLastModifiedDate() {

--- a/src/test/java/org/springframework/data/couchbase/repository/CouchbaseRepositoryQueryIntegrationTests.java
+++ b/src/test/java/org/springframework/data/couchbase/repository/CouchbaseRepositoryQueryIntegrationTests.java
@@ -636,7 +636,7 @@ public class CouchbaseRepositoryQueryIntegrationTests extends ClusterAwareIntegr
 
 	@Configuration
 	@EnableCouchbaseRepositories("org.springframework.data.couchbase")
-	@EnableCouchbaseAuditing(auditorAwareRef = "auditorAwareRef", dateTimeProviderRef = "dateTimeProviderRef")
+	@EnableCouchbaseAuditing(dateTimeProviderRef = "dateTimeProviderRef")
 	static class Config extends AbstractCouchbaseConfiguration {
 
 		@Override

--- a/src/test/java/org/springframework/data/couchbase/repository/ReactiveCouchbaseRepositoryKeyValueIntegrationTests.java
+++ b/src/test/java/org/springframework/data/couchbase/repository/ReactiveCouchbaseRepositoryKeyValueIntegrationTests.java
@@ -82,7 +82,7 @@ public class ReactiveCouchbaseRepositoryKeyValueIntegrationTests extends Cluster
 
 	@Configuration
 	@EnableReactiveCouchbaseRepositories("org.springframework.data.couchbase")
-	@EnableReactiveCouchbaseAuditing
+	@EnableReactiveCouchbaseAuditing(dateTimeProviderRef = "dateTimeProviderRef")
 	static class Config extends AbstractCouchbaseConfiguration {
 
 		@Override


### PR DESCRIPTION
Remove unnecessary auditorAwareRef from test config as it causes
confusion. The property does not need to be preset for the auditorAwareRef
bean to be used.
The dateTimeProviderRef must be present for the provided
dateTimeProviderRef bean to be used.
Fixed up the test cases so they no longer work by accident.

Closes #1052.

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATACOUCH).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
