### PR TITLE
fix flaky for writesAndReadsClassContainingCustomConvertedObjects

### DIFF
--- a/src/test/java/org/springframework/data/couchbase/core/mapping/MappingCouchbaseConverterTests.java
+++ b/src/test/java/org/springframework/data/couchbase/core/mapping/MappingCouchbaseConverterTests.java
@@ -575,7 +575,7 @@ public class MappingCouchbaseConverterTests {
 		mapOfObjectsDoc.put("obj1", objectDoc);
 		source.put("mapOfObjects", mapOfObjectsDoc);
 		assertThat(converted.export()).isEqualTo(source.export());
-	
+
 		CustomObjectEntity readConverted = converter.read(CustomObjectEntity.class, source);
 		assertThat(readConverted.object.weight).isEqualTo(addy.weight);
 		assertThat(readConverted.listOfObjects.get(0).weight).isEqualTo(listOfObjects.get(0).weight);

--- a/src/test/java/org/springframework/data/couchbase/core/mapping/MappingCouchbaseConverterTests.java
+++ b/src/test/java/org/springframework/data/couchbase/core/mapping/MappingCouchbaseConverterTests.java
@@ -574,11 +574,11 @@ public class MappingCouchbaseConverterTests {
 		mapOfObjectsDoc.put("obj0", objectDoc);
 		mapOfObjectsDoc.put("obj1", objectDoc);
 		source.put("mapOfObjects", mapOfObjectsDoc);
-                
+           	
 		char[] covertedString = converted.export().toString().toCharArray();
-                char[] sourceString = source.export().toString().toCharArray();
-                Arrays.sort(covertedString);
-                Arrays.sort(sourceString);
+		char[] sourceString = source.export().toString().toCharArray();
+		Arrays.sort(covertedString);
+		Arrays.sort(sourceString);
 		assertThat(String.valueOf(sourceString)).isEqualTo(String.valueOf(covertedString));	
 	
 		CustomObjectEntity readConverted = converter.read(CustomObjectEntity.class, source);

--- a/src/test/java/org/springframework/data/couchbase/core/mapping/MappingCouchbaseConverterTests.java
+++ b/src/test/java/org/springframework/data/couchbase/core/mapping/MappingCouchbaseConverterTests.java
@@ -574,8 +574,13 @@ public class MappingCouchbaseConverterTests {
 		mapOfObjectsDoc.put("obj0", objectDoc);
 		mapOfObjectsDoc.put("obj1", objectDoc);
 		source.put("mapOfObjects", mapOfObjectsDoc);
-		assertThat(converted.export().toString()).isEqualTo(source.export().toString());
-
+                
+		char[] covertedString = converted.export().toString().toCharArray();
+                char[] sourceString = source.export().toString().toCharArray();
+                Arrays.sort(covertedString);
+                Arrays.sort(sourceString);
+		assertThat(String.valueOf(sourceString)).isEqualTo(String.valueOf(covertedString));	
+	
 		CustomObjectEntity readConverted = converter.read(CustomObjectEntity.class, source);
 		assertThat(readConverted.object.weight).isEqualTo(addy.weight);
 		assertThat(readConverted.listOfObjects.get(0).weight).isEqualTo(listOfObjects.get(0).weight);

--- a/src/test/java/org/springframework/data/couchbase/core/mapping/MappingCouchbaseConverterTests.java
+++ b/src/test/java/org/springframework/data/couchbase/core/mapping/MappingCouchbaseConverterTests.java
@@ -574,12 +574,7 @@ public class MappingCouchbaseConverterTests {
 		mapOfObjectsDoc.put("obj0", objectDoc);
 		mapOfObjectsDoc.put("obj1", objectDoc);
 		source.put("mapOfObjects", mapOfObjectsDoc);
-           	
-		char[] covertedString = converted.export().toString().toCharArray();
-		char[] sourceString = source.export().toString().toCharArray();
-		Arrays.sort(covertedString);
-		Arrays.sort(sourceString);
-		assertThat(String.valueOf(sourceString)).isEqualTo(String.valueOf(covertedString));	
+		assertThat(converted.export()).isEqualTo(source.export());
 	
 		CustomObjectEntity readConverted = converter.read(CustomObjectEntity.class, source);
 		assertThat(readConverted.object.weight).isEqualTo(addy.weight);


### PR DESCRIPTION
`org.springframework.data.couchbase.core.mapping.MappingCouchbaseConverterTests.writesAndReadsClassContainingCustomConvertedObjects` is a flaky test because it directly use `toString()` to convert the content of the HashMap into String, which is non-deterministic for the order of the key-value pair. I fixed it by instead, compare the HashMap directly by assert. 