### PR TITLE
Register Couchbase Types with Conversion Services.

### DIFF
--- a/src/main/java/org/springframework/data/couchbase/core/convert/CouchbaseCustomConversions.java
+++ b/src/main/java/org/springframework/data/couchbase/core/convert/CouchbaseCustomConversions.java
@@ -40,6 +40,7 @@ import org.springframework.data.convert.PropertyValueConverterFactory;
 import org.springframework.data.convert.PropertyValueConverterRegistrar;
 import org.springframework.data.convert.SimplePropertyValueConversions;
 import org.springframework.data.couchbase.core.mapping.CouchbasePersistentProperty;
+import org.springframework.data.couchbase.core.mapping.CouchbaseSimpleTypes;
 import org.springframework.data.mapping.PersistentProperty;
 import org.springframework.data.mapping.model.SimpleTypeHolder;
 import org.springframework.util.Assert;
@@ -54,7 +55,8 @@ import org.springframework.util.Assert;
  * @author Oliver Gierke
  * @author Mark Paluch
  * @author Subhashni Balakrishnan
- * @Michael Reiche
+ * @author Michael Reiche
+ * @author Tigran Babloyan
  * @see org.springframework.data.convert.CustomConversions
  * @see SimpleTypeHolder
  * @since 2.0
@@ -74,7 +76,7 @@ public class CouchbaseCustomConversions extends org.springframework.data.convert
 		converters.addAll(OtherConverters.getConvertersToRegister());
 
 		STORE_CONVERTERS = Collections.unmodifiableList(converters);
-		STORE_CONVERSIONS = StoreConversions.of(SimpleTypeHolder.DEFAULT, STORE_CONVERTERS);
+		STORE_CONVERSIONS = StoreConversions.of(CouchbaseSimpleTypes.DOCUMENT_TYPES, STORE_CONVERTERS);
 	}
 
 	/**


### PR DESCRIPTION
Register CouchbaseDocument and CouchbaseList as simple types (datastore supported) to get rid of conversation warning messages.

Closes #1700.

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATACOUCH).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
