### PR TITLE
Fix remaining javadoc in 5.0.x

### DIFF
--- a/src/main/java/org/springframework/data/couchbase/core/mapping/CouchbaseDocument.java
+++ b/src/main/java/org/springframework/data/couchbase/core/mapping/CouchbaseDocument.java
@@ -215,7 +215,7 @@ public class CouchbaseDocument implements CouchbaseStorable {
 
 	/**
 	 * Returns the expiration time of the document.
-	 * <p/>
+	 * <p>
 	 * If the expiration time is 0, then the document will be persisted until deleted manually ("forever").
 	 *
 	 * @return the expiration time of the document.
@@ -226,9 +226,9 @@ public class CouchbaseDocument implements CouchbaseStorable {
 
 	/**
 	 * Set the expiration time of the document.
-	 * <p/>
+	 * <p>
 	 * If the expiration time is 0, then the document will be persisted until deleted manually ("forever").
-	 * <p/>
+	 * <p>
 	 * Expiration should be expressed as seconds if <= 30 days (30 x 24 x 60 x 60 seconds), or as an expiry date (UTC,
 	 * UNIX time ie. seconds form the Epoch) if > 30 days.
 	 *


### PR DESCRIPTION
Closes #1291.

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATACOUCH).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
