### PR TITLE
Pass source as parent when reading subobject.

### DIFF
--- a/src/main/java/org/springframework/data/couchbase/core/convert/MappingCouchbaseConverter.java
+++ b/src/main/java/org/springframework/data/couchbase/core/convert/MappingCouchbaseConverter.java
@@ -954,7 +954,7 @@ public class MappingCouchbaseConverter extends AbstractCouchbaseConverter implem
 				return null;
 			}
 
-			return readValue(value, property.getTypeInformation(), parent);
+			return readValue(value, property.getTypeInformation(), source);
 		}
 	}
 

--- a/src/test/java/org/springframework/data/couchbase/repository/CouchbaseRepositoryQueryIntegrationTests.java
+++ b/src/test/java/org/springframework/data/couchbase/repository/CouchbaseRepositoryQueryIntegrationTests.java
@@ -40,7 +40,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.stream.Collectors;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
@@ -92,8 +91,6 @@ import com.couchbase.client.java.json.JsonArray;
 import com.couchbase.client.java.kv.GetResult;
 import com.couchbase.client.java.kv.MutationState;
 import com.couchbase.client.java.kv.UpsertOptions;
-import com.couchbase.client.java.manager.query.CreatePrimaryQueryIndexOptions;
-import com.couchbase.client.java.manager.query.CreateQueryIndexOptions;
 import com.couchbase.client.java.query.QueryOptions;
 import com.couchbase.client.java.query.QueryScanConsistency;
 
@@ -120,18 +117,6 @@ public class CouchbaseRepositoryQueryIntegrationTests extends ClusterAwareIntegr
 
 	String scopeName = "_default";
 	String collectionName = "_default";
-
-	@BeforeEach
-	public void beforeEach() {
-		clientFactory.getCluster().queryIndexes().createPrimaryIndex(bucketName(),
-				CreatePrimaryQueryIndexOptions.createPrimaryQueryIndexOptions().ignoreIfExists(true));
-		// this is for the N1qlJoin test
-		List<String> fieldList = new ArrayList<>();
-		fieldList.add("parentId");
-		clientFactory.getCluster().queryIndexes().createIndex(bucketName(), "parent_idx", fieldList,
-				CreateQueryIndexOptions.createQueryIndexOptions().ignoreIfExists(true));
-		// .with("_class", "org.springframework.data.couchbase.domain.Address"));
-	}
 
 	@Test
 	void shouldSaveAndFindAll() {


### PR DESCRIPTION
Also rearranges test initializations so test order doesn't matter.

Closes #1221.

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATACOUCH).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
