### PR TITLE
Back-out the breaking part of 1445 from 4_4_x.

### DIFF
--- a/src/main/java/org/springframework/data/couchbase/repository/query/StringBasedN1qlQueryParser.java
+++ b/src/main/java/org/springframework/data/couchbase/repository/query/StringBasedN1qlQueryParser.java
@@ -205,7 +205,7 @@ public class StringBasedN1qlQueryParser {
 	 */
 	public N1qlSpelValues createN1qlSpelValues(String bucketName, String scope, String collection, Class domainClass,
 			String typeField, String typeValue, boolean isCount, String[] distinctFields, String[] fields) {
-		String b = bucketName;
+		String b = collection != null ? collection : bucketName;
 		String keyspace = collection != null ? collection : bucketName;
 		Assert.isTrue(!(distinctFields != null && fields != null),
 				"only one of project(fields) and distinct(distinctFields) can be specified");


### PR DESCRIPTION
n1ql.bucket will continue to be (collection != null ? collection : bucket)
so that queries that referenced n1ql.bucket after being used on collections
will still work.

Closes #1462.

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATACOUCH).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
