### PR TITLE
Reinstate the getDefaultConsistency() method in the Configuration.

### DIFF
--- a/src/main/java/org/springframework/data/couchbase/config/AbstractCouchbaseConfiguration.java
+++ b/src/main/java/org/springframework/data/couchbase/config/AbstractCouchbaseConfiguration.java
@@ -22,6 +22,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
+import com.couchbase.client.java.query.QueryScanConsistency;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.context.annotation.Bean;
@@ -157,7 +158,8 @@ public abstract class AbstractCouchbaseConfiguration {
 	@Bean(name = BeanNames.COUCHBASE_TEMPLATE)
 	public CouchbaseTemplate couchbaseTemplate(CouchbaseClientFactory couchbaseClientFactory,
 			MappingCouchbaseConverter mappingCouchbaseConverter, TranslationService couchbaseTranslationService) {
-		return new CouchbaseTemplate(couchbaseClientFactory, mappingCouchbaseConverter, couchbaseTranslationService);
+		return new CouchbaseTemplate(couchbaseClientFactory, mappingCouchbaseConverter, couchbaseTranslationService,
+				getDefaultConsistency());
 	}
 
 	public CouchbaseTemplate couchbaseTemplate(CouchbaseClientFactory couchbaseClientFactory,
@@ -168,8 +170,8 @@ public abstract class AbstractCouchbaseConfiguration {
 	@Bean(name = BeanNames.REACTIVE_COUCHBASE_TEMPLATE)
 	public ReactiveCouchbaseTemplate reactiveCouchbaseTemplate(CouchbaseClientFactory couchbaseClientFactory,
 			MappingCouchbaseConverter mappingCouchbaseConverter, TranslationService couchbaseTranslationService) {
-		return new ReactiveCouchbaseTemplate(couchbaseClientFactory, mappingCouchbaseConverter,
-				couchbaseTranslationService);
+		return new ReactiveCouchbaseTemplate(couchbaseClientFactory, mappingCouchbaseConverter, couchbaseTranslationService,
+				getDefaultConsistency());
 	}
 
 	public ReactiveCouchbaseTemplate reactiveCouchbaseTemplate(CouchbaseClientFactory couchbaseClientFactory,
@@ -377,6 +379,10 @@ public abstract class AbstractCouchbaseConfiguration {
 		} catch (Throwable t) {
 			return false;
 		}
+	}
+
+	public QueryScanConsistency getDefaultConsistency() {
+		return null;
 	}
 
 }

--- a/src/main/java/org/springframework/data/couchbase/core/CouchbaseOperations.java
+++ b/src/main/java/org/springframework/data/couchbase/core/CouchbaseOperations.java
@@ -19,6 +19,8 @@ package org.springframework.data.couchbase.core;
 import org.springframework.data.couchbase.CouchbaseClientFactory;
 import org.springframework.data.couchbase.core.convert.CouchbaseConverter;
 
+import com.couchbase.client.java.query.QueryScanConsistency;
+
 /**
  * Defines common operations on the Couchbase data source, most commonly implemented by {@link CouchbaseTemplate}.
  */
@@ -44,4 +46,8 @@ public interface CouchbaseOperations extends FluentCouchbaseOperations {
 	 */
 	CouchbaseClientFactory getCouchbaseClientFactory();
 
+	/**
+	 * Returns the default consistency to use for queries
+	 */
+	QueryScanConsistency getConsistency();
 }

--- a/src/main/java/org/springframework/data/couchbase/core/CouchbaseTemplate.java
+++ b/src/main/java/org/springframework/data/couchbase/core/CouchbaseTemplate.java
@@ -28,11 +28,11 @@ import org.springframework.data.couchbase.core.index.CouchbasePersistentEntityIn
 import org.springframework.data.couchbase.core.mapping.CouchbaseMappingContext;
 import org.springframework.data.couchbase.core.mapping.CouchbasePersistentEntity;
 import org.springframework.data.couchbase.core.mapping.CouchbasePersistentProperty;
-import org.springframework.data.couchbase.core.support.PseudoArgs;
 import org.springframework.data.mapping.context.MappingContext;
 import org.springframework.lang.Nullable;
 
 import com.couchbase.client.java.Collection;
+import com.couchbase.client.java.query.QueryScanConsistency;
 
 /**
  * Implements lower-level couchbase operations on top of the SDK with entity mapping capabilities.
@@ -50,6 +50,7 @@ public class CouchbaseTemplate implements CouchbaseOperations, ApplicationContex
 	private final MappingContext<? extends CouchbasePersistentEntity<?>, CouchbasePersistentProperty> mappingContext;
 	private final ReactiveCouchbaseTemplate reactiveCouchbaseTemplate;
 	private @Nullable CouchbasePersistentEntityIndexCreator indexCreator;
+	private QueryScanConsistency scanConsistency;
 
 	public CouchbaseTemplate(final CouchbaseClientFactory clientFactory, final CouchbaseConverter converter) {
 		this(clientFactory, converter, new JacksonTranslationService());
@@ -57,11 +58,17 @@ public class CouchbaseTemplate implements CouchbaseOperations, ApplicationContex
 
 	public CouchbaseTemplate(final CouchbaseClientFactory clientFactory, final CouchbaseConverter converter,
 			final TranslationService translationService) {
+		this(clientFactory, converter, translationService, null);
+	}
+
+	public CouchbaseTemplate(final CouchbaseClientFactory clientFactory, final CouchbaseConverter converter,
+			final TranslationService translationService, QueryScanConsistency scanConsistency) {
 		this.clientFactory = clientFactory;
 		this.converter = converter;
 		this.templateSupport = new CouchbaseTemplateSupport(converter, translationService);
-		this.reactiveCouchbaseTemplate = new ReactiveCouchbaseTemplate(clientFactory, converter, translationService);
-
+		this.reactiveCouchbaseTemplate = new ReactiveCouchbaseTemplate(clientFactory, converter, translationService,
+				scanConsistency);
+		this.scanConsistency = scanConsistency;
 		this.mappingContext = this.converter.getMappingContext();
 		if (mappingContext instanceof CouchbaseMappingContext) {
 			CouchbaseMappingContext cmc = (CouchbaseMappingContext) mappingContext;
@@ -134,6 +141,11 @@ public class CouchbaseTemplate implements CouchbaseOperations, ApplicationContex
 	@Override
 	public CouchbaseClientFactory getCouchbaseClientFactory() {
 		return clientFactory;
+	}
+
+	@Override
+	public QueryScanConsistency getConsistency() {
+		return scanConsistency;
 	}
 
 	/**

--- a/src/main/java/org/springframework/data/couchbase/core/ReactiveCouchbaseOperations.java
+++ b/src/main/java/org/springframework/data/couchbase/core/ReactiveCouchbaseOperations.java
@@ -20,6 +20,8 @@ import org.springframework.data.couchbase.CouchbaseClientFactory;
 import org.springframework.data.couchbase.core.convert.CouchbaseConverter;
 import org.springframework.data.couchbase.core.support.PseudoArgs;
 
+import com.couchbase.client.java.query.QueryScanConsistency;
+
 /**
  * Defines common operations on the Couchbase data source, most commonly implemented by
  * {@link ReactiveCouchbaseTemplate}.
@@ -47,8 +49,12 @@ public interface ReactiveCouchbaseOperations extends ReactiveFluentCouchbaseOper
 	CouchbaseClientFactory getCouchbaseClientFactory();
 
 	/**
-	 * @@return the pseudoArgs from the ThreadLocal field of the CouchbaseOperations
+	 * @return the pseudoArgs from the ThreadLocal field of the CouchbaseOperations
 	 */
 	PseudoArgs<?> getPseudoArgs();
 
+	/**
+	 * @return the default consistency to use for queries
+	 */
+	QueryScanConsistency getConsistency();
 }

--- a/src/main/java/org/springframework/data/couchbase/core/ReactiveCouchbaseTemplate.java
+++ b/src/main/java/org/springframework/data/couchbase/core/ReactiveCouchbaseTemplate.java
@@ -28,6 +28,7 @@ import org.springframework.data.couchbase.core.convert.translation.TranslationSe
 import org.springframework.data.couchbase.core.support.PseudoArgs;
 
 import com.couchbase.client.java.Collection;
+import com.couchbase.client.java.query.QueryScanConsistency;
 
 /**
  * template class for Reactive Couchbase operations
@@ -44,6 +45,7 @@ public class ReactiveCouchbaseTemplate implements ReactiveCouchbaseOperations, A
 	private final PersistenceExceptionTranslator exceptionTranslator;
 	private final ReactiveCouchbaseTemplateSupport templateSupport;
 	private ThreadLocal<PseudoArgs<?>> threadLocalArgs = new ThreadLocal<>();
+	private QueryScanConsistency scanConsistency;
 
 	public ReactiveCouchbaseTemplate(final CouchbaseClientFactory clientFactory, final CouchbaseConverter converter) {
 		this(clientFactory, converter, new JacksonTranslationService());
@@ -51,10 +53,16 @@ public class ReactiveCouchbaseTemplate implements ReactiveCouchbaseOperations, A
 
 	public ReactiveCouchbaseTemplate(final CouchbaseClientFactory clientFactory, final CouchbaseConverter converter,
 			final TranslationService translationService) {
+		this(clientFactory, converter, translationService, null);
+	}
+
+	public ReactiveCouchbaseTemplate(final CouchbaseClientFactory clientFactory, final CouchbaseConverter converter,
+			final TranslationService translationService, QueryScanConsistency scanConsistency) {
 		this.clientFactory = clientFactory;
 		this.converter = converter;
 		this.exceptionTranslator = clientFactory.getExceptionTranslator();
 		this.templateSupport = new ReactiveCouchbaseTemplateSupport(converter, translationService);
+		this.scanConsistency = scanConsistency;
 	}
 
 	@Override
@@ -163,6 +171,14 @@ public class ReactiveCouchbaseTemplate implements ReactiveCouchbaseOperations, A
 	@Override
 	public PseudoArgs<?> getPseudoArgs() {
 		return threadLocalArgs == null ? null : threadLocalArgs.get();
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public QueryScanConsistency getConsistency() {
+		return scanConsistency;
 	}
 
 }

--- a/src/main/java/org/springframework/data/couchbase/core/ReactiveFindByQueryOperationSupport.java
+++ b/src/main/java/org/springframework/data/couchbase/core/ReactiveFindByQueryOperationSupport.java
@@ -201,7 +201,8 @@ public class ReactiveFindByQueryOperationSupport implements ReactiveFindByQueryO
 
 		@Override
 		public QueryOptions buildOptions(QueryOptions options) {
-			QueryOptions opts = query.buildQueryOptions(options, scanConsistency);
+			QueryScanConsistency qsc = scanConsistency != null ? scanConsistency : template.getConsistency();
+			QueryOptions opts = query.buildQueryOptions(options, qsc);
 			return opts;
 		}
 

--- a/src/main/java/org/springframework/data/couchbase/core/ReactiveRemoveByQueryOperationSupport.java
+++ b/src/main/java/org/springframework/data/couchbase/core/ReactiveRemoveByQueryOperationSupport.java
@@ -15,7 +15,6 @@
  */
 package org.springframework.data.couchbase.core;
 
-import org.springframework.util.Assert;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
@@ -26,6 +25,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.data.couchbase.core.query.Query;
 import org.springframework.data.couchbase.core.support.PseudoArgs;
 import org.springframework.data.couchbase.core.support.TemplateUtils;
+import org.springframework.util.Assert;
 
 import com.couchbase.client.java.query.QueryOptions;
 import com.couchbase.client.java.query.QueryScanConsistency;
@@ -45,8 +45,7 @@ public class ReactiveRemoveByQueryOperationSupport implements ReactiveRemoveByQu
 
 	@Override
 	public <T> ReactiveRemoveByQuery<T> removeByQuery(Class<T> domainType) {
-		return new ReactiveRemoveByQuerySupport<>(template, domainType, ALL_QUERY,null, null,
-				null, null);
+		return new ReactiveRemoveByQuerySupport<>(template, domainType, ALL_QUERY, null, null, null, null);
 	}
 
 	static class ReactiveRemoveByQuerySupport<T> implements ReactiveRemoveByQuery<T> {
@@ -94,7 +93,8 @@ public class ReactiveRemoveByQueryOperationSupport implements ReactiveRemoveByQu
 		}
 
 		private QueryOptions buildQueryOptions(QueryOptions options) {
-			return query.buildQueryOptions(options, scanConsistency);
+			QueryScanConsistency qsc = scanConsistency != null ? scanConsistency : template.getConsistency();
+			return query.buildQueryOptions(options, qsc);
 		}
 
 		@Override

--- a/src/test/java/org/springframework/data/couchbase/domain/AirportRepository.java
+++ b/src/test/java/org/springframework/data/couchbase/domain/AirportRepository.java
@@ -43,6 +43,10 @@ import com.couchbase.client.java.query.QueryScanConsistency;
 @Repository
 public interface AirportRepository extends CouchbaseRepository<Airport, String> {
 
+	// NOT_BOUNDED to test ScanConsistency
+	// @ScanConsistency(query = QueryScanConsistency.NOT_BOUNDED)
+	Airport iata(String iata);
+
 	@Override
 	@ScanConsistency(query = QueryScanConsistency.REQUEST_PLUS)
 	List<Airport> findAll();


### PR DESCRIPTION
This is chiefly to allow all queries to have scanConsistency REQUEST_PLUS to accommodate tests which insert and then query.  In a production setting, the default consistency should be left null.

In 4.3, the @ScanConsistency annotation can be applied to entity classes to have the same effect.

Closes #1243.

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATACOUCH).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
