### PR TITLE
Add n1ql.scope and n1ql.collection spel expressions for @Query.

### DIFF
--- a/src/main/asciidoc/repository.adoc
+++ b/src/main/asciidoc/repository.adoc
@@ -133,6 +133,8 @@ A few N1QL-specific values are provided through SpEL:
 - `#n1ql.selectEntity` allows to easily make sure the statement will select all the fields necessary to build the full entity (including document ID and CAS value).
 - `#n1ql.filter` in the WHERE clause adds a criteria matching the entity type with the field that Spring Data uses to store type information.
 - `#n1ql.bucket` will be replaced by the name of the bucket the entity is stored in, escaped in backticks.
+- `#n1ql.scope` will be replaced by the name of the scope the entity is stored in, escaped in backticks.
+- `#n1ql.collection` will be replaced by the name of the collection the entity is stored in, escaped in backticks.
 - `#n1ql.fields` will be replaced by the list of fields (eg. for a SELECT clause) necessary to reconstruct the entity.
 - `#n1ql.delete` will be replaced by the `delete from` statement.
 - `#n1ql.returning` will be replaced by returning clause needed for reconstructing entity.
@@ -164,7 +166,7 @@ This is *NOT* intended for projections to DTOs.
 Another example: +
 `#{#n1ql.selectEntity} WHERE #{#n1ql.filter} AND test = $1` +
 is equivalent to +
-`SELECT #{#n1ql.fields} FROM #{#n1ql.bucket} WHERE #{#n1ql.filter} AND test = $1`
+`SELECT #{#n1ql.fields} FROM #{#n1ql.collection} WHERE #{#n1ql.filter} AND test = $1`
 
 .A practical application of SpEL with Spring Security
 ****

