### PR TITLE
Fix serialization for field level encryption.

### DIFF
--- a/src/main/java/org/springframework/data/couchbase/core/convert/AbstractCouchbaseConverter.java
+++ b/src/main/java/org/springframework/data/couchbase/core/convert/AbstractCouchbaseConverter.java
@@ -160,7 +160,8 @@ public abstract class AbstractCouchbaseConverter implements CouchbaseConverter, 
 		Class<?> elementType = value.getClass();
 
 		if (elementType == null || conversions.isSimpleType(elementType)) {
-			// superseded by EnumCvtrs value = Enum.class.isAssignableFrom(value.getClass()) ? ((Enum<?>) value).name() : value;
+			// superseded by EnumCvtrs value = Enum.class.isAssignableFrom(value.getClass()) ? ((Enum<?>) value).name() :
+			// value;
 		} else if (value instanceof Collection || elementType.isArray()) {
 			TypeInformation<?> type = ClassTypeInformation.from(value.getClass());
 			value = ((MappingCouchbaseConverter) this).writeCollectionInternal(MappingCouchbaseConverter.asCollection(value),
@@ -168,7 +169,7 @@ public abstract class AbstractCouchbaseConverter implements CouchbaseConverter, 
 		} else {
 			CouchbaseDocument embeddedDoc = new CouchbaseDocument();
 			TypeInformation<?> type = ClassTypeInformation.from(value.getClass());
-			((MappingCouchbaseConverter) this).writeInternalRoot(value, embeddedDoc, type, false, null);
+			((MappingCouchbaseConverter) this).writeInternalRoot(value, embeddedDoc, type, false, null, true);
 			value = embeddedDoc;
 		}
 		return value;

--- a/src/main/java/org/springframework/data/couchbase/core/convert/CouchbasePropertyValueConverterFactory.java
+++ b/src/main/java/org/springframework/data/couchbase/core/convert/CouchbasePropertyValueConverterFactory.java
@@ -31,7 +31,7 @@ import org.springframework.data.mapping.PersistentProperty;
 import com.couchbase.client.core.encryption.CryptoManager;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
-import org.springframework.util.Assert;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
  * Accept the Couchbase @Encrypted and @JsonValue annotations in addition to @ValueConverter annotation.<br>
@@ -48,14 +48,16 @@ import org.springframework.util.Assert;
  */
 public class CouchbasePropertyValueConverterFactory implements PropertyValueConverterFactory {
 
-	final CryptoManager cryptoManager;
-	final Map<Class<? extends Annotation>, Class<?>> annotationToConverterMap;
+	private final CryptoManager cryptoManager;
+	private final ObjectMapper objectMapper;
+	private final Map<Class<? extends Annotation>, Class<?>> annotationToConverterMap;
 	static protected final Map<Class<?>, Optional<PropertyValueConverter<?, ?, ?>>> converterCacheForType = new ConcurrentHashMap<>();
 
 	public CouchbasePropertyValueConverterFactory(CryptoManager cryptoManager,
-			Map<Class<? extends Annotation>, Class<?>> annotationToConverterMap) {
+			Map<Class<? extends Annotation>, Class<?>> annotationToConverterMap, ObjectMapper objectMapper) {
 		this.cryptoManager = cryptoManager;
 		this.annotationToConverterMap = annotationToConverterMap;
+		this.objectMapper = objectMapper;
 	}
 
 	/**
@@ -155,7 +157,7 @@ public class CouchbasePropertyValueConverterFactory implements PropertyValueConv
 
 		// CryptoConverter takes a cryptoManager argument
 		if (CryptoConverter.class.isAssignableFrom(converterType)) {
-			return (PropertyValueConverter<DV, SV, P>) new CryptoConverter(cryptoManager);
+			return (PropertyValueConverter<DV, SV, P>) new CryptoConverter(cryptoManager, objectMapper);
 		} else if (property != null) { // try constructor that takes PersistentProperty
 			try {
 				Constructor<?> constructor = converterType.getConstructor(PersistentProperty.class);

--- a/src/main/java/org/springframework/data/couchbase/core/convert/OtherConverters.java
+++ b/src/main/java/org/springframework/data/couchbase/core/convert/OtherConverters.java
@@ -27,7 +27,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.UUID;
 
-import com.fasterxml.jackson.databind.ObjectWriter;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.data.convert.ReadingConverter;
 import org.springframework.data.convert.WritingConverter;
@@ -200,7 +199,7 @@ public final class OtherConverters {
 
 	/**
 	 * Writing converter for Enums. This is registered in
-	 * {@link org.springframework.data.couchbase.config.AbstractCouchbaseConfiguration#customConversions( CryptoManager)}.
+	 * {@link org.springframework.data.couchbase.config.AbstractCouchbaseConfiguration#customConversions( CryptoManager, ObjectMapper)}.
 	 * The corresponding reading converters are in {@link IntegerToEnumConverterFactory} and
 	 * {@link StringToEnumConverterFactory}
 	 */
@@ -220,12 +219,12 @@ public final class OtherConverters {
 				objectMapper.writeValue(generator, source);
 				String s = writer.toString();
 				if (s != null && s.startsWith("\"")) {
-					return objectMapper.readValue(s,String.class);
+					return objectMapper.readValue(s, String.class);
 				}
 				if ("true".equals(s) || "false".equals(s)) {
-					return objectMapper.readValue(s,Boolean.class);
+					return objectMapper.readValue(s, Boolean.class);
 				}
-				return objectMapper.readValue(s,Number.class);
+				return objectMapper.readValue(s, Number.class);
 			} catch (IOException e) {
 				throw new RuntimeException(e);
 			}

--- a/src/test/java/org/springframework/data/couchbase/domain/Address.java
+++ b/src/test/java/org/springframework/data/couchbase/domain/Address.java
@@ -15,7 +15,6 @@
  */
 package org.springframework.data.couchbase.domain;
 
-import com.couchbase.client.java.encryption.annotation.Encrypted;
 import org.springframework.data.couchbase.core.mapping.Document;
 
 @Document
@@ -26,6 +25,7 @@ public class Address extends ComparableEntity {
 	// for N1qlJoin
 	private String id;
 	private String parentId;
+	private ETurbulenceCategory turbulence;
 
 	public Address() {}
 
@@ -45,6 +45,13 @@ public class Address extends ComparableEntity {
 		this.city = city;
 	}
 
+	public ETurbulenceCategory getTurbulence() {
+		return turbulence;
+	}
+
+	public void setTurbulence(ETurbulenceCategory turbulence) {
+		this.turbulence = turbulence;
+	}
 	public String getParentId() {
 		return parentId;
 	}

--- a/src/test/java/org/springframework/data/couchbase/domain/ETurbulenceCategory.java
+++ b/src/test/java/org/springframework/data/couchbase/domain/ETurbulenceCategory.java
@@ -23,7 +23,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
  * @author Michael Reiche
  */
 public enum ETurbulenceCategory {
-	T10("10%"), T20("20%"), T30("30%");
+	T10("\"10%"), T20("\"20%"), T30("\"30%");
 
 	private final String code;
 

--- a/src/test/java/org/springframework/data/couchbase/domain/UserEncrypted.java
+++ b/src/test/java/org/springframework/data/couchbase/domain/UserEncrypted.java
@@ -137,6 +137,7 @@ public class UserEncrypted extends AbstractUser implements Serializable {
 	@Encrypted public UUID encUUID;
 	@Encrypted public DateTime encDateTime;
 
+	@Encrypted public ETurbulenceCategory turbulence;
 	@Encrypted public Address encAddress = new Address();
 
 	public Date plainDate;
@@ -228,8 +229,8 @@ public class UserEncrypted extends AbstractUser implements Serializable {
 		encCharacter = 'a';
 		encCharacters = new Character[] { 'a', 'b' };
 
-		encString = "myString";
-		encStrings = new String[] { "myString" };
+		encString = "myS\"tring";
+		encStrings = new String[] { "mySt\"ring" };
 
 		encDate = NOW_Date;
 		encDates = new Date[] { NOW_Date };
@@ -248,13 +249,12 @@ public class UserEncrypted extends AbstractUser implements Serializable {
 		//clazz = String.class;
 
 		encDateTime = NOW_DateTime;
-
-		encAddress = new Address();
-
 		plainDate = NOW_Date;
 		plainDateTime = NOW_DateTime;
 
 		nicknames = List.of("Happy", "Sleepy");
+
+		turbulence = ETurbulenceCategory.T10;
 
 	}
 }

--- a/src/test/java/org/springframework/data/couchbase/repository/CouchbaseRepositoryFieldLevelEncryptionIntegrationTests.java
+++ b/src/test/java/org/springframework/data/couchbase/repository/CouchbaseRepositoryFieldLevelEncryptionIntegrationTests.java
@@ -38,6 +38,7 @@ import org.springframework.data.couchbase.config.AbstractCouchbaseConfiguration;
 import org.springframework.data.couchbase.core.CouchbaseTemplate;
 import org.springframework.data.couchbase.domain.Address;
 import org.springframework.data.couchbase.domain.AddressWithEncStreet;
+import org.springframework.data.couchbase.domain.ETurbulenceCategory;
 import org.springframework.data.couchbase.domain.TestEncrypted;
 import org.springframework.data.couchbase.domain.UserEncrypted;
 import org.springframework.data.couchbase.domain.UserEncryptedRepository;
@@ -97,6 +98,7 @@ public class CouchbaseRepositoryFieldLevelEncryptionIntegrationTests extends Clu
 	@Test
 	@IgnoreWhen(clusterTypes = ClusterType.MOCKED)
 	void saveAndFindByTestId() {
+		boolean cleanAfter = true;
 		TestEncrypted user = new TestEncrypted(UUID.randomUUID().toString());
 		user.initSimpleTypes();
 		couchbaseTemplate.save(user);
@@ -121,13 +123,20 @@ public class CouchbaseRepositoryFieldLevelEncryptionIntegrationTests extends Clu
 		writeSDKReadSpring.setId(user.getId());
 
 		assertEquals(user.toString(), writeSDKReadSpring.toString());
+		if (cleanAfter) {
+			try {
+				couchbaseTemplate.removeById(UserEncrypted.class).one(user.getId());
+			} catch (DataRetrievalFailureException iae) {
+				// ignore
+			}
+		}
 	}
 
 	@Test
 	@IgnoreWhen(clusterTypes = ClusterType.MOCKED)
 	void writeSpring_readSpring() {
-		boolean cleanAfter = false;
-		UserEncrypted user = new UserEncrypted(UUID.randomUUID().toString(), "writeSpring_readSpring", "l", "hello");
+		boolean cleanAfter = true;
+		UserEncrypted user = new UserEncrypted(UUID.randomUUID().toString(), "writeSpring_readSpring", "l", "hel\"lo");
 		AddressWithEncStreet address = new AddressWithEncStreet(); // plaintext address with encrypted street
 		address.setEncStreet("Olcott Street");
 		address.setCity("Santa Clara");
@@ -136,6 +145,7 @@ public class CouchbaseRepositoryFieldLevelEncryptionIntegrationTests extends Clu
 		Address encAddress = new Address(); // encrypted address with plaintext street.
 		encAddress.setStreet("Castro St");
 		encAddress.setCity("Mountain View");
+		encAddress.setTurbulence(ETurbulenceCategory.T10);
 		user.setEncAddress(encAddress);
 
 		user.initSimpleTypes();
@@ -159,8 +169,8 @@ public class CouchbaseRepositoryFieldLevelEncryptionIntegrationTests extends Clu
 	@Test
 	@IgnoreWhen(clusterTypes = ClusterType.MOCKED)
 	void writeSpring_readSDK() {
-		boolean cleanAfter = false;
-		UserEncrypted user = new UserEncrypted(UUID.randomUUID().toString(), "writeSpring_readSDK", "l", "hello");
+		boolean cleanAfter = true;
+		UserEncrypted user = new UserEncrypted(UUID.randomUUID().toString(), "writeSpring_readSDK", "l", "hel\"lo");
 		AddressWithEncStreet address = new AddressWithEncStreet(); // plaintext address with encrypted street
 		address.setEncStreet("Olcott Street");
 		address.setCity("Santa Clara");
@@ -195,8 +205,8 @@ public class CouchbaseRepositoryFieldLevelEncryptionIntegrationTests extends Clu
 	@Test
 	@IgnoreWhen(clusterTypes = ClusterType.MOCKED)
 	void writeSDK_readSpring() {
-		boolean cleanAfter = false;
-		UserEncrypted user = new UserEncrypted(UUID.randomUUID().toString(), "writeSDK_readSpring", "l", "hello");
+		boolean cleanAfter = true;
+		UserEncrypted user = new UserEncrypted(UUID.randomUUID().toString(), "writeSDK_readSpring", "l", "hel\"lo");
 		AddressWithEncStreet address = new AddressWithEncStreet(); // plaintext address with encrypted street
 		address.setEncStreet("Olcott Street");
 		address.setCity("Santa Clara");
@@ -232,8 +242,8 @@ public class CouchbaseRepositoryFieldLevelEncryptionIntegrationTests extends Clu
 	@Test
 	@IgnoreWhen(clusterTypes = ClusterType.MOCKED)
 	void writeSDK_readSDK() {
-		boolean cleanAfter = false;
-		UserEncrypted user = new UserEncrypted(UUID.randomUUID().toString(), "writeSDK_readSDK", "l", "hello");
+		boolean cleanAfter = true;
+		UserEncrypted user = new UserEncrypted(UUID.randomUUID().toString(), "writeSDK_readSDK", "l", "hel\"lo");
 		AddressWithEncStreet address = new AddressWithEncStreet(); // plaintext address with encrypted street
 		address.setEncStreet("Olcott Street");
 		address.setCity("Santa Clara");


### PR DESCRIPTION
The key changes are at lines 141 and 145 of CryptoConverter.

(a) use objectMapper to encode strings instead of just escaping and adding quotes; and
(b) use context.getConverter().writeInternalRoot() to serialize instead of 
 relying on context.read(value).toString()) which relies on the entity object having a toString() that produces json.

Closes #1621.

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATACOUCH).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
