### PR TITLE
Add test for CouchbaseDocument.verifyValueType

### DIFF
--- a/src/test/java/org/springframework/data/couchbase/core/mapping/MappingCouchbaseConverterTests.java
+++ b/src/test/java/org/springframework/data/couchbase/core/mapping/MappingCouchbaseConverterTests.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.data.Offset.offset;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -69,6 +70,7 @@ import org.springframework.data.mapping.MappingException;
  * @author Geoffrey Mina
  * @author Subhashni Balakrishnan
  * @author Mark Paluch
+ * @author Carolin Brandt
  */
 public class MappingCouchbaseConverterTests {
 
@@ -1182,5 +1184,11 @@ public class MappingCouchbaseConverterTests {
 		assertThatExceptionOfType(MappingException.class).isThrownBy(() -> {
 			converter.write(entity, converted);
 		});
+	}
+
+	@Test
+	void testExport() throws Exception {
+		CouchbaseDocument doc = new CouchbaseDocument("key");
+		assertEquals( "русский" , doc.put("language", "русский").export().get("language"));
 	}
 }


### PR DESCRIPTION
Hey 😊
I want to contribute a test.
Curious to hear what you think!

(I wrote this test as part of a research study at TU Delft. [Find out more](https://github.com/lacinoire/lacinoire/blob/main/README.md))


---

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [ ] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATACOUCH).
        This is a "trivial" change to test code which I believe is too simple for a jira ticket?
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [ ] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
No, but other contributors to the test classes also didn't
