### PR TITLE
Durability via Annotations

### DIFF
--- a/src/main/asciidoc/entity.adoc
+++ b/src/main/asciidoc/entity.adoc
@@ -77,6 +77,9 @@ The `@Id` annotation needs to be present because every document in Couchbase nee
 This key needs to be any string with a length of maximum 250 characters.
 Feel free to use whatever fits your use case, be it a UUID, an email address or anything else.
 
+Writes to Couchbase-Server buckets can optionally be assigned durability requirements; which instruct Couchbase Server to update the specified document on multiple nodes in memory and/or disk locations across the cluster; before considering the write to be committed.
+Default durability requirements can also be configured through the `@Document` annotation.
+For example: `@Document(durabilityLevel = DurabilityLevel.MAJORITY)` will force mutations to be replicated to a majority of the Data Service nodes.
 [[datatypes]]
 == Datatypes and Converters
 

--- a/src/main/asciidoc/template.adoc
+++ b/src/main/asciidoc/template.adoc
@@ -30,7 +30,7 @@ User found = couchbaseTemplate.findById(User.class).one(user.getId());
 ----
 ====
 
-If you wanted to use a custom durability requirement for the `upsert` operation you can chain it in:
+If you wanted to use a custom (by default durability options from the `@Document` annotation will be used) durability requirement for the `upsert` operation you can chain it in:
 
 .Upsert with durability
 ====

--- a/src/main/java/org/springframework/data/couchbase/core/ExecutableInsertByIdOperationSupport.java
+++ b/src/main/java/org/springframework/data/couchbase/core/ExecutableInsertByIdOperationSupport.java
@@ -39,7 +39,8 @@ public class ExecutableInsertByIdOperationSupport implements ExecutableInsertByI
 	public <T> ExecutableInsertById<T> insertById(final Class<T> domainType) {
 		Assert.notNull(domainType, "DomainType must not be null!");
 		return new ExecutableInsertByIdSupport<>(template, domainType, OptionsBuilder.getScopeFrom(domainType),
-				OptionsBuilder.getCollectionFrom(domainType), null, PersistTo.NONE, ReplicateTo.NONE, DurabilityLevel.NONE,
+				OptionsBuilder.getCollectionFrom(domainType), null, OptionsBuilder.getPersistTo(domainType),
+				OptionsBuilder.getReplicateTo(domainType), OptionsBuilder.getDurabilityLevel(domainType),
 				null);
 	}
 

--- a/src/main/java/org/springframework/data/couchbase/core/ExecutableRemoveByIdOperationSupport.java
+++ b/src/main/java/org/springframework/data/couchbase/core/ExecutableRemoveByIdOperationSupport.java
@@ -31,6 +31,7 @@ import com.couchbase.client.java.kv.ReplicateTo;
  * {@link ExecutableRemoveByIdOperation} implementations for Couchbase.
  *
  * @author Michael Reiche