--- a/src/main/java/org/springframework/data/couchbase/core/ReactiveFindByQueryOperationSupport.java
+++ b/src/main/java/org/springframework/data/couchbase/core/ReactiveFindByQueryOperationSupport.java
@@ -169,7 +169,7 @@ public class ReactiveFindByQueryOperationSupport implements ReactiveFindByQueryO
 		@Override
 		public Flux<T> all() {
 			PseudoArgs<QueryOptions> pArgs = new PseudoArgs(template, scope, collection, options, domainType);
-			String statement = assembleEntityQuery(false, distinctFields, pArgs.getCollection());
+			String statement = assembleEntityQuery(false, distinctFields, pArgs.getScope(), pArgs.getCollection());
 			LOG.trace("findByQuery {} statement: {}", pArgs, statement);
 			Mono<ReactiveQueryResult> allResult = pArgs.getScope() == null
 					? template.getCouchbaseClientFactory().getCluster().reactive().query(statement,
@@ -214,7 +214,7 @@ public class ReactiveFindByQueryOperationSupport implements ReactiveFindByQueryO
 		@Override
 		public Mono<Long> count() {
 			PseudoArgs<QueryOptions> pArgs = new PseudoArgs(template, scope, collection, options, domainType);
-			String statement = assembleEntityQuery(true, distinctFields, pArgs.getCollection());
+			String statement = assembleEntityQuery(true, distinctFields, pArgs.getScope(), pArgs.getCollection());
 			LOG.trace("findByQuery {} statement: {}", pArgs, statement);
 			Mono<ReactiveQueryResult> countResult = pArgs.getScope() == null
 					? template.getCouchbaseClientFactory().getCluster().reactive().query(statement,
@@ -236,8 +236,8 @@ public class ReactiveFindByQueryOperationSupport implements ReactiveFindByQueryO
 			return count().map(count -> count > 0); // not efficient, just need the first one
 		}
 
-		private String assembleEntityQuery(final boolean count, String[] distinctFields, String collection) {
-			return query.toN1qlSelectString(template, collection, this.domainType, this.returnType, count,
+		private String assembleEntityQuery(final boolean count, String[] distinctFields, String scope, String collection) {
+			return query.toN1qlSelectString(template, scope, collection, this.domainType, this.returnType, count,
 					query.getDistinctFields() != null ? query.getDistinctFields() : distinctFields, fields);
 		}
 	}

--- a/src/main/java/org/springframework/data/couchbase/core/ReactiveRemoveByQueryOperationSupport.java
+++ b/src/main/java/org/springframework/data/couchbase/core/ReactiveRemoveByQueryOperationSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2021 the original author or authors
+ * Copyright 2012-2022 the original author or authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -71,7 +71,7 @@ public class ReactiveRemoveByQueryOperationSupport implements ReactiveRemoveByQu
 		@Override
 		public Flux<RemoveResult> all() {
 			PseudoArgs<QueryOptions> pArgs = new PseudoArgs<>(template, scope, collection, options, domainType);
-			String statement = assembleDeleteQuery(pArgs.getCollection());
+			String statement = assembleDeleteQuery(pArgs.getScope(), pArgs.getCollection());
 			LOG.trace("removeByQuery {} statement: {}", pArgs, statement);
 			Mono<ReactiveQueryResult> allResult = pArgs.getScope() == null
 					? template.getCouchbaseClientFactory().getCluster().reactive().query(statement,
@@ -119,8 +119,8 @@ public class ReactiveRemoveByQueryOperationSupport implements ReactiveRemoveByQu
 					options);
 		}
 
-		private String assembleDeleteQuery(String collection) {
-			return query.toN1qlRemoveString(template, collection, this.domainType);
+		private String assembleDeleteQuery(String scope, String collection) {
+			return query.toN1qlRemoveString(template, scope, collection, this.domainType);
 		}
 
 		@Override

--- a/src/main/java/org/springframework/data/couchbase/core/convert/join/N1qlJoinResolver.java
+++ b/src/main/java/org/springframework/data/couchbase/core/convert/join/N1qlJoinResolver.java
@@ -73,13 +73,14 @@ public class N1qlJoinResolver {
 		String from = "FROM " + keySpacePair.lhs.keyspace + " lks " + useLKS + joinType + " " + keySpacePair.rhs.keyspace
 				+ " rks";
 
-		StringBasedN1qlQueryParser.N1qlSpelValues n1qlL = Query.getN1qlSpelValues(template, keySpacePair.lhs.collection,
-				parameters.getEntityTypeInfo().getType(), parameters.getEntityTypeInfo().getType(), false, null, null);
+		StringBasedN1qlQueryParser.N1qlSpelValues n1qlL = Query.getN1qlSpelValues(template, null,
+				keySpacePair.lhs.collection, parameters.getEntityTypeInfo().getType(), parameters.getEntityTypeInfo().getType(),
+				false, null, null);
 		String onLks = "lks." + n1qlL.filter;
 
-		StringBasedN1qlQueryParser.N1qlSpelValues n1qlR = Query.getN1qlSpelValues(template, keySpacePair.rhs.collection,
-				parameters.getAssociatedEntityTypeInfo().getType(), parameters.getAssociatedEntityTypeInfo().getType(), false,
-				null, null);
+		StringBasedN1qlQueryParser.N1qlSpelValues n1qlR = Query.getN1qlSpelValues(template, null,
+				keySpacePair.rhs.collection, parameters.getAssociatedEntityTypeInfo().getType(),
+				parameters.getAssociatedEntityTypeInfo().getType(), false, null, null);
 		String onRks = "rks." + n1qlR.filter;
 
 		StringBuilder useRKSBuilder = new StringBuilder();

--- a/src/main/java/org/springframework/data/couchbase/core/query/N1QLExpression.java
+++ b/src/main/java/org/springframework/data/couchbase/core/query/N1QLExpression.java
@@ -210,6 +210,13 @@ public class N1QLExpression {
 	}
 
 	/**
+	 * Returned expression results in distinct of the expression
+	 */
+	public static N1QLExpression distinct(N1QLExpression expression) {
+		return  x("distinct{" + expression.toString() + "}");
+	}
+
+	/**
 	 * Helper method to wrap varargs with the given character.
 	 *
 	 * @param wrapper the wrapper character.

--- a/src/main/java/org/springframework/data/couchbase/core/query/N1QLQuery.java
+++ b/src/main/java/org/springframework/data/couchbase/core/query/N1QLQuery.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2021 the original author or authors
+ * Copyright 2012-2022 the original author or authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -48,8 +48,8 @@ public class N1QLQuery extends Query {
 	}
 
 	@Override
-	public String toN1qlSelectString(ReactiveCouchbaseTemplate template, String collectionName, Class domainClass,
-			Class returnClass, boolean isCount, String[] distinctFields, String[] fields) {
+	public String toN1qlSelectString(ReactiveCouchbaseTemplate template, String scopeName, String collectionName,
+			Class domainClass, Class returnClass, boolean isCount, String[] distinctFields, String[] fields) {
 		return expression.toString();
 	}
 }

--- a/src/main/java/org/springframework/data/couchbase/core/query/Query.java
+++ b/src/main/java/org/springframework/data/couchbase/core/query/Query.java
@@ -338,13 +338,17 @@ public class Query {
 		return sb.toString();
 	}
 
+	/**
+	 *
+	 */
+	@Deprecated
 	public String toN1qlSelectString(ReactiveCouchbaseTemplate template, Class domainClass, boolean isCount) {
-		return toN1qlSelectString(template, null, domainClass, null, isCount, null, null);
+		return toN1qlSelectString(template, null, null, domainClass, null, isCount, null, null);
 	}
 
-	public String toN1qlSelectString(ReactiveCouchbaseTemplate template, String collectionName, Class domainClass,
-			Class returnClass, boolean isCount, String[] distinctFields, String[] fields) {
-		StringBasedN1qlQueryParser.N1qlSpelValues n1ql = getN1qlSpelValues(template, collectionName, domainClass,
+	public String toN1qlSelectString(ReactiveCouchbaseTemplate template, String scopeName, String collectionName,
+			Class domainClass, Class returnClass, boolean isCount, String[] distinctFields, String[] fields) {
+		StringBasedN1qlQueryParser.N1qlSpelValues n1ql = getN1qlSpelValues(template, scopeName, collectionName, domainClass,
 				returnClass, isCount, distinctFields, fields);
 		final StringBuilder statement = new StringBuilder();
 		appendString(statement, n1ql.selectEntity); // select ...
@@ -357,9 +361,10 @@ public class Query {
 		return statement.toString();
 	}
 
-	public String toN1qlRemoveString(ReactiveCouchbaseTemplate template, String collectionName, Class domainClass) {
-		StringBasedN1qlQueryParser.N1qlSpelValues n1ql = getN1qlSpelValues(template, collectionName, domainClass, null,
-				false, null, null);
+	public String toN1qlRemoveString(ReactiveCouchbaseTemplate template, String scopeName, String collectionName,
+			Class domainClass) {
+		StringBasedN1qlQueryParser.N1qlSpelValues n1ql = getN1qlSpelValues(template, scopeName, collectionName, domainClass,
+				null, false, null, null);
 		final StringBuilder statement = new StringBuilder();
 		appendString(statement, n1ql.delete); // delete ...
 		appendWhereString(statement, n1ql.filter); // typeKey = typeValue
@@ -369,8 +374,8 @@ public class Query {
 	}
 
 	public static StringBasedN1qlQueryParser.N1qlSpelValues getN1qlSpelValues(ReactiveCouchbaseTemplate template,
-			String collectionName, Class domainClass, Class returnClass, boolean isCount, String[] distinctFields,
-			String[] fields) {
+			String scopeName, String collectionName, Class domainClass, Class returnClass, boolean isCount,
+			String[] distinctFields, String[] fields) {
 		String typeKey = template.getConverter().getTypeKey();
 		final CouchbasePersistentEntity<?> persistentEntity = template.getConverter().getMappingContext()
 				.getRequiredPersistentEntity(domainClass);
@@ -382,9 +387,10 @@ public class Query {
 			typeValue = alias.toString();
 		}
 
-		StringBasedN1qlQueryParser sbnqp = new StringBasedN1qlQueryParser(template.getBucketName(), collectionName,
-				template.getConverter(), domainClass, returnClass, typeKey, typeValue, isCount, distinctFields, fields);
-		return isCount ? sbnqp.getCountContext() : sbnqp.getStatementContext();
+		StringBasedN1qlQueryParser sbnqp = new StringBasedN1qlQueryParser(template.getBucketName(), scopeName,
+				collectionName, template.getConverter(), domainClass, returnClass, typeKey, typeValue, isCount, distinctFields,
+				fields);
+		return sbnqp.getStatementContext();
 	}
 
 	/**

--- a/src/main/java/org/springframework/data/couchbase/repository/query/N1qlRepositoryQueryExecutor.java
+++ b/src/main/java/org/springframework/data/couchbase/repository/query/N1qlRepositoryQueryExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2021 the original author or authors
+ * Copyright 2012-2022 the original author or authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -65,15 +65,16 @@ public class N1qlRepositoryQueryExecutor {
 		Query query;
 		ExecutableFindByQuery q;
 		if (queryMethod.hasN1qlAnnotation()) {
-			query = new StringN1qlQueryCreator(accessor, queryMethod, operations.getConverter(), operations.getBucketName(),
-					SPEL_PARSER, evaluationContextProvider, namedQueries).createQuery();
+			query = new StringN1qlQueryCreator(accessor, queryMethod, operations.getConverter(), SPEL_PARSER,
+					evaluationContextProvider, namedQueries).createQuery();
 		} else {
 			final PartTree tree = new PartTree(queryMethod.getName(), domainClass);
-			query = new N1qlQueryCreator(tree, accessor, queryMethod, operations.getConverter(), operations.getBucketName()).createQuery();
+			query = new N1qlQueryCreator(tree, accessor, queryMethod, operations.getConverter(), operations.getBucketName())
+					.createQuery();
 		}
 
-		ExecutableFindByQuery<?> operation = (ExecutableFindByQuery<?>) operations
-				.findByQuery(domainClass).withConsistency(buildQueryScanConsistency());
+		ExecutableFindByQuery<?> operation = (ExecutableFindByQuery<?>) operations.findByQuery(domainClass)
+				.withConsistency(buildQueryScanConsistency());
 		if (queryMethod.isCountQuery()) {
 			return operation.matching(query).count();
 		} else if (queryMethod.isCollectionQuery()) {

--- a/src/main/java/org/springframework/data/couchbase/repository/query/ReactiveStringBasedCouchbaseQuery.java
+++ b/src/main/java/org/springframework/data/couchbase/repository/query/ReactiveStringBasedCouchbaseQuery.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 the original author or authors.
+ * Copyright 2020-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -77,8 +77,7 @@ public class ReactiveStringBasedCouchbaseQuery extends AbstractReactiveCouchbase
 	protected Query createQuery(ParametersParameterAccessor accessor) {
 
 		StringN1qlQueryCreator creator = new StringN1qlQueryCreator(accessor, getQueryMethod(),
-				getOperations().getConverter(), getOperations().getBucketName(), expressionParser, evaluationContextProvider,
-				namedQueries);
+				getOperations().getConverter(), expressionParser, evaluationContextProvider, namedQueries);
 
 		Query query = creator.createQuery();
 

--- a/src/main/java/org/springframework/data/couchbase/repository/query/StringBasedCouchbaseQuery.java
+++ b/src/main/java/org/springframework/data/couchbase/repository/query/StringBasedCouchbaseQuery.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 the original author or authors.
+ * Copyright 2020-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -75,8 +75,7 @@ public class StringBasedCouchbaseQuery extends AbstractCouchbaseQuery {
 	protected Query createQuery(ParametersParameterAccessor accessor) {
 
 		StringN1qlQueryCreator creator = new StringN1qlQueryCreator(accessor, getQueryMethod(),
-				getOperations().getConverter(), getOperations().getBucketName(), expressionParser, evaluationContextProvider,
-				namedQueries);
+				getOperations().getConverter(), expressionParser, evaluationContextProvider, namedQueries);
 		Query query = creator.createQuery();
 
 		if (LOG.isTraceEnabled()) {

--- a/src/test/java/org/springframework/data/couchbase/domain/UserRepository.java
+++ b/src/test/java/org/springframework/data/couchbase/domain/UserRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2021 the original author or authors
+ * Copyright 2012-2022 the original author or authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,9 +20,11 @@ import java.util.List;
 import java.util.stream.Stream;
 
 import org.springframework.cache.annotation.Cacheable;
+import org.springframework.data.couchbase.repository.Collection;
 import org.springframework.data.couchbase.repository.CouchbaseRepository;
 import org.springframework.data.couchbase.repository.Query;
 import org.springframework.data.couchbase.repository.ScanConsistency;
+import org.springframework.data.couchbase.repository.Scope;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
@@ -58,6 +60,11 @@ public interface UserRepository extends CouchbaseRepository<User, String> {
 	List<User> findByIdIsNotNullAndFirstnameEquals(String firstname);
 
 	List<User> findByVersionEqualsAndFirstnameEquals(Long version, String firstname);
+
+	@Query("#{#n1ql.selectEntity}|#{#n1ql.filter}|#{#n1ql.bucket}|#{#n1ql.scope}|#{#n1ql.collection}")
+	@Scope("thisScope")
+	@Collection("thisCollection")
+	List<User> spelTests();
 
 	// simulate a slow operation
 	@Cacheable("mySpringCache")

--- a/src/test/java/org/springframework/data/couchbase/repository/query/StringN1qlQueryCreatorIntegrationTests.java
+++ b/src/test/java/org/springframework/data/couchbase/repository/query/StringN1qlQueryCreatorIntegrationTests.java
@@ -66,9 +66,9 @@ import com.couchbase.client.java.query.QueryScanConsistency;
  * @author Michael Nitschinger
  * @author Michael Reiche
  */
-@SpringJUnitConfig(StringN1qlQueryCreatorTests.Config.class)
+@SpringJUnitConfig(StringN1qlQueryCreatorIntegrationTests.Config.class)
 @IgnoreWhen(clusterTypes = ClusterType.MOCKED)
-class StringN1qlQueryCreatorTests extends ClusterAwareIntegrationTests {
+class StringN1qlQueryCreatorIntegrationTests extends ClusterAwareIntegrationTests {
 
 	MappingContext<? extends CouchbasePersistentEntity<?>, CouchbasePersistentProperty> context;
 	CouchbaseConverter converter;
@@ -98,8 +98,8 @@ class StringN1qlQueryCreatorTests extends ClusterAwareIntegrationTests {
 					converter.getMappingContext());
 
 			StringN1qlQueryCreator creator = new StringN1qlQueryCreator(getAccessor(getParameters(method), "Continental"),
-					queryMethod, converter, config().bucketname(), new SpelExpressionParser(),
-					QueryMethodEvaluationContextProvider.DEFAULT, namedQueries);
+					queryMethod, converter, new SpelExpressionParser(), QueryMethodEvaluationContextProvider.DEFAULT,
+					namedQueries);
 
 			Query query = creator.createQuery();
 
@@ -131,8 +131,8 @@ class StringN1qlQueryCreatorTests extends ClusterAwareIntegrationTests {
 					converter.getMappingContext());
 
 			StringN1qlQueryCreator creator = new StringN1qlQueryCreator(getAccessor(getParameters(method), "Continental"),
-					queryMethod, converter, config().bucketname(), new SpelExpressionParser(),
-					QueryMethodEvaluationContextProvider.DEFAULT, namedQueries);
+					queryMethod, converter, new SpelExpressionParser(), QueryMethodEvaluationContextProvider.DEFAULT,
+					namedQueries);
 
 			Query query = creator.createQuery();
 

--- a/src/test/java/org/springframework/data/couchbase/repository/query/StringN1qlQueryCreatorMockedTests.java
+++ b/src/test/java/org/springframework/data/couchbase/repository/query/StringN1qlQueryCreatorMockedTests.java
@@ -84,13 +84,15 @@ class StringN1qlQueryCreatorMockedTests extends ClusterAwareIntegrationTests {
 				converter.getMappingContext());
 
 		StringN1qlQueryCreator creator = new StringN1qlQueryCreator(getAccessor(getParameters(method), "Oliver", "Twist"),
-				queryMethod, converter, "travel-sample", new SpelExpressionParser(),
-				QueryMethodEvaluationContextProvider.DEFAULT, namedQueries);
+				queryMethod, converter, new SpelExpressionParser(), QueryMethodEvaluationContextProvider.DEFAULT, namedQueries);
 
 		Query query = creator.createQuery();
 		assertEquals(
-				"SELECT `_class`, META(`travel-sample`).`cas` AS __cas, `createdBy`, `createdDate`, `lastModifiedBy`, `lastModifiedDate`, META(`travel-sample`).`id` AS __id, `firstname`, `lastname`, `subtype` FROM `travel-sample` where `_class` = \"abstractuser\" and firstname = $1 and lastname = $2",
-				query.toN1qlSelectString(couchbaseTemplate.reactive(), User.class, false));
+				"SELECT `_class`, META(`" + bucketName()
+						+ "`).`cas` AS __cas, `createdBy`, `createdDate`, `lastModifiedBy`, `lastModifiedDate`, META(`"
+						+ bucketName() + "`).`id` AS __id, `firstname`, `lastname`, `subtype` FROM `" + bucketName()
+						+ "` where `_class` = \"abstractuser\" and firstname = $1 and lastname = $2",
+				query.toN1qlSelectString(couchbaseTemplate.reactive(), null, null, User.class, User.class, false, null, null));
 	}
 
 	@Test
@@ -103,13 +105,15 @@ class StringN1qlQueryCreatorMockedTests extends ClusterAwareIntegrationTests {
 				converter.getMappingContext());
 
 		StringN1qlQueryCreator creator = new StringN1qlQueryCreator(getAccessor(getParameters(method), "Oliver", "Twist"),
-				queryMethod, converter, "travel-sample", new SpelExpressionParser(),
-				QueryMethodEvaluationContextProvider.DEFAULT, namedQueries);
+				queryMethod, converter, new SpelExpressionParser(), QueryMethodEvaluationContextProvider.DEFAULT, namedQueries);
 
 		Query query = creator.createQuery();
 		assertEquals(
-				"SELECT `_class`, META(`travel-sample`).`cas` AS __cas, `createdBy`, `createdDate`, `lastModifiedBy`, `lastModifiedDate`, META(`travel-sample`).`id` AS __id, `firstname`, `lastname`, `subtype` FROM `travel-sample` where `_class` = \"abstractuser\" and (firstname = $first or lastname = $last)",
-				query.toN1qlSelectString(couchbaseTemplate.reactive(), User.class, false));
+				"SELECT `_class`, META(`" + bucketName()
+						+ "`).`cas` AS __cas, `createdBy`, `createdDate`, `lastModifiedBy`, `lastModifiedDate`, META(`"
+						+ bucketName() + "`).`id` AS __id, `firstname`, `lastname`, `subtype` FROM `" + bucketName()
+						+ "` where `_class` = \"abstractuser\" and (firstname = $first or lastname = $last)",
+				query.toN1qlSelectString(couchbaseTemplate.reactive(), null, null, User.class, User.class, false, null, null));
 	}
 
 	@Test
@@ -123,8 +127,8 @@ class StringN1qlQueryCreatorMockedTests extends ClusterAwareIntegrationTests {
 
 		try {
 			StringN1qlQueryCreator creator = new StringN1qlQueryCreator(getAccessor(getParameters(method), "Oliver"),
-					queryMethod, converter, "travel-sample", new SpelExpressionParser(),
-					QueryMethodEvaluationContextProvider.DEFAULT, namedQueries);
+					queryMethod, converter, new SpelExpressionParser(), QueryMethodEvaluationContextProvider.DEFAULT,
+					namedQueries);
 		} catch (IllegalArgumentException e) {
 			return;
 		}
@@ -141,12 +145,31 @@ class StringN1qlQueryCreatorMockedTests extends ClusterAwareIntegrationTests {
 
 		try {
 			StringN1qlQueryCreator creator = new StringN1qlQueryCreator(getAccessor(getParameters(method), "Oliver"),
-					queryMethod, converter, "travel-sample", new SpelExpressionParser(),
-					QueryMethodEvaluationContextProvider.DEFAULT, namedQueries);
+					queryMethod, converter, new SpelExpressionParser(), QueryMethodEvaluationContextProvider.DEFAULT,
+					namedQueries);
 		} catch (IllegalArgumentException e) {
 			return;
 		}
 		fail("should have failed with IllegalArgumentException: query has no inline Query or named Query not found");
+	}
+
+	@Test
+	void spelTests() throws Exception {
+		String input = "spelTests";
+		Method method = UserRepository.class.getMethod(input);
+		CouchbaseQueryMethod queryMethod = new CouchbaseQueryMethod(method,
+				new DefaultRepositoryMetadata(UserRepository.class), new SpelAwareProxyProjectionFactory(),
+				converter.getMappingContext());
+
+		StringN1qlQueryCreator creator = new StringN1qlQueryCreator(getAccessor(getParameters(method)), queryMethod,
+				converter, new SpelExpressionParser(), QueryMethodEvaluationContextProvider.DEFAULT, namedQueries);
+
+		Query query = creator.createQuery();
+
+		String s = query.toN1qlSelectString(couchbaseTemplate.reactive(), "myScope", "myCollection", User.class, null,
+				false, null, null);
+		System.out.println("query: " + s);
+
 	}
 
 	private ParameterAccessor getAccessor(Parameters<?, ?> params, Object... values) {


### PR DESCRIPTION
This adds n1ql.scope and n1ql.collection spel expressions for
@Query so that n1ql.bucket doesn't need to be overloaded with
the collection name. This will make the bucket name available
in n1q.bucket.

This is a breaking change as queries that used n1ql.bucket to
get the collection name (especially in the case of pre-scope-
and-collection @Queries that (a) referenced n1ql.bucket instead
of referencing other spel expressions that include the
bucket/collection name; and (b)  still worked after the
repository was moved from a bucket onto a collection by
virtue of n1ql.bucket having the value of the collection in
such instances.

Closes #1445.

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATACOUCH).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
