### PR TITLE
Rename FluxTest to FluxIntegrationTests as it requires a server.

### DIFF
--- a/src/test/java/org/springframework/data/couchbase/domain/FluxIntegrationTests.java
+++ b/src/test/java/org/springframework/data/couchbase/domain/FluxIntegrationTests.java
@@ -66,9 +66,9 @@ import com.couchbase.client.java.query.QueryScanConsistency;
 /**
  * @author Michael Reiche
  */
-@SpringJUnitConfig(FluxTest.Config.class)
+@SpringJUnitConfig(FluxIntegrationTests.Config.class)
 @IgnoreWhen(clusterTypes = ClusterType.MOCKED)
-public class FluxTest extends JavaIntegrationTests {
+public class FluxIntegrationTests extends JavaIntegrationTests {
 
 	@BeforeAll
 	public static void beforeEverything() {
@@ -76,7 +76,7 @@ public class FluxTest extends JavaIntegrationTests {
 		 * The couchbaseTemplate inherited from JavaIntegrationTests uses org.springframework.data.couchbase.domain.Config
 		 * It has typeName = 't' (instead of _class). Don't use it.
 		 */
-		ApplicationContext ac = new AnnotationConfigApplicationContext(FluxTest.Config.class);
+		ApplicationContext ac = new AnnotationConfigApplicationContext(FluxIntegrationTests.Config.class);
 		couchbaseTemplate = (CouchbaseTemplate) ac.getBean(BeanNames.COUCHBASE_TEMPLATE);
 		reactiveCouchbaseTemplate = (ReactiveCouchbaseTemplate) ac.getBean(BeanNames.REACTIVE_COUCHBASE_TEMPLATE);
 		collection = couchbaseTemplate.getCouchbaseClientFactory().getBucket().defaultCollection();


### PR DESCRIPTION
Closes #1474.

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATACOUCH).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
