### PR TITLE
Javadoc and other java 1_8 compatible changes in 50x back to main.

### DIFF
--- a/src/main/java/org/springframework/data/couchbase/core/CouchbaseTemplateSupport.java
+++ b/src/main/java/org/springframework/data/couchbase/core/CouchbaseTemplateSupport.java
@@ -190,7 +190,7 @@ class CouchbaseTemplateSupport implements ApplicationContextAware, TemplateSuppo
 	/**
 	 * Set the {@link EntityCallbacks} instance to use when invoking
 	 * {@link org.springframework.data.mapping.callback.EntityCallback callbacks} like the {@link BeforeConvertCallback}.
-	 * <p/>
+	 * <p>
 	 * Overrides potentially existing {@link EntityCallbacks}.
 	 *
 	 * @param entityCallbacks must not be {@literal null}.

--- a/src/main/java/org/springframework/data/couchbase/core/ReactiveCouchbaseTemplateSupport.java
+++ b/src/main/java/org/springframework/data/couchbase/core/ReactiveCouchbaseTemplateSupport.java
@@ -200,7 +200,7 @@ class ReactiveCouchbaseTemplateSupport implements ApplicationContextAware, React
 	 * Set the {@link ReactiveEntityCallbacks} instance to use when invoking
 	 * {@link org.springframework.data.mapping.callback.ReactiveEntityCallbacks callbacks} like the
 	 * {@link ReactiveBeforeConvertCallback}.
-	 * <p/>
+	 * <p>
 	 * Overrides potentially existing {@link EntityCallbacks}.
 	 *
 	 * @param reactiveEntityCallbacks must not be {@literal null}.

--- a/src/main/java/org/springframework/data/couchbase/core/mapping/CouchbaseDocument.java
+++ b/src/main/java/org/springframework/data/couchbase/core/mapping/CouchbaseDocument.java
@@ -215,7 +215,7 @@ public class CouchbaseDocument implements CouchbaseStorable {
 
 	/**
 	 * Returns the expiration time of the document.
-	 * <p/>
+	 * <p>
 	 * If the expiration time is 0, then the document will be persisted until deleted manually ("forever").
 	 *
 	 * @return the expiration time of the document.
@@ -226,9 +226,9 @@ public class CouchbaseDocument implements CouchbaseStorable {
 
 	/**
 	 * Set the expiration time of the document.
-	 * <p/>
+	 * <p>
 	 * If the expiration time is 0, then the document will be persisted until deleted manually ("forever").
-	 * <p/>
+	 * <p>
 	 * Expiration should be expressed as seconds if <= 30 days (30 x 24 x 60 x 60 seconds), or as an expiry date (UTC,
 	 * UNIX time ie. seconds form the Epoch) if > 30 days.
 	 *

--- a/src/main/java/org/springframework/data/couchbase/core/mapping/CouchbaseList.java
+++ b/src/main/java/org/springframework/data/couchbase/core/mapping/CouchbaseList.java
@@ -186,10 +186,8 @@ public class CouchbaseList implements CouchbaseStorable {
 
 	/**
 	 * Verifies that only values of a certain and supported type can be stored.
-	 * <p/>
 	 * <p>
 	 * If this is not the case, a {@link IllegalArgumentException} is thrown.
-	 * </p>
 	 *
 	 * @param value the object to verify its type.
 	 */

--- a/src/main/java/org/springframework/data/couchbase/repository/auditing/CouchbaseAuditingRegistrar.java
+++ b/src/main/java/org/springframework/data/couchbase/repository/auditing/CouchbaseAuditingRegistrar.java
@@ -19,6 +19,7 @@ package org.springframework.data.couchbase.repository.auditing;
 import java.lang.annotation.Annotation;
 
 import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.beans.factory.support.AbstractBeanDefinition;
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.beans.factory.support.BeanDefinitionRegistry;
 import org.springframework.beans.factory.support.RootBeanDefinition;
@@ -70,7 +71,11 @@ public class CouchbaseAuditingRegistrar extends AuditingBeanDefinitionRegistrarS
 		Assert.notNull(configuration, "AuditingConfiguration must not be null!");
 
 		BeanDefinitionBuilder builder = BeanDefinitionBuilder.rootBeanDefinition(IsNewAwareAuditingHandler.class);
