### PR TITLE
Add BigDecimal converter.

### DIFF
--- a/src/main/java/org/springframework/data/couchbase/core/convert/OtherConverters.java
+++ b/src/main/java/org/springframework/data/couchbase/core/convert/OtherConverters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 the original author or authors
+ * Copyright 2021-2022 the original author or authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package org.springframework.data.couchbase.core.convert;
 
+import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -47,6 +48,8 @@ public final class OtherConverters {
 		converters.add(StringToUuid.INSTANCE);
 		converters.add(BigIntegerToString.INSTANCE);
 		converters.add(StringToBigInteger.INSTANCE);
+		converters.add(BigDecimalToString.INSTANCE);
+		converters.add(StringToBigDecimal.INSTANCE);
 
 		return converters;
 	}
@@ -88,6 +91,26 @@ public final class OtherConverters {
 		@Override
 		public BigInteger convert(String source) {
 			return source == null ? null : new BigInteger(source);
+		}
+	}
+
+	@WritingConverter
+	public enum BigDecimalToString implements Converter<BigDecimal, String> {
+		INSTANCE;
+
+		@Override
+		public String convert(BigDecimal source) {
+			return source == null ? null : source.toPlainString();
+		}
+	}
+
+	@ReadingConverter
+	public enum StringToBigDecimal implements Converter<String, BigDecimal> {
+		INSTANCE;
+
+		@Override
+		public BigDecimal convert(String source) {
+			return source == null ? null : new BigDecimal(source);
 		}
 	}
 }


### PR DESCRIPTION
Add BigDecimal converter, add converter tests for BigDecimal and BigInteger.
Since BigDecimal is now supported, it cannot be used in the CustomerConverter tests.
So instead use ChoiceFormat for CustomConverter tests.

Closes #1459.

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATACOUCH).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
