### PR TITLE
Fix flaky test method writesAndReadsCustomFieldsConvertedClass.

### DIFF
--- a/src/main/java/org/springframework/data/couchbase/core/mapping/CouchbaseDocument.java
+++ b/src/main/java/org/springframework/data/couchbase/core/mapping/CouchbaseDocument.java
@@ -18,14 +18,14 @@ package org.springframework.data.couchbase.core.mapping;
 
 import com.couchbase.client.java.json.JsonObject;
 
-import java.util.HashMap;
+import java.util.TreeMap;
 import java.util.Map;
 
 /**
  * A {@link CouchbaseDocument} is an abstract representation of a document stored inside Couchbase Server.
  * <p/>
  * <p>
- * It acts like a {@link HashMap}, but only allows those types to be written that are supported by the underlying
+ * It acts like a {@link TreeMap}, but only allows those types to be written that are supported by the underlying
  * storage format, which is currently JSON. Note that JSON conversion is not happening here, but performed at a
  * different stage based on the payload stored in the {@link CouchbaseDocument}.
  * </p>
@@ -85,7 +85,7 @@ public class CouchbaseDocument implements CouchbaseStorable {
 	public CouchbaseDocument(final String id, final int expiration) {
 		this.id = id;
 		this.expiration = expiration;
-		content = new HashMap<>();
+		content = new TreeMap<>();
 	}
 
 	/**
@@ -119,8 +119,8 @@ public class CouchbaseDocument implements CouchbaseStorable {
 	 *
 	 * @return
 	 */
-	public final HashMap<String, Object> export() {
-		HashMap<String, Object> toExport = new HashMap<String, Object>(content);
+	public final TreeMap<String, Object> export() {
+		TreeMap<String, Object> toExport = new TreeMap<String, Object>(content);
 		for (Map.Entry<String, Object> entry : content.entrySet()) {
 			if (entry.getValue() instanceof CouchbaseDocument) {
 				toExport.put(entry.getKey(), ((CouchbaseDocument) entry.getValue()).export());

--- a/src/test/java/org/springframework/data/couchbase/core/mapping/MappingCouchbaseConverterTests.java
+++ b/src/test/java/org/springframework/data/couchbase/core/mapping/MappingCouchbaseConverterTests.java
@@ -455,7 +455,7 @@ public class MappingCouchbaseConverterTests {
 		List<BigDecimal> listOfValues = new ArrayList<>();
 		listOfValues.add(value);
 		listOfValues.add(value2);
-		Map<String, BigDecimal> mapOfValues = new HashMap<>();
+		Map<String, BigDecimal> mapOfValues = new TreeMap<>();
 		mapOfValues.put("val1", value);
 		mapOfValues.put("val2", value2);
 


### PR DESCRIPTION
Fix flaky test method writesAndReadsCustomFieldsConvertedClass due to non-deterministic iteration order of HashMap.

In this test method, two CouchbaseDocument instances, converted and source, are converted to strings and asserted to be equal. However, the test may fail because the iteration order of HashMap is non-deterministic. As a result, in the string, the order of fields can be different. To fix this, HashMap is replaced with TreeMap in both the test code and the implementation code so that the order is deterministic.