### PR TITLE
Field named id treated as document id.

### DIFF
--- a/src/main/java/org/springframework/data/couchbase/repository/query/StringBasedN1qlQueryParser.java
+++ b/src/main/java/org/springframework/data/couchbase/repository/query/StringBasedN1qlQueryParser.java
@@ -29,7 +29,6 @@ import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import com.couchbase.client.core.error.CouchbaseException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.data.couchbase.core.convert.CouchbaseConverter;
@@ -51,6 +50,7 @@ import org.springframework.expression.common.TemplateParserContext;
 import org.springframework.expression.spel.standard.SpelExpressionParser;
 import org.springframework.util.Assert;
 
+import com.couchbase.client.core.error.CouchbaseException;
 import com.couchbase.client.core.error.InvalidArgumentException;
 import com.couchbase.client.java.json.JsonArray;
 import com.couchbase.client.java.json.JsonObject;
@@ -213,10 +213,10 @@ public class StringBasedN1qlQueryParser {
 			persistentEntity.doWithProperties(new PropertyHandler<CouchbasePersistentProperty>() {
 				@Override
 				public void doWithPersistentProperty(final CouchbasePersistentProperty prop) {
-					if (prop.isIdProperty() && parent == null) {
+					if (prop == persistentEntity.getIdProperty() && parent == null) {
 						return;
 					}
-					if (prop.isVersionProperty()) {
+					if (prop == persistentEntity.getVersionProperty() && parent == null) {
 						return;
 					}
 					String projectField = null;
@@ -224,7 +224,7 @@ public class StringBasedN1qlQueryParser {
 					if (fieldList == null || fieldList.contains(prop.getFieldName())) {
 						PersistentPropertyPath<CouchbasePersistentProperty> path = couchbaseConverter.getMappingContext()
 								.getPersistentPropertyPath(prop.getName(), resultClass.getType());
-						projectField = N1qlQueryCreator.addMetaIfRequired(bucketName, path, prop).toString();
+						projectField = N1qlQueryCreator.addMetaIfRequired(bucketName, path, prop, persistentEntity).toString();
 						if (sb.length() > 0) {
 							sb.append(", ");
 						}
@@ -250,7 +250,7 @@ public class StringBasedN1qlQueryParser {
 			// needs further discussion as removing a field from an entity could cause this and not necessarily be an error
 			if (fieldList != null && !fieldList.isEmpty()) {
 				throw new CouchbaseException(
-				 "projected fields (" + fieldList + ") not found in entity: " + persistentEntity.getName());
+						"projected fields (" + fieldList + ") not found in entity: " + persistentEntity.getName());
 			}
 		} else {
 			for (String field : fields) {

--- a/src/test/java/org/springframework/data/couchbase/core/CouchbaseTemplateQueryIntegrationTests.java
+++ b/src/test/java/org/springframework/data/couchbase/core/CouchbaseTemplateQueryIntegrationTests.java
@@ -35,6 +35,7 @@ import org.springframework.data.couchbase.core.query.Query;
 import org.springframework.data.couchbase.core.query.QueryCriteria;
 import org.springframework.data.couchbase.domain.Address;
 import org.springframework.data.couchbase.domain.Airport;
+import org.springframework.data.couchbase.domain.AssessmentDO;
 import org.springframework.data.couchbase.domain.Course;
 import org.springframework.data.couchbase.domain.NaiveAuditorAware;
 import org.springframework.data.couchbase.domain.Submission;
@@ -130,6 +131,21 @@ class CouchbaseTemplateQueryIntegrationTests extends JavaIntegrationTests {
 				.withConsistency(QueryScanConsistency.REQUEST_PLUS).matching(specialUsers).all();
 
 		assertEquals(1, foundUsers.size());
+	}
+
+	@Test
+	void findAssessmentDO() {
+		AssessmentDO ado = new AssessmentDO();
+		ado.setEventTimestamp(44444444);// this is also an @IdAttribute
+		ado.setId("123");
+		ado = couchbaseTemplate.upsertById(AssessmentDO.class).one(ado);
+
+		Query specialUsers = new Query(QueryCriteria.where(i("id")).is(ado.getId()));
+		final List<AssessmentDO> foundUsers = couchbaseTemplate.findByQuery(AssessmentDO.class)
+				.withConsistency(QueryScanConsistency.REQUEST_PLUS).matching(specialUsers).all();
+		assertEquals("123", foundUsers.get(0).getId(), "id");
+		assertEquals("44444444", foundUsers.get(0).getDocumentId(), "documentId");
+		assertEquals(ado, foundUsers.get(0));
 	}
 
 	@Test

--- a/src/test/java/org/springframework/data/couchbase/domain/AssessmentDO.java
+++ b/src/test/java/org/springframework/data/couchbase/domain/AssessmentDO.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2012-2021 the original author or authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.data.couchbase.domain;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.couchbase.core.mapping.Document;
+import org.springframework.data.couchbase.core.mapping.Field;
+import org.springframework.data.couchbase.core.mapping.id.GeneratedValue;
+import org.springframework.data.couchbase.core.mapping.id.GenerationStrategy;
+import org.springframework.data.couchbase.core.mapping.id.IdAttribute;
+
+/**
+ * @author Michael Reiche
+ */
+@Document()
+@Data
+@NoArgsConstructor
+public class AssessmentDO {
+	@Id @GeneratedValue(strategy = GenerationStrategy.USE_ATTRIBUTES) private String documentId;
+
+	@Field @IdAttribute private long eventTimestamp;
+
+	@Field("docType") private String documentType;
+
+	@Field private String id;
+}

--- a/src/test/java/org/springframework/data/couchbase/repository/query/N1qlQueryCreatorTests.java
+++ b/src/test/java/org/springframework/data/couchbase/repository/query/N1qlQueryCreatorTests.java
@@ -37,10 +37,13 @@ import org.springframework.data.couchbase.domain.PersonRepository;
 import org.springframework.data.couchbase.domain.User;
 import org.springframework.data.couchbase.domain.UserRepository;
 import org.springframework.data.mapping.context.MappingContext;
+import org.springframework.data.projection.SpelAwareProxyProjectionFactory;
+import org.springframework.data.repository.core.support.DefaultRepositoryMetadata;
 import org.springframework.data.repository.query.DefaultParameters;
 import org.springframework.data.repository.query.ParameterAccessor;
 import org.springframework.data.repository.query.Parameters;
 import org.springframework.data.repository.query.ParametersParameterAccessor;
+import org.springframework.data.repository.query.QueryMethod;
 import org.springframework.data.repository.query.parser.PartTree;
 
 import com.couchbase.client.java.json.JsonArray;
@@ -69,9 +72,10 @@ class N1qlQueryCreatorTests {
 		String input = "findByFirstname";
 		PartTree tree = new PartTree(input, User.class);
 		Method method = UserRepository.class.getMethod(input, String.class);
-
-		N1qlQueryCreator creator = new N1qlQueryCreator(tree, getAccessor(getParameters(method), "Oliver"), null, converter,
-				bucketName);
+		QueryMethod queryMethod = new QueryMethod(method, new DefaultRepositoryMetadata(UserRepository.class),
+				new SpelAwareProxyProjectionFactory());
+		N1qlQueryCreator creator = new N1qlQueryCreator(tree, getAccessor(getParameters(method), "Oliver"), queryMethod,
+				converter, bucketName);
 		Query query = creator.createQuery();
 
 		assertEquals(query.export(), " WHERE " + where(i("firstname")).is("Oliver").export());
@@ -82,9 +86,10 @@ class N1qlQueryCreatorTests {
 		String input = "findByMiddlename";
 		PartTree tree = new PartTree(input, Person.class);
 		Method method = PersonRepository.class.getMethod(input, String.class);
-
-		N1qlQueryCreator creator = new N1qlQueryCreator(tree, getAccessor(getParameters(method), "Oliver"), null, converter,
-				bucketName);
+		QueryMethod queryMethod = new QueryMethod(method, new DefaultRepositoryMetadata(UserRepository.class),
+				new SpelAwareProxyProjectionFactory());
+		N1qlQueryCreator creator = new N1qlQueryCreator(tree, getAccessor(getParameters(method), "Oliver"), queryMethod,
+				converter, bucketName);
 		Query query = creator.createQuery();
 
 		assertEquals(query.export(), " WHERE " + where(i("nickname")).is("Oliver").export());
@@ -95,10 +100,12 @@ class N1qlQueryCreatorTests {
 		String input = "findByFirstnameIn";
 		PartTree tree = new PartTree(input, User.class);
 		Method method = UserRepository.class.getMethod(input, String[].class);
+		QueryMethod queryMethod = new QueryMethod(method, new DefaultRepositoryMetadata(UserRepository.class),
+				new SpelAwareProxyProjectionFactory());
 		Query expected = (new Query()).addCriteria(where(i("firstname")).in("Oliver", "Charles"));
 		N1qlQueryCreator creator = new N1qlQueryCreator(tree,
-				getAccessor(getParameters(method), new Object[] { new Object[] { "Oliver", "Charles" } }), null, converter,
-				bucketName);
+				getAccessor(getParameters(method), new Object[] { new Object[] { "Oliver", "Charles" } }), queryMethod,
+				converter, bucketName);
 		Query query = creator.createQuery();
 
 		// Query expected = (new Query()).addCriteria(where("firstname").in("Oliver", "Charles"));
@@ -115,11 +122,12 @@ class N1qlQueryCreatorTests {
 		String input = "findByFirstnameIn";
 		PartTree tree = new PartTree(input, User.class);
 		Method method = UserRepository.class.getMethod(input, JsonArray.class);
-
+		QueryMethod queryMethod = new QueryMethod(method, new DefaultRepositoryMetadata(UserRepository.class),
+				new SpelAwareProxyProjectionFactory());
 		JsonArray jsonArray = JsonArray.create();
 		jsonArray.add("Oliver");
 		jsonArray.add("Charles");
-		N1qlQueryCreator creator = new N1qlQueryCreator(tree, getAccessor(getParameters(method), jsonArray), null,
+		N1qlQueryCreator creator = new N1qlQueryCreator(tree, getAccessor(getParameters(method), jsonArray), queryMethod,
 				converter, bucketName);
 		Query query = creator.createQuery();
 
@@ -137,11 +145,13 @@ class N1qlQueryCreatorTests {
 		String input = "findByFirstnameIn";
 		PartTree tree = new PartTree(input, User.class);
 		Method method = UserRepository.class.getMethod(input, String[].class);
+		QueryMethod queryMethod = new QueryMethod(method, new DefaultRepositoryMetadata(UserRepository.class),
+				new SpelAwareProxyProjectionFactory());
 		List<String> list = new LinkedList<>();
 		list.add("Oliver");
 		list.add("Charles");
 		N1qlQueryCreator creator = new N1qlQueryCreator(tree, getAccessor(getParameters(method), new Object[] { list }),
-				null, converter, bucketName);
+				queryMethod, converter, bucketName);
 		Query query = creator.createQuery();
 
 		Query expected = (new Query()).addCriteria(where(i("firstname")).in("Oliver", "Charles"));
@@ -159,8 +169,10 @@ class N1qlQueryCreatorTests {
 		String input = "findByFirstnameAndLastname";
 		PartTree tree = new PartTree(input, User.class);
 		Method method = UserRepository.class.getMethod(input, String.class, String.class);
-		N1qlQueryCreator creator = new N1qlQueryCreator(tree, getAccessor(getParameters(method), "John", "Doe"), null,
-				converter, bucketName);
+		QueryMethod queryMethod = new QueryMethod(method, new DefaultRepositoryMetadata(UserRepository.class),
+				new SpelAwareProxyProjectionFactory());
+		N1qlQueryCreator creator = new N1qlQueryCreator(tree, getAccessor(getParameters(method), "John", "Doe"),
+				queryMethod, converter, bucketName);
 		Query query = creator.createQuery();
 
 		assertEquals(" WHERE " + where(i("firstname")).is("John").and(i("lastname")).is("Doe").export(), query.export());
@@ -171,9 +183,10 @@ class N1qlQueryCreatorTests {
 		String input = "findByIdIsNotNullAndFirstnameEquals";
 		PartTree tree = new PartTree(input, User.class);
 		Method method = UserRepository.class.getMethod(input, String.class);
-
-		N1qlQueryCreator creator = new N1qlQueryCreator(tree, getAccessor(getParameters(method), "Oliver"), null, converter,
-				bucketName);
+		QueryMethod queryMethod = new QueryMethod(method, new DefaultRepositoryMetadata(UserRepository.class),
+				new SpelAwareProxyProjectionFactory());
+		N1qlQueryCreator creator = new N1qlQueryCreator(tree, getAccessor(getParameters(method), "Oliver"), queryMethod,
+				converter, bucketName);
 		Query query = creator.createQuery();
 
 		assertEquals(query.export(),
@@ -185,9 +198,10 @@ class N1qlQueryCreatorTests {
 		String input = "findByVersionEqualsAndFirstnameEquals";
 		PartTree tree = new PartTree(input, User.class);
 		Method method = UserRepository.class.getMethod(input, Long.class, String.class);
-
+		QueryMethod queryMethod = new QueryMethod(method, new DefaultRepositoryMetadata(UserRepository.class),
+				new SpelAwareProxyProjectionFactory());
 		N1qlQueryCreator creator = new N1qlQueryCreator(tree,
-				getAccessor(getParameters(method), 1611287177404088320L, "Oliver"), null, converter, bucketName);
+				getAccessor(getParameters(method), 1611287177404088320L, "Oliver"), queryMethod, converter, bucketName);
 		Query query = creator.createQuery();
 
 		assertEquals(query.export(), " WHERE " + where(x("META(`" + bucketName + "`).`cas`")).is(1611287177404088320L)


### PR DESCRIPTION
Should use entity.getIdProperty() to identify the id property.  property.isIdProperty() only identifies if a property could be an IdProperty (by having an annotation or being named id).  It doesn't indicate if the property actually is the id property - only entity.getIdProperty() does that.

Closes #1258.

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATACOUCH).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
