### PR TITLE
Fix flaky test in org.springframework.data.couchbase.core.mapping.MappingCouchbaseConverterTests.writesAndReadsCustomConvertedClass

### DIFF
--- a/src/test/java/org/springframework/data/couchbase/core/mapping/MappingCouchbaseConverterTests.java
+++ b/src/test/java/org/springframework/data/couchbase/core/mapping/MappingCouchbaseConverterTests.java
@@ -476,7 +476,12 @@ public class MappingCouchbaseConverterTests {
 
 		assertThat(valueStr).isEqualTo(((CouchbaseList) converted.getContent().get("listOfValues")).get(0));
 		assertThat(value2Str).isEqualTo(((CouchbaseList) converted.getContent().get("listOfValues")).get(1));
-		assertThat(converted.export().toString()).isEqualTo(source.export().toString());
+		assertThat(converted.getContent().get("listOfValues").toString()).isEqualTo(source.getContent().get("listOfValues").toString());
+		CouchbaseDocument sourceVals = (CouchbaseDocument) source.getContent().get("mapOfValues");
+		CouchbaseDocument convertedVals = (CouchbaseDocument) converted.getContent().get("mapOfValues");
+
+		assertThat(sourceVals.getContent().get("val1").toString()).isEqualTo(convertedVals.getContent().get("val1").toString());
+		assertThat(sourceVals.getContent().get("val2").toString()).isEqualTo(convertedVals.getContent().get("val2").toString());
 
 		CustomEntity readConverted = converter.read(CustomEntity.class, source);
 		assertThat(readConverted.value).isEqualTo(value);


### PR DESCRIPTION
`org.springframework.data.couchbase.core.mapping.MappingCouchbaseConverterTests.writesAndReadsCustomConvertedClass` has a flaky test because it directly uses `.toString()` when wanted to compare the actual value in the `HashMap` for `source` and `converted`. Every time you use `.toString()` for `HashMap`, it might construct the string in a different order. I fixed it by get all elements in the `HashMap` and compare them one by one.