### PR TITLE
Fix for 5_0_x branch.

### DIFF
--- a/src/main/java/org/springframework/data/couchbase/core/mapping/event/ValidatingCouchbaseEventListener.java
+++ b/src/main/java/org/springframework/data/couchbase/core/mapping/event/ValidatingCouchbaseEventListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2020 the original author or authors
+ * Copyright 2012-2021 the original author or authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,10 +16,11 @@
 
 package org.springframework.data.couchbase.core.mapping.event;
 
+import jakarta.validation.ConstraintViolationException;
+import jakarta.validation.Validator;
+
 import java.util.Set;
 
-
-import jakarta.validation.ConstraintViolationException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.data.couchbase.core.mapping.CouchbaseDocument;
@@ -33,19 +34,20 @@ import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean;
  * @author Maciej Walkowiak
  * @author Michael Nitschinger
  * @author Mark Paluch
+ * @author Michael Reiche
  */
 public class ValidatingCouchbaseEventListener extends AbstractCouchbaseEventListener<Object> {
 
 	private static final Logger LOG = LoggerFactory.getLogger(ValidatingCouchbaseEventListener.class);
 
-	private final LocalValidatorFactoryBean validator;
+	private final Validator validator;
 
 	/**
 	 * Creates a new {@link ValidatingCouchbaseEventListener} using the given {@link Validator}.
 	 *
 	 * @param validator must not be {@literal null}.
 	 */
-	public ValidatingCouchbaseEventListener(LocalValidatorFactoryBean validator) {
+	public ValidatingCouchbaseEventListener(Validator validator) {
 		Assert.notNull(validator, "Validator must not be null!");
 		this.validator = validator;
 	}


### PR DESCRIPTION
Closes #1280.

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATACOUCH).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
