### PR TITLE
Make withDurability() return WithScope type for all operations.

### DIFF
--- a/src/main/java/org/springframework/data/couchbase/core/ExecutableInsertByIdOperation.java
+++ b/src/main/java/org/springframework/data/couchbase/core/ExecutableInsertByIdOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2021 the original author or authors
+ * Copyright 2012-2022 the original author or authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -117,10 +117,10 @@ public interface ExecutableInsertByIdOperation {
 	interface InsertByIdWithDurability<T> extends InsertByIdInScope<T>, WithDurability<T> {
 
 		@Override
-		InsertByIdInCollection<T> withDurability(DurabilityLevel durabilityLevel);
+		InsertByIdInScope<T> withDurability(DurabilityLevel durabilityLevel);
 
 		@Override
-		InsertByIdInCollection<T> withDurability(PersistTo persistTo, ReplicateTo replicateTo);
+		InsertByIdInScope<T> withDurability(PersistTo persistTo, ReplicateTo replicateTo);
 
 	}
 

--- a/src/main/java/org/springframework/data/couchbase/core/ExecutableInsertByIdOperationSupport.java
+++ b/src/main/java/org/springframework/data/couchbase/core/ExecutableInsertByIdOperationSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2021 the original author or authors
+ * Copyright 2012-2022 the original author or authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -100,14 +100,14 @@ public class ExecutableInsertByIdOperationSupport implements ExecutableInsertByI
 		}
 
 		@Override
