### PR TITLE
Proper handling of metadata from CrudMethodMetadataPostProcessor.

### DIFF
--- a/src/main/java/org/springframework/data/couchbase/repository/support/CrudMethodMetadataPostProcessor.java
+++ b/src/main/java/org/springframework/data/couchbase/repository/support/CrudMethodMetadataPostProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2020 the original author or authors
+ * Copyright 2012-2022 the original author or authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -168,10 +168,10 @@ class CrudMethodMetadataPostProcessor implements RepositoryProxyPostProcessor, B
 				try {
 					return invocation.proceed();
 				} finally {
-					// TransactionSynchronizationManager.unbindResource(method);
+					TransactionSynchronizationManager.unbindResource(method);
 				}
 			} finally {
-				// currentInvocation.set(oldInvocation);
+				currentInvocation.set(oldInvocation);
 			}
 		}
 	}
@@ -209,7 +209,7 @@ class CrudMethodMetadataPostProcessor implements RepositoryProxyPostProcessor, B
 				return;
 			}
 
-			AnnotatedElement[] annotated = new AnnotatedElement[] { method, method.getDeclaringClass()};
+			AnnotatedElement[] annotated = new AnnotatedElement[] { method, method.getDeclaringClass() };
 			this.scanConsistency = OptionsBuilder.annotation(ScanConsistency.class, "query", QueryScanConsistency.NOT_BOUNDED,
 					annotated);
 			this.scope = OptionsBuilder.annotationString(Scope.class, CollectionIdentifier.DEFAULT_SCOPE, annotated);


### PR DESCRIPTION
Retrieve the data before any reactive lambda.
When the method returns, in can immediately be removed from
the currentInvocation, and the previous data restored.

Closes #1392.

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATACOUCH).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