+ * @author Tigran Babloyan
  */
 public class ExecutableRemoveByIdOperationSupport implements ExecutableRemoveByIdOperation {
 
@@ -50,7 +51,8 @@ public class ExecutableRemoveByIdOperationSupport implements ExecutableRemoveByI
 	public ExecutableRemoveById removeById(Class<?> domainType) {
 
 		return new ExecutableRemoveByIdSupport(template, domainType, OptionsBuilder.getScopeFrom(domainType),
-				OptionsBuilder.getCollectionFrom(domainType), null, PersistTo.NONE, ReplicateTo.NONE, DurabilityLevel.NONE,
+				OptionsBuilder.getCollectionFrom(domainType), null, OptionsBuilder.getPersistTo(domainType),
+				OptionsBuilder.getReplicateTo(domainType), OptionsBuilder.getDurabilityLevel(domainType),
 				null);
 	}
 

--- a/src/main/java/org/springframework/data/couchbase/core/ExecutableReplaceByIdOperationSupport.java
+++ b/src/main/java/org/springframework/data/couchbase/core/ExecutableReplaceByIdOperationSupport.java
@@ -39,7 +39,8 @@ public class ExecutableReplaceByIdOperationSupport implements ExecutableReplaceB
 	public <T> ExecutableReplaceById<T> replaceById(final Class<T> domainType) {
 		Assert.notNull(domainType, "DomainType must not be null!");
 		return new ExecutableReplaceByIdSupport<>(template, domainType, OptionsBuilder.getScopeFrom(domainType),
-				OptionsBuilder.getCollectionFrom(domainType), null, PersistTo.NONE, ReplicateTo.NONE, DurabilityLevel.NONE,
+				OptionsBuilder.getCollectionFrom(domainType), null, OptionsBuilder.getPersistTo(domainType),
+				OptionsBuilder.getReplicateTo(domainType), OptionsBuilder.getDurabilityLevel(domainType),
 				null);
 	}
 

--- a/src/main/java/org/springframework/data/couchbase/core/ExecutableUpsertByIdOperationSupport.java
+++ b/src/main/java/org/springframework/data/couchbase/core/ExecutableUpsertByIdOperationSupport.java
@@ -39,7 +39,8 @@ public class ExecutableUpsertByIdOperationSupport implements ExecutableUpsertByI
 	public <T> ExecutableUpsertById<T> upsertById(final Class<T> domainType) {
 		Assert.notNull(domainType, "DomainType must not be null!");
 		return new ExecutableUpsertByIdSupport<>(template, domainType, OptionsBuilder.getScopeFrom(domainType),
-				OptionsBuilder.getCollectionFrom(domainType), null, PersistTo.NONE, ReplicateTo.NONE, DurabilityLevel.NONE,
+				OptionsBuilder.getCollectionFrom(domainType), null, OptionsBuilder.getPersistTo(domainType),
+				OptionsBuilder.getReplicateTo(domainType), OptionsBuilder.getDurabilityLevel(domainType),
 				null);
 	}
 

--- a/src/main/java/org/springframework/data/couchbase/core/ReactiveInsertByIdOperationSupport.java
+++ b/src/main/java/org/springframework/data/couchbase/core/ReactiveInsertByIdOperationSupport.java
@@ -45,6 +45,7 @@ import com.couchbase.client.java.kv.ReplicateTo;
  * {@link ReactiveInsertByIdOperation} implementations for Couchbase.
  *
  * @author Michael Reiche
+ * @author Tigran Babloyan
  */
 public class ReactiveInsertByIdOperationSupport implements ReactiveInsertByIdOperation {
 
@@ -59,7 +60,8 @@ public class ReactiveInsertByIdOperationSupport implements ReactiveInsertByIdOpe
 	public <T> ReactiveInsertById<T> insertById(final Class<T> domainType) {
 		Assert.notNull(domainType, "DomainType must not be null!");
 		return new ReactiveInsertByIdSupport<>(template, domainType, OptionsBuilder.getScopeFrom(domainType),
-				OptionsBuilder.getCollectionFrom(domainType), null, PersistTo.NONE, ReplicateTo.NONE, DurabilityLevel.NONE,
+				OptionsBuilder.getCollectionFrom(domainType), null, OptionsBuilder.getPersistTo(domainType),
+				OptionsBuilder.getReplicateTo(domainType), OptionsBuilder.getDurabilityLevel(domainType),
 				null, template.support());
 	}
 

--- a/src/main/java/org/springframework/data/couchbase/core/ReactiveRemoveByIdOperationSupport.java
+++ b/src/main/java/org/springframework/data/couchbase/core/ReactiveRemoveByIdOperationSupport.java
@@ -46,6 +46,7 @@ import com.couchbase.client.java.kv.ReplicateTo;
  * {@link ReactiveRemoveByIdOperation} implementations for Couchbase.
  *
  * @author Michael Reiche
+ * @author Tigran Babloyan
  */
 public class ReactiveRemoveByIdOperationSupport implements ReactiveRemoveByIdOperation {
 
@@ -65,7 +66,8 @@ public class ReactiveRemoveByIdOperationSupport implements ReactiveRemoveByIdOpe
 	@Override
 	public ReactiveRemoveById removeById(Class<?> domainType) {
 		return new ReactiveRemoveByIdSupport(template, domainType, OptionsBuilder.getScopeFrom(domainType),
-				OptionsBuilder.getCollectionFrom(domainType), null, PersistTo.NONE, ReplicateTo.NONE, DurabilityLevel.NONE,
+				OptionsBuilder.getCollectionFrom(domainType), null, OptionsBuilder.getPersistTo(domainType),
+				OptionsBuilder.getReplicateTo(domainType), OptionsBuilder.getDurabilityLevel(domainType),
 				null);
 	}
 

--- a/src/main/java/org/springframework/data/couchbase/core/ReactiveReplaceByIdOperationSupport.java
+++ b/src/main/java/org/springframework/data/couchbase/core/ReactiveReplaceByIdOperationSupport.java
@@ -48,6 +48,7 @@ import com.couchbase.client.java.kv.ReplicateTo;
  * {@link ReactiveReplaceByIdOperation} implementations for Couchbase.
  *
  * @author Michael Reiche
+ * @author Tigran Babloyan
  */
 public class ReactiveReplaceByIdOperationSupport implements ReactiveReplaceByIdOperation {
 
@@ -62,7 +63,8 @@ public class ReactiveReplaceByIdOperationSupport implements ReactiveReplaceByIdO
 	public <T> ReactiveReplaceById<T> replaceById(final Class<T> domainType) {
 		Assert.notNull(domainType, "DomainType must not be null!");
 		return new ReactiveReplaceByIdSupport<>(template, domainType, OptionsBuilder.getScopeFrom(domainType),
-				OptionsBuilder.getCollectionFrom(domainType), null, PersistTo.NONE, ReplicateTo.NONE, DurabilityLevel.NONE,
+				OptionsBuilder.getCollectionFrom(domainType), null, OptionsBuilder.getPersistTo(domainType),
+				OptionsBuilder.getReplicateTo(domainType), OptionsBuilder.getDurabilityLevel(domainType),
 				null, template.support());
 	}
 

--- a/src/main/java/org/springframework/data/couchbase/core/ReactiveUpsertByIdOperationSupport.java
+++ b/src/main/java/org/springframework/data/couchbase/core/ReactiveUpsertByIdOperationSupport.java
@@ -37,6 +37,7 @@ import com.couchbase.client.java.kv.UpsertOptions;
  * {@link ReactiveUpsertByIdOperation} implementations for Couchbase.
  *
  * @author Michael Reiche
+ * @author Tigran Babloyan
  */
 public class ReactiveUpsertByIdOperationSupport implements ReactiveUpsertByIdOperation {
 
@@ -51,7 +52,8 @@ public class ReactiveUpsertByIdOperationSupport implements ReactiveUpsertByIdOpe
 	public <T> ReactiveUpsertById<T> upsertById(final Class<T> domainType) {
 		Assert.notNull(domainType, "DomainType must not be null!");
 		return new ReactiveUpsertByIdSupport<>(template, domainType, OptionsBuilder.getScopeFrom(domainType),
-				OptionsBuilder.getCollectionFrom(domainType), null, PersistTo.NONE, ReplicateTo.NONE, DurabilityLevel.NONE,
+				OptionsBuilder.getCollectionFrom(domainType), null, OptionsBuilder.getPersistTo(domainType),
+				OptionsBuilder.getReplicateTo(domainType), OptionsBuilder.getDurabilityLevel(domainType),
 				null, template.support());
 	}
 

--- a/src/main/java/org/springframework/data/couchbase/core/mapping/Document.java
+++ b/src/main/java/org/springframework/data/couchbase/core/mapping/Document.java
@@ -23,6 +23,9 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import java.util.concurrent.TimeUnit;
 
+import com.couchbase.client.core.msg.kv.DurabilityLevel;
+import com.couchbase.client.java.kv.PersistTo;
+import com.couchbase.client.java.kv.ReplicateTo;
 import org.springframework.core.annotation.AliasFor;
 import org.springframework.data.annotation.Persistent;
 import org.springframework.data.couchbase.repository.Collection;
@@ -36,6 +39,7 @@ import com.couchbase.client.java.query.QueryScanConsistency;
  *
  * @author Michael Nitschinger
  * @author Andrey Rubtsov
+ * @author Tigran Babloyan
  */
 @Persistent
 @Inherited
@@ -84,4 +88,22 @@ public @interface Document {
 	 */
 	@AliasFor(annotation = ScanConsistency.class, attribute = "query")
 	QueryScanConsistency queryScanConsistency() default QueryScanConsistency.NOT_BOUNDED;
+
+	/**
+	 * How many persisted copies of the modified record must exist on the given document. Default is {@link PersistTo#NONE}. 
+	 * For Couchbase version >= 6.5 see {@link #durabilityLevel()}.
+	 */
+	PersistTo persistTo() default PersistTo.NONE;
+
+	/**
+	 * How many replicas must this documents operations be propagated to. Default is {@link ReplicateTo#NONE}.
+	 * For Couchbase version >= 6.5 see {@link #durabilityLevel()}.
+	 */
+	ReplicateTo replicateTo() default ReplicateTo.NONE;
+
+	/**
+	 * The optional durabilityLevel for all mutating operations, allows the application to wait until this replication
+	 * (or persistence) is successful before proceeding
+	 */
+	DurabilityLevel durabilityLevel() default DurabilityLevel.NONE;
 }

--- a/src/main/java/org/springframework/data/couchbase/core/query/OptionsBuilder.java
+++ b/src/main/java/org/springframework/data/couchbase/core/query/OptionsBuilder.java
@@ -31,6 +31,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.core.annotation.AnnotatedElementUtils;
 import org.springframework.data.couchbase.core.mapping.CouchbaseDocument;
+import org.springframework.data.couchbase.core.mapping.Document;
+import org.springframework.data.couchbase.core.mapping.Expiry;
 import org.springframework.data.couchbase.repository.Collection;
 import org.springframework.data.couchbase.repository.ScanConsistency;
 import org.springframework.data.couchbase.repository.Scope;
@@ -56,6 +58,7 @@ import com.couchbase.client.java.transactions.TransactionQueryOptions;
  * Methods for building Options objects for Couchbae APIs.
  *
  * @author Michael Reiche
+ * @author Tigran Babloyan
  */
 public class OptionsBuilder {
 
@@ -224,6 +227,30 @@ public class OptionsBuilder {
 			return ann.value();
 		}
 		return null;
+	}
+	
+	public static DurabilityLevel getDurabilityLevel(Class<?> domainType) {
+		if (domainType == null) {
+			return DurabilityLevel.NONE;
+		}
+		Document document = AnnotatedElementUtils.findMergedAnnotation(domainType, Document.class);
+		return document != null ? document.durabilityLevel() : DurabilityLevel.NONE;
+	}
+
+	public static PersistTo getPersistTo(Class<?> domainType) {
+		if (domainType == null) {
+			return  PersistTo.NONE;
+		}
+		Document document = AnnotatedElementUtils.findMergedAnnotation(domainType, Document.class);
+		return document != null ? document.persistTo() : PersistTo.NONE;
+	}
+
+	public static ReplicateTo getReplicateTo(Class<?> domainType) {
+		if (domainType == null) {
+			return ReplicateTo.NONE;
+		}
+		Document document = AnnotatedElementUtils.findMergedAnnotation(domainType, Document.class);
+		return document != null ? document.replicateTo() : ReplicateTo.NONE;
 	}
 
 	/**

--- a/src/test/java/org/springframework/data/couchbase/domain/PersonWithDurability.java
+++ b/src/test/java/org/springframework/data/couchbase/domain/PersonWithDurability.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2012-2023 the original author or authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.couchbase.domain;
+
+import com.couchbase.client.java.kv.PersistTo;
+import com.couchbase.client.java.kv.ReplicateTo;
+import org.springframework.data.couchbase.core.mapping.Document;
+
+import java.util.UUID;
+
+/**
+ * Person entity for tests.
+ *
+ * @author Tigran Babloyan
+ */
+@Document(persistTo = PersistTo.ONE, replicateTo = ReplicateTo.ONE)
+public class PersonWithDurability extends Person {
+	public PersonWithDurability() {
+		setId(UUID.randomUUID());
+		setMiddlename("Nick");
+	}
+
+	public PersonWithDurability(String firstname, String lastname) {
+		this();
+		setFirstname(firstname);
+		setLastname(lastname);
+		isNew(true);
+	}
+}

--- a/src/test/java/org/springframework/data/couchbase/domain/PersonWithDurability2.java
+++ b/src/test/java/org/springframework/data/couchbase/domain/PersonWithDurability2.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2012-2023 the original author or authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.couchbase.domain;
+
+import com.couchbase.client.core.msg.kv.DurabilityLevel;
+import com.couchbase.client.java.kv.PersistTo;
+import com.couchbase.client.java.kv.ReplicateTo;
+import org.springframework.data.couchbase.core.mapping.Document;
+
+import java.util.UUID;
+
+/**
+ * Person entity for tests.
+ *
+ * @author Tigran Babloyan
+ */
+@Document(durabilityLevel = DurabilityLevel.MAJORITY)
+public class PersonWithDurability2 extends Person {
+	public PersonWithDurability2() {
+		setId(UUID.randomUUID());
+		setMiddlename("Nick");
+	}
+
+	public PersonWithDurability2(String firstname, String lastname) {
+		this();
+		setFirstname(firstname);
+		setLastname(lastname);
+		isNew(true);
+	}
+}

--- a/src/test/java/org/springframework/data/couchbase/domain/UserAnnotatedDurability.java
+++ b/src/test/java/org/springframework/data/couchbase/domain/UserAnnotatedDurability.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2020-2023 the original author or authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.data.couchbase.domain;
+
+import com.couchbase.client.core.msg.kv.DurabilityLevel;
+import org.springframework.data.couchbase.core.mapping.Document;
+
+import java.io.Serializable;
+
+/**
+ * Annotated User entity for tests
+ *
+ * @author Tigran Babloyan
+ */
+
+@Document(durabilityLevel = DurabilityLevel.MAJORITY)
+public class UserAnnotatedDurability extends User implements Serializable {
+
+	public UserAnnotatedDurability(String id, String firstname, String lastname) {
+		super(id, firstname, lastname);
+	}
+}

--- a/src/test/java/org/springframework/data/couchbase/domain/UserAnnotatedPersistTo.java
+++ b/src/test/java/org/springframework/data/couchbase/domain/UserAnnotatedPersistTo.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2020-2023 the original author or authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.data.couchbase.domain;
+
+import com.couchbase.client.java.kv.PersistTo;
+import com.couchbase.client.java.kv.ReplicateTo;
+import org.springframework.data.couchbase.core.mapping.Document;
+
+import java.io.Serializable;
+
+/**
+ * Annotated User entity for tests
+ *
+ * @author Tigran Babloyan
+ */
+
+@Document(persistTo = PersistTo.ACTIVE)
+public class UserAnnotatedPersistTo extends User implements Serializable {
+
+	public UserAnnotatedPersistTo(String id, String firstname, String lastname) {
+		super(id, firstname, lastname);
+	}
+}

--- a/src/test/java/org/springframework/data/couchbase/domain/UserAnnotatedReplicateTo.java
+++ b/src/test/java/org/springframework/data/couchbase/domain/UserAnnotatedReplicateTo.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2020-2023 the original author or authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.data.couchbase.domain;
+
+import com.couchbase.client.core.msg.kv.DurabilityLevel;
+import com.couchbase.client.java.kv.ReplicateTo;
+import org.springframework.data.couchbase.core.mapping.Document;
+
+import java.io.Serializable;
+
+/**
+ * Annotated User entity for tests
+ *
+ * @author Tigran Babloyan
+ */
+
+@Document(replicateTo = ReplicateTo.ONE)
+public class UserAnnotatedReplicateTo extends User implements Serializable {
+
+	public UserAnnotatedReplicateTo(String id, String firstname, String lastname) {
+		super(id, firstname, lastname);
+	}
+}

--- a/src/test/java/org/springframework/data/couchbase/transactions/CouchbaseTransactionalUnsettableParametersIntegrationTests.java
+++ b/src/test/java/org/springframework/data/couchbase/transactions/CouchbaseTransactionalUnsettableParametersIntegrationTests.java
@@ -31,6 +31,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.couchbase.CouchbaseClientFactory;
 import org.springframework.data.couchbase.core.CouchbaseOperations;
 import org.springframework.data.couchbase.domain.Person;
+import org.springframework.data.couchbase.domain.PersonWithDurability;
+import org.springframework.data.couchbase.domain.PersonWithDurability2;
 import org.springframework.data.couchbase.transaction.error.TransactionSystemUnambiguousException;
 import org.springframework.data.couchbase.util.Capabilities;
 import org.springframework.data.couchbase.util.ClusterType;
@@ -54,6 +56,7 @@ import com.couchbase.client.java.kv.ReplicateTo;
  *
  * @author Graham Pople
  * @author Michael Reiche
+ * @author Tigran Babloyan
  */
 @IgnoreWhen(missesCapabilities = Capabilities.QUERY, clusterTypes = ClusterType.MOCKED)
 @SpringJUnitConfig(classes = { TransactionsConfig.class,
@@ -96,6 +99,14 @@ public class CouchbaseTransactionalUnsettableParametersIntegrationTests extends 
 		});
 	}
 
+	@DisplayName("Using insertById() with Durability set via annotations in a transaction is rejected at runtime")
+	@Test
+	public void insertWithDurabilityAnnotated() {
+		test((ops) -> {
+			ops.insertById(PersonWithDurability.class).one(new PersonWithDurability("Walter", "White"));
+		});
+	}
+
 	@DisplayName("Using insertById().withExpiry in a transaction is rejected at runtime")
 	@Test
 	public void insertWithExpiry() {
@@ -109,6 +120,14 @@ public class CouchbaseTransactionalUnsettableParametersIntegrationTests extends 
 	public void insertWithDurability2() {
 		test((ops) -> {
 			ops.insertById(Person.class).withDurability(DurabilityLevel.MAJORITY).one(WalterWhite);
+		});
+	}
+
+	@DisplayName("Using insertById with Durability set via annotations in a transaction is rejected at runtime")
+	@Test
+	public void insertWithDurabilityAnnotated2() {
+		test((ops) -> {
+			ops.insertById(PersonWithDurability2.class).one(new PersonWithDurability2("Walter", "White"));
 		});
 	}
 
@@ -128,6 +147,14 @@ public class CouchbaseTransactionalUnsettableParametersIntegrationTests extends 
 		});
 	}
 
+	@DisplayName("Using replaceById() with Durability set via annotations in a transaction is rejected at runtime")
+	@Test
+	public void replaceWithAnnotatedDurability() {
+		test((ops) -> {
+			ops.replaceById(PersonWithDurability.class).one(new PersonWithDurability("Walter", "White"));
+		});
+	}
+
 	@DisplayName("Using replaceById().withExpiry in a transaction is rejected at runtime")
 	@Test
 	public void replaceWithExpiry() {
@@ -141,6 +168,14 @@ public class CouchbaseTransactionalUnsettableParametersIntegrationTests extends 
 	public void replaceWithDurability2() {
 		test((ops) -> {
 			ops.replaceById(Person.class).withDurability(DurabilityLevel.MAJORITY).one(WalterWhite);
+		});
+	}
+
+	@DisplayName("Using replaceById() with Durability set via annotations in a transaction is rejected at runtime")
+	@Test
+	public void replaceWithAnnotatedDurability2() {
+		test((ops) -> {
+			ops.replaceById(PersonWithDurability2.class).one(new PersonWithDurability2("Walter", "White"));
 		});
 	}
 
@@ -160,11 +195,27 @@ public class CouchbaseTransactionalUnsettableParametersIntegrationTests extends 
 		});
 	}
 
+	@DisplayName("Using removeById() with Durability set via annotations in a transaction is rejected at runtime")
+	@Test
+	public void removeWithAnnotatedDurability() {
+		test((ops) -> {
+			ops.removeById(PersonWithDurability.class).oneEntity(new PersonWithDurability("Walter", "White"));
+		});
+	}
+
 	@DisplayName("Using removeById().withDurability(durabilityLevel) in a transaction is rejected at runtime")
 	@Test
 	public void removeWithDurability2() {
 		test((ops) -> {
 			ops.removeById(Person.class).withDurability(DurabilityLevel.MAJORITY).oneEntity(WalterWhite);
+		});
+	}
+
+	@DisplayName("Using removeById().withDurability(durabilityLevel) in a transaction is rejected at runtime")
+	@Test
+	public void removeWithAnnotatedDurability2() {
+		test((ops) -> {
+			ops.removeById(PersonWithDurability2.class).oneEntity(new PersonWithDurability2("Walter", "White"));
 		});
 	}
 


### PR DESCRIPTION
Added support of the PersistTo, ReplicateTo, and DurabilityLevel via @Document annotation.

Closes #1486


- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATACOUCH).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