-		builder.addConstructorArgReference(BeanNames.COUCHBASE_MAPPING_CONTEXT);
+
+		BeanDefinitionBuilder definition = BeanDefinitionBuilder.genericBeanDefinition(PersistentEntitiesFactoryBean.class);
+		definition.setAutowireMode(AbstractBeanDefinition.AUTOWIRE_CONSTRUCTOR);
+
+		builder.addConstructorArgValue(definition.getBeanDefinition());
 		return configureDefaultAuditHandlerAttributes(configuration, builder);
 	}
 

--- a/src/main/java/org/springframework/data/couchbase/repository/query/support/N1qlUtils.java
+++ b/src/main/java/org/springframework/data/couchbase/repository/query/support/N1qlUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2020 the original author or authors
+ * Copyright 2012-2022 the original author or authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@ import org.springframework.core.convert.converter.Converter;
 import org.springframework.data.couchbase.core.convert.CouchbaseConverter;
 import org.springframework.data.couchbase.core.mapping.CouchbasePersistentEntity;
 import org.springframework.data.couchbase.core.mapping.CouchbasePersistentProperty;
+import org.springframework.data.couchbase.core.mapping.Field;
 import org.springframework.data.couchbase.core.query.N1QLExpression;
 import org.springframework.data.couchbase.core.query.N1QLQuery;
 import org.springframework.data.couchbase.repository.query.CouchbaseEntityInformation;

--- a/src/main/java/org/springframework/data/couchbase/repository/support/ViewPostProcessor.java
+++ b/src/main/java/org/springframework/data/couchbase/repository/support/ViewPostProcessor.java
@@ -62,7 +62,7 @@ public enum ViewPostProcessor implements RepositoryProxyPostProcessor {
 
 	/**
 	 * {@link MethodInterceptor} to inspect the currently invoked {@link Method} for a {@link View} annotation.
-	 * <p/>
+	 * <p>
 	 * If a View annotation is found, it will bind it to a locally held ThreadLocal for later lookup in the
 	 * SimpleCouchbaseRepository class.
 	 *

--- a/src/test/java/org/springframework/data/couchbase/util/ClusterInvocationProvider.java
+++ b/src/test/java/org/springframework/data/couchbase/util/ClusterInvocationProvider.java
@@ -31,7 +31,6 @@ import org.junit.platform.commons.support.AnnotationSupport;
  * <p>
  * Note that the internals on what and how the containers are managed is up to the {@link TestCluster} implementation,
  * and if it is unmanaged than this very well be mostly a "stub".
- * </p>
  *
  * @since 2.0.0
  */

--- a/src/test/java/org/springframework/data/couchbase/util/TestClusterConfig.java
+++ b/src/test/java/org/springframework/data/couchbase/util/TestClusterConfig.java
@@ -79,7 +79,6 @@ public class TestClusterConfig {
 	 * Finds the first node with a given service enabled in the config.
 	 * <p>
 	 * This method can be used to find bootstrap nodes and similar.
-	 * </p>
 	 *
 	 * @param service the service to find.
 	 * @return a node config if found, empty otherwise.

--- a/src/test/java/org/springframework/data/couchbase/util/Util.java
+++ b/src/test/java/org/springframework/data/couchbase/util/Util.java
@@ -33,7 +33,7 @@ public class Util {
    * Waits and sleeps for a little bit of time until the given condition is met.
    *
    * <p>Sleeps 1ms between "false" invocations. It will wait at most one minute to prevent hanging forever in case
-   * the condition never becomes true.</p>
+   * the condition never becomes true.
    *
    * @param supplier return true once it should stop waiting.
    */
@@ -83,7 +83,7 @@ public class Util {
    * Reads a file from the resources folder (in the same path as the requesting test class).
    *
    * <p>The class will be automatically loaded relative to the namespace and converted
-   * to a string.</p>
+   * to a string.
    *
    * @param filename the filename of the resource.
    * @param clazz    the reference class.


### PR DESCRIPTION
Closes #1327.

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATACOUCH).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