-		public InsertByIdInCollection<T> withDurability(final DurabilityLevel durabilityLevel) {
+		public InsertByIdInScope<T> withDurability(final DurabilityLevel durabilityLevel) {
 			Assert.notNull(durabilityLevel, "Durability Level must not be null.");
 			return new ExecutableInsertByIdSupport<>(template, domainType, scope, collection, options, persistTo, replicateTo,
 					durabilityLevel, expiry);
 		}
 
 		@Override
-		public InsertByIdInCollection<T> withDurability(final PersistTo persistTo, final ReplicateTo replicateTo) {
+		public InsertByIdInScope<T> withDurability(final PersistTo persistTo, final ReplicateTo replicateTo) {
 			Assert.notNull(persistTo, "PersistTo must not be null.");
 			Assert.notNull(replicateTo, "ReplicateTo must not be null.");
 			return new ExecutableInsertByIdSupport<>(template, domainType, scope, collection, options, persistTo, replicateTo,

--- a/src/main/java/org/springframework/data/couchbase/core/ExecutableRemoveByIdOperation.java
+++ b/src/main/java/org/springframework/data/couchbase/core/ExecutableRemoveByIdOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2021 the original author or authors
+ * Copyright 2012-2022 the original author or authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -114,10 +114,10 @@ public interface ExecutableRemoveByIdOperation {
 	interface RemoveByIdWithDurability extends RemoveByIdInScope, WithDurability<RemoveResult> {
 
 		@Override
-		RemoveByIdInCollection withDurability(DurabilityLevel durabilityLevel);
+		RemoveByIdInScope withDurability(DurabilityLevel durabilityLevel);
 
 		@Override
-		RemoveByIdInCollection withDurability(PersistTo persistTo, ReplicateTo replicateTo);
+		RemoveByIdInScope withDurability(PersistTo persistTo, ReplicateTo replicateTo);
 
 	}
 

--- a/src/main/java/org/springframework/data/couchbase/core/ExecutableRemoveByIdOperationSupport.java
+++ b/src/main/java/org/springframework/data/couchbase/core/ExecutableRemoveByIdOperationSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2021 the original author or authors
+ * Copyright 2012-2022 the original author or authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -92,14 +92,14 @@ public class ExecutableRemoveByIdOperationSupport implements ExecutableRemoveByI
 		}
 
 		@Override
-		public RemoveByIdInCollection withDurability(final DurabilityLevel durabilityLevel) {
+		public RemoveByIdInScope withDurability(final DurabilityLevel durabilityLevel) {
 			Assert.notNull(durabilityLevel, "Durability Level must not be null.");
 			return new ExecutableRemoveByIdSupport(template, domainType, scope, collection, options, persistTo, replicateTo,
 					durabilityLevel, cas);
 		}
 
 		@Override
-		public RemoveByIdInCollection withDurability(final PersistTo persistTo, final ReplicateTo replicateTo) {
+		public RemoveByIdInScope withDurability(final PersistTo persistTo, final ReplicateTo replicateTo) {
 			Assert.notNull(persistTo, "PersistTo must not be null.");
 			Assert.notNull(replicateTo, "ReplicateTo must not be null.");
 			return new ExecutableRemoveByIdSupport(template, domainType, scope, collection, options, persistTo, replicateTo,

--- a/src/main/java/org/springframework/data/couchbase/core/ReactiveInsertByIdOperation.java
+++ b/src/main/java/org/springframework/data/couchbase/core/ReactiveInsertByIdOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2021 the original author or authors
+ * Copyright 2012-2022 the original author or authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -113,10 +113,10 @@ public interface ReactiveInsertByIdOperation {
 	interface InsertByIdWithDurability<T> extends InsertByIdInScope<T>, WithDurability<T> {
 
 		@Override
-		InsertByIdInCollection<T> withDurability(DurabilityLevel durabilityLevel);
+		InsertByIdInScope<T> withDurability(DurabilityLevel durabilityLevel);
 
 		@Override
-		InsertByIdInCollection<T> withDurability(PersistTo persistTo, ReplicateTo replicateTo);
+		InsertByIdInScope<T> withDurability(PersistTo persistTo, ReplicateTo replicateTo);
 
 	}
 

--- a/src/main/java/org/springframework/data/couchbase/core/ReactiveInsertByIdOperationSupport.java
+++ b/src/main/java/org/springframework/data/couchbase/core/ReactiveInsertByIdOperationSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2021 the original author or authors
+ * Copyright 2012-2022 the original author or authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -125,14 +125,14 @@ public class ReactiveInsertByIdOperationSupport implements ReactiveInsertByIdOpe
 		}
 
 		@Override
-		public InsertByIdInCollection<T> withDurability(final DurabilityLevel durabilityLevel) {
+		public InsertByIdInScope<T> withDurability(final DurabilityLevel durabilityLevel) {
 			Assert.notNull(durabilityLevel, "Durability Level must not be null.");
 			return new ReactiveInsertByIdSupport<>(template, domainType, scope, collection, options, persistTo, replicateTo,
 					durabilityLevel, expiry, support);
 		}
 
 		@Override
-		public InsertByIdInCollection<T> withDurability(final PersistTo persistTo, final ReplicateTo replicateTo) {
+		public InsertByIdInScope<T> withDurability(final PersistTo persistTo, final ReplicateTo replicateTo) {
 			Assert.notNull(persistTo, "PersistTo must not be null.");
 			Assert.notNull(replicateTo, "ReplicateTo must not be null.");
 			return new ReactiveInsertByIdSupport<>(template, domainType, scope, collection, options, persistTo, replicateTo,

--- a/src/main/java/org/springframework/data/couchbase/core/ReactiveRemoveByIdOperation.java
+++ b/src/main/java/org/springframework/data/couchbase/core/ReactiveRemoveByIdOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2021 the original author or authors
+ * Copyright 2012-2022 the original author or authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -112,10 +112,10 @@ public interface ReactiveRemoveByIdOperation {
 
 	interface RemoveByIdWithDurability extends RemoveByIdInScope, WithDurability<RemoveResult> {
 		@Override
-		RemoveByIdInCollection withDurability(DurabilityLevel durabilityLevel);
+		RemoveByIdInScope withDurability(DurabilityLevel durabilityLevel);
 
 		@Override
-		RemoveByIdInCollection withDurability(PersistTo persistTo, ReplicateTo replicateTo);
+		RemoveByIdInScope withDurability(PersistTo persistTo, ReplicateTo replicateTo);
 
 	}
 

--- a/src/main/java/org/springframework/data/couchbase/core/ReactiveRemoveByIdOperationSupport.java
+++ b/src/main/java/org/springframework/data/couchbase/core/ReactiveRemoveByIdOperationSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2021 the original author or authors
+ * Copyright 2012-2022 the original author or authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -105,14 +105,14 @@ public class ReactiveRemoveByIdOperationSupport implements ReactiveRemoveByIdOpe
 		}
 
 		@Override
-		public RemoveByIdInCollection withDurability(final DurabilityLevel durabilityLevel) {
+		public RemoveByIdInScope withDurability(final DurabilityLevel durabilityLevel) {
 			Assert.notNull(durabilityLevel, "Durability Level must not be null.");
 			return new ReactiveRemoveByIdSupport(template, domainType, scope, collection, options, persistTo, replicateTo,
 					durabilityLevel, cas);
 		}
 
 		@Override
-		public RemoveByIdInCollection withDurability(final PersistTo persistTo, final ReplicateTo replicateTo) {
+		public RemoveByIdInScope withDurability(final PersistTo persistTo, final ReplicateTo replicateTo) {
 			Assert.notNull(persistTo, "PersistTo must not be null.");
 			Assert.notNull(replicateTo, "ReplicateTo must not be null.");
 			return new ReactiveRemoveByIdSupport(template, domainType, scope, collection, options, persistTo, replicateTo,

--- a/src/main/java/org/springframework/data/couchbase/core/ReactiveReplaceByIdOperation.java
+++ b/src/main/java/org/springframework/data/couchbase/core/ReactiveReplaceByIdOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2021 the original author or authors
+ * Copyright 2012-2022 the original author or authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -116,9 +116,9 @@ public interface ReactiveReplaceByIdOperation {
 
 	interface ReplaceByIdWithDurability<T> extends ReplaceByIdInScope<T>, WithDurability<T> {
 
-		ReplaceByIdInCollection<T> withDurability(DurabilityLevel durabilityLevel);
+		ReplaceByIdInScope<T> withDurability(DurabilityLevel durabilityLevel);
 
-		ReplaceByIdInCollection<T> withDurability(PersistTo persistTo, ReplicateTo replicateTo);
+		ReplaceByIdInScope<T> withDurability(PersistTo persistTo, ReplicateTo replicateTo);
 
 	}
 

--- a/src/main/java/org/springframework/data/couchbase/core/ReactiveReplaceByIdOperationSupport.java
+++ b/src/main/java/org/springframework/data/couchbase/core/ReactiveReplaceByIdOperationSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2021 the original author or authors
+ * Copyright 2012-2022 the original author or authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -126,14 +126,14 @@ public class ReactiveReplaceByIdOperationSupport implements ReactiveReplaceByIdO
 		}
 
 		@Override
-		public ReplaceByIdInCollection<T> withDurability(final DurabilityLevel durabilityLevel) {
+		public ReplaceByIdInScope<T> withDurability(final DurabilityLevel durabilityLevel) {
 			Assert.notNull(durabilityLevel, "Durability Level must not be null.");
 			return new ReactiveReplaceByIdSupport<>(template, domainType, scope, collection, options, persistTo, replicateTo,
 					durabilityLevel, expiry, support);
 		}
 
 		@Override
-		public ReplaceByIdInCollection<T> withDurability(final PersistTo persistTo, final ReplicateTo replicateTo) {
+		public ReplaceByIdInScope<T> withDurability(final PersistTo persistTo, final ReplicateTo replicateTo) {
 			Assert.notNull(persistTo, "PersistTo must not be null.");
 			Assert.notNull(replicateTo, "ReplicateTo must not be null.");
 			return new ReactiveReplaceByIdSupport<>(template, domainType, scope, collection, options, persistTo, replicateTo,

--- a/src/main/java/org/springframework/data/couchbase/core/ReactiveUpsertByIdOperation.java
+++ b/src/main/java/org/springframework/data/couchbase/core/ReactiveUpsertByIdOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2021 the original author or authors
+ * Copyright 2012-2022 the original author or authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -118,10 +118,10 @@ public interface ReactiveUpsertByIdOperation {
 
 	interface UpsertByIdWithDurability<T> extends UpsertByIdInScope<T>, WithDurability<T> {
 		@Override
-		UpsertByIdInCollection<T> withDurability(DurabilityLevel durabilityLevel);
+		UpsertByIdInScope<T> withDurability(DurabilityLevel durabilityLevel);
 
 		@Override
-		UpsertByIdInCollection<T> withDurability(PersistTo persistTo, ReplicateTo replicateTo);
+		UpsertByIdInScope<T> withDurability(PersistTo persistTo, ReplicateTo replicateTo);
 
 	}
 

--- a/src/main/java/org/springframework/data/couchbase/core/ReactiveUpsertByIdOperationSupport.java
+++ b/src/main/java/org/springframework/data/couchbase/core/ReactiveUpsertByIdOperationSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2021 the original author or authors
+ * Copyright 2012-2022 the original author or authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -125,14 +125,14 @@ public class ReactiveUpsertByIdOperationSupport implements ReactiveUpsertByIdOpe
 		}
 
 		@Override
-		public UpsertByIdInCollection<T> withDurability(final DurabilityLevel durabilityLevel) {
+		public UpsertByIdInScope<T> withDurability(final DurabilityLevel durabilityLevel) {
 			Assert.notNull(durabilityLevel, "Durability Level must not be null.");
 			return new ReactiveUpsertByIdSupport<>(template, domainType, scope, collection, options, persistTo, replicateTo,
 					durabilityLevel, expiry, support);
 		}
 
 		@Override
-		public UpsertByIdInCollection<T> withDurability(final PersistTo persistTo, final ReplicateTo replicateTo) {
+		public UpsertByIdInScope<T> withDurability(final PersistTo persistTo, final ReplicateTo replicateTo) {
 			Assert.notNull(persistTo, "PersistTo must not be null.");
 			Assert.notNull(replicateTo, "ReplicateTo must not be null.");
 			return new ReactiveUpsertByIdSupport<>(template, domainType, scope, collection, options, persistTo, replicateTo,

--- a/src/test/java/org/springframework/data/couchbase/core/CouchbaseTemplateQueryCollectionIntegrationTests.java
+++ b/src/test/java/org/springframework/data/couchbase/core/CouchbaseTemplateQueryCollectionIntegrationTests.java
@@ -30,6 +30,7 @@ import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
+import com.couchbase.client.core.msg.kv.DurabilityLevel;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -800,4 +801,38 @@ class CouchbaseTemplateQueryCollectionIntegrationTests extends CollectionAwareIn
 			} catch (DataRetrievalFailureException drfe) {}
 		}
 	}
+
+	@Test
+	void testFluentApi() {
+		User user1 = new User(UUID.randomUUID().toString(), "user1", "user1");
+		DurabilityLevel dl = DurabilityLevel.NONE;
+		User result;
+		RemoveResult rr;
+		result = couchbaseTemplate.insertById(User.class).withDurability(dl).inScope(scopeName).inCollection(collectionName)
+				.one(user1);
+		assertEquals(user1,result);
+		result = couchbaseTemplate.upsertById(User.class).withDurability(dl).inScope(scopeName).inCollection(collectionName)
+				.one(user1);
+		assertEquals(user1,result);
+		result = couchbaseTemplate.replaceById(User.class).withDurability(dl).inScope(scopeName).inCollection(collectionName)
+				.one(user1);
+		assertEquals(user1,result);
+		rr = couchbaseTemplate.removeById(User.class).withDurability(dl).inScope(scopeName).inCollection(collectionName)
+				.one(user1.getId());
+		assertEquals(rr.getId(), user1.getId());
+		assertEquals(user1,result);
+		result = reactiveCouchbaseTemplate.insertById(User.class).withDurability(dl).inScope(scopeName).inCollection(collectionName)
+				.one(user1).block();
+		assertEquals(user1,result);
+		result = reactiveCouchbaseTemplate.upsertById(User.class).withDurability(dl).inScope(scopeName).inCollection(collectionName)
+				.one(user1).block();
+		assertEquals(user1,result);
+		result = reactiveCouchbaseTemplate.replaceById(User.class).withDurability(dl).inScope(scopeName)
+				.inCollection(collectionName).one(user1).block();
+		assertEquals(user1,result);
+		 rr = reactiveCouchbaseTemplate.removeById(User.class).withDurability(dl).inScope(scopeName).inCollection(collectionName)
+				.one(user1.getId()).block();
+		assertEquals(rr.getId(), user1.getId());
+	}
+
 }


### PR DESCRIPTION
Some of the operations were mistakenly declared to return a
WithCollection type, making it impossible to call the inScope()
method.

Closes #1329.

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATACOUCH).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
