### PR TITLE
Move duplicate code in QueryCriteria to new method.

### DIFF
--- a/src/main/java/org/springframework/data/couchbase/core/query/QueryCriteria.java
+++ b/src/main/java/org/springframework/data/couchbase/core/query/QueryCriteria.java
@@ -38,6 +38,7 @@ import com.couchbase.client.java.json.JsonValue;
  * @author Michael Nitschinger
  * @author Michael Reiche
  * @author Mauro Monti
+ * @author Shubham Mishra
  */
 public class QueryCriteria implements QueryCriteriaDefinition {
 
@@ -148,13 +149,7 @@ public class QueryCriteria implements QueryCriteriaDefinition {
 	}
 
 	public QueryCriteria and(QueryCriteria criteria) {
-		if (this.criteriaChain != null && !this.criteriaChain.contains(this)) {
-			throw new RuntimeException("criteria chain does not include this");
-		}
-		if (this.criteriaChain == null) {
-			this.criteriaChain = new LinkedList<>();
-			this.criteriaChain.add(this);
-		}
+		checkAndAddToCriteriaChain();
 		QueryCriteria newThis = wrap(this);
 		QueryCriteria qc = wrap(criteria);
 		newThis.criteriaChain.add(qc);
@@ -189,13 +184,7 @@ public class QueryCriteria implements QueryCriteriaDefinition {
 	}
 
 	public QueryCriteria or(QueryCriteria criteria) {
-		if (this.criteriaChain != null && !this.criteriaChain.contains(this)) {
-			throw new RuntimeException("criteria chain does not include this");
-		}
-		if (this.criteriaChain == null) {
-			this.criteriaChain = new LinkedList<>();
-			this.criteriaChain.add(this);
-		}
+		checkAndAddToCriteriaChain();
 		QueryCriteria newThis = wrap(this);
 		QueryCriteria qc = wrap(criteria);
 		qc.criteriaChain = newThis.criteriaChain;
@@ -718,5 +707,15 @@ public class QueryCriteria implements QueryCriteriaDefinition {
 		}
 		sb.append("}");
 		return sb.toString();
+	}
+
+	private void checkAndAddToCriteriaChain() {
+		if (this.criteriaChain != null && !this.criteriaChain.contains(this)) {
+			throw new RuntimeException("criteria chain does not include this");
+		}
+		if (this.criteriaChain == null) {
+			this.criteriaChain = new LinkedList<>();
+			this.criteriaChain.add(this);
+		}
 	}
 }


### PR DESCRIPTION
Issue #1707. I extracted duplicated code fragment into a new method "private void checkAndAddToCriteriaChain()". The previous test cases are working and there is no need to add new cased as I did only refactoring. 

<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATACOUCH).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
