### PR TITLE
Removing the form of checkForTransactionInThreadLocalStorage

### DIFF
--- a/spring-data-couchbase/src/main/java/org/springframework/data/couchbase/core/TransactionalSupport.java
+++ b/spring-data-couchbase/src/main/java/org/springframework/data/couchbase/core/TransactionalSupport.java
@@ -52,14 +52,6 @@ public class TransactionalSupport {
 		});
 	}
 
-	public static Optional<CouchbaseResourceHolder> checkForTransactionInThreadLocalStorage(ContextView ctx) {
-		return Optional.ofNullable(ctx.hasKey(TransactionMarker.class) ? new CouchbaseResourceHolder(ctx.get(TransactionMarker.class).context()) : null);
-	}
-
-	//public static Optional<CouchbaseResourceHolder> blockingCheckForTransactionInThreadLocalStorage() {
-	//		return TransactionMarkerOwner.marker;
-	//	}
-
 	public static Mono<Void> verifyNotInTransaction(String methodName) {
 		return checkForTransactionInThreadLocalStorage().flatMap(s -> {
 			if (s.isPresent()) {

--- a/spring-data-couchbase/src/test/java/org/springframework/data/couchbase/transactions/sdk/SDKTransactionsNonBlockingThreadIntegrationTests.java
+++ b/spring-data-couchbase/src/test/java/org/springframework/data/couchbase/transactions/sdk/SDKTransactionsNonBlockingThreadIntegrationTests.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2022 the original author or authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.data.couchbase.transactions.sdk;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.springframework.data.couchbase.transactions.util.TransactionTestUtil.assertNotInTransaction;
+
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.couchbase.CouchbaseClientFactory;
+import org.springframework.data.couchbase.core.CouchbaseTemplate;
+import org.springframework.data.couchbase.core.ReactiveCouchbaseTemplate;
+import org.springframework.data.couchbase.domain.Person;
+import org.springframework.data.couchbase.transactions.TransactionsConfig;
+import org.springframework.data.couchbase.util.Capabilities;
+import org.springframework.data.couchbase.util.ClusterType;
+import org.springframework.data.couchbase.util.IgnoreWhen;
+import org.springframework.data.couchbase.util.JavaIntegrationTests;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+/**
+ * Added for issue 1527: Tests running regular SDK transactions (blocking and reactive) on a reactor non-blocking
+ * thread.
+ *
+ * @author Graham Pople
+ */
+@IgnoreWhen(missesCapabilities = Capabilities.QUERY, clusterTypes = ClusterType.MOCKED)
+@SpringJUnitConfig(TransactionsConfig.class)
+public class SDKTransactionsNonBlockingThreadIntegrationTests extends JavaIntegrationTests {
+	@Autowired private CouchbaseClientFactory couchbaseClientFactory;
+	@Autowired private CouchbaseTemplate ops;
+	@Autowired private ReactiveCouchbaseTemplate reactiveOps;
+
+	@BeforeEach
+	public void beforeEachTest() {
+		assertNotInTransaction();
+	}
+
+	@AfterEach
+	public void afterEachTest() {
+		assertNotInTransaction();
+	}
+
+	@DisplayName("Trying to run a blocking transaction (or anything blocking) on a non-blocking thread, will not work")
+	@Test
+	public void blockingTransactionOnNonBlockingThread() {
+		try {
+			Mono.just(1).publishOn(Schedulers.parallel()).flatMap(ignore -> {
+				assertTrue(Schedulers.isInNonBlockingThread());
+				assertTrue(Thread.currentThread().getName().contains("parallel"));
+
+				couchbaseClientFactory.getCluster().transactions().run(ctx -> {
+					ops.insertById(Person.class).one(new Person("Walter", "White"));
+				});
+				return Mono.empty();
+			}).block();
+			fail();
+		} catch (IllegalStateException ignored) {}
+	}
+
+	@DisplayName("Trying to run a reactive transaction on a non-blocking thread should work")
+	@Test
+	public void reactiveTransactionOnNonBlockingThread() {
+		Mono.just(1).publishOn(Schedulers.parallel()).flatMap(ignore -> {
+			return couchbaseClientFactory.getCluster().reactive().transactions().run(ctx -> {
+				return reactiveOps.insertById(Person.class).one(new Person("Walter", "White"));
+			});
+		}).block();
+	}
+}

--- a/spring-data-couchbase/src/test/java/org/springframework/data/couchbase/transactions/sdk/SDKTransactionsSaveIntegrationTests.java
+++ b/spring-data-couchbase/src/test/java/org/springframework/data/couchbase/transactions/sdk/SDKTransactionsSaveIntegrationTests.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2022 the original author or authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.data.couchbase.transactions.sdk;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.springframework.data.couchbase.transactions.util.TransactionTestUtil.assertNotInTransaction;
+
+import org.springframework.data.couchbase.domain.PersonWithoutVersion;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.couchbase.CouchbaseClientFactory;
+import org.springframework.data.couchbase.core.CouchbaseTemplate;
+import org.springframework.data.couchbase.core.ReactiveCouchbaseTemplate;
+import org.springframework.data.couchbase.domain.Person;
+import org.springframework.data.couchbase.transactions.TransactionsConfig;
+import org.springframework.data.couchbase.util.Capabilities;
+import org.springframework.data.couchbase.util.ClusterType;
+import org.springframework.data.couchbase.util.IgnoreWhen;
+import org.springframework.data.couchbase.util.JavaIntegrationTests;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+/**
+ * Added for issue 1527: Tests the .save() command.
+ *
+ * @author Graham Pople
+ */
+@IgnoreWhen(missesCapabilities = Capabilities.QUERY, clusterTypes = ClusterType.MOCKED)
+@SpringJUnitConfig(TransactionsConfig.class)
+public class SDKTransactionsSaveIntegrationTests extends JavaIntegrationTests {
+	@Autowired private CouchbaseClientFactory couchbaseClientFactory;
+	@Autowired private CouchbaseTemplate ops;
+	@Autowired private ReactiveCouchbaseTemplate reactiveOps;
+
+	@BeforeEach
+	public void beforeEachTest() {
+		assertNotInTransaction();
+	}
+
+	@AfterEach
+	public void afterEachTest() {
+		assertNotInTransaction();
+	}
+
+	@DisplayName("ReactiveCouchbaseTemplate.save() called inside a reactive SDK transaction should work")
+	@Test
+	public void reactiveSaveInReactiveTransaction() {
+		couchbaseClientFactory.getCluster().reactive().transactions().run(ctx -> {
+			PersonWithoutVersion p = new PersonWithoutVersion("Walter", "White");
+			return reactiveOps.save(p);
+		}).block();
+	}
+
+	@DisplayName("ReactiveCouchbaseTemplate.save().block() called inside a non-reactive SDK transaction should work")
+	@Test
+	public void reactiveSaveInBlockingTransaction() {
+		couchbaseClientFactory.getCluster().transactions().run(ctx -> {
+			PersonWithoutVersion p = new PersonWithoutVersion("Walter", "White");
+			reactiveOps.save(p).block();
+		});
+	}
+
+	@DisplayName("ReactiveCouchbaseTemplate.save() called inside a reactive SDK transaction should work")
+	@Test
+	public void blockingSaveInReactiveTransaction() {
+		couchbaseClientFactory.getCluster().reactive().transactions().run(ctx -> {
+			PersonWithoutVersion p = new PersonWithoutVersion("Walter", "White");
+			ops.save(p);
+			return Mono.empty();
+		}).block();
+	}
+
+	@DisplayName("ReactiveCouchbaseTemplate.save().block() called inside a non-reactive SDK transaction should work")
+	@Test
+	public void blockingSaveInBlockingTransaction() {
+		couchbaseClientFactory.getCluster().transactions().run(ctx -> {
+			PersonWithoutVersion p = new PersonWithoutVersion("Walter", "White");
+			ops.save(p);
+		});
+	}
+}


### PR DESCRIPTION
that does not use TransactionMarkerOwner.  As this bypasses
a critical check on whether we are inside a blocking
transaction.

Two new tests in SDKTransactionsSaveIntegrationTests
(reactiveSaveInBlockingTransaction and blockingSaveInBlockingTransaction)
will fail without this, as the .save() does not realise
it's in a transaction.

Adding new tests, for .save() and for performing transactions
in reactor blocking threads.

<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [ ] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [ ] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATACOUCH).
- [ ] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [ ] You submit test cases (unit or integration tests) that back your changes.
- [ ] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
