### PR TITLE
Added support of the read locks

### DIFF
--- a/src/main/java/org/springframework/data/couchbase/core/ExecutableFindByIdOperation.java
+++ b/src/main/java/org/springframework/data/couchbase/core/ExecutableFindByIdOperation.java
@@ -26,11 +26,13 @@ import org.springframework.data.couchbase.core.support.InScope;
 
 import com.couchbase.client.java.kv.GetOptions;
 import org.springframework.data.couchbase.core.support.WithExpiry;
+import org.springframework.data.couchbase.core.support.WithLock;
 
 /**
  * Get Operations
  *
  * @author Christoph Strobl
+ * @author Tigran Babloyan
  * @since 2.0
  */
 public interface ExecutableFindByIdOperation {
@@ -132,11 +134,25 @@ public interface ExecutableFindByIdOperation {
 		FindByIdWithProjection<T> withExpiry(Duration expiry);
 	}
 
+	interface FindByIdWithLock<T> extends FindByIdWithExpiry<T>, WithLock<T> {
+		/**
+		 * Fetches document and write-locks it for the given duration.
+		 * <p>
+		 * Note that the client does not enforce an upper limit on the {@link Duration} lockTime. The maximum lock time
+		 * by default on the server is 30 seconds. Any value larger than 30 seconds will be capped down by the server to
+		 * the default lock time, which is 15 seconds unless modified on the server side.
+		 *
+		 * @param lockDuration how long to write-lock the document for (any duration > 30s will be capped to server default of 15s).
+		 */
+		@Override
+		FindByIdWithExpiry<T> withLock(Duration lockDuration);
+	}
+
 	/**
 	 * Provides methods for constructing query operations in a fluent way.
 	 *
 	 * @param <T> the entity type to use for the results
 	 */
-	interface ExecutableFindById<T> extends FindByIdWithExpiry<T> {}
+	interface ExecutableFindById<T> extends FindByIdWithLock<T> {}
 
 }

--- a/src/main/java/org/springframework/data/couchbase/core/ReactiveFindByIdOperation.java
+++ b/src/main/java/org/springframework/data/couchbase/core/ReactiveFindByIdOperation.java
@@ -25,6 +25,7 @@ import org.springframework.data.couchbase.core.support.InCollection;
 import org.springframework.data.couchbase.core.support.InScope;
 import org.springframework.data.couchbase.core.support.OneAndAllIdReactive;
 import org.springframework.data.couchbase.core.support.WithExpiry;
+import org.springframework.data.couchbase.core.support.WithLock;
 import org.springframework.data.couchbase.core.support.WithGetOptions;
 import org.springframework.data.couchbase.core.support.WithProjectionId;
 
@@ -34,6 +35,7 @@ import com.couchbase.client.java.kv.GetOptions;
  * Get Operations
  *
  * @author Christoph Strobl
+ * @author Tigran Babloyan
  * @since 2.0
  */
 public interface ReactiveFindByIdOperation {
@@ -136,11 +138,25 @@ public interface ReactiveFindByIdOperation {
 		FindByIdWithProjection<T> withExpiry(Duration expiry);
 	}
 
+	interface FindByIdWithLock<T> extends FindByIdWithExpiry<T>, WithLock<T> {
+		/**
+		 * Fetches document and write-locks it for the given duration.
+		 * <p>
+		 * Note that the client does not enforce an upper limit on the {@link Duration} lockTime. The maximum lock time
+		 * by default on the server is 30 seconds. Any value larger than 30 seconds will be capped down by the server to
+		 * the default lock time, which is 15 seconds unless modified on the server side.
+		 *
+		 * @param lockDuration how long to write-lock the document for (any duration > 30s will be capped to server default of 15s).
+		 */
+		@Override
+		FindByIdWithExpiry<T> withLock(Duration lockDuration);
+	}
+
 	/**
 	 * Provides methods for constructing query operations in a fluent way.
 	 *
 	 * @param <T> the entity type to use for the results
 	 */
-	interface ReactiveFindById<T> extends FindByIdWithExpiry<T> {}
+	interface ReactiveFindById<T> extends FindByIdWithLock<T> {}
 
 }

--- a/src/main/java/org/springframework/data/couchbase/core/support/WithLock.java
+++ b/src/main/java/org/springframework/data/couchbase/core/support/WithLock.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2020-2023 the original author or authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.couchbase.core.support;
+
+import java.time.Duration;
+
+/**
+ * A common interface for those that support withLock()
+ *
+ * @author Tigran Babloyan
+ * @param <R> - the entity class
+ */
+public interface WithLock<R> {
+	Object withLock(Duration lockDuration);
+
+}


### PR DESCRIPTION
Added support of the read locks via `withLock()` operation chaining. 


closes #1059

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATACOUCH).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
