### PR TITLE
Expression Based Durability Levels

### DIFF
--- a/src/main/asciidoc/entity.adoc
+++ b/src/main/asciidoc/entity.adoc
@@ -78,8 +78,8 @@ This key needs to be any string with a length of maximum 250 characters.
 Feel free to use whatever fits your use case, be it a UUID, an email address or anything else.
 
 Writes to Couchbase-Server buckets can optionally be assigned durability requirements; which instruct Couchbase Server to update the specified document on multiple nodes in memory and/or disk locations across the cluster; before considering the write to be committed.
-Default durability requirements can also be configured through the `@Document` annotation.
-For example: `@Document(durabilityLevel = DurabilityLevel.MAJORITY)` will force mutations to be replicated to a majority of the Data Service nodes.
+Default durability requirements can also be configured through the `@Document` or `@Durability` annotations.
+For example: `@Document(durabilityLevel = DurabilityLevel.MAJORITY)` will force mutations to be replicated to a majority of the Data Service nodes. Both of the annotations support expression based durability level assignment via `durabilityExpression` attribute (Note SPEL is not supported).
 [[datatypes]]
 == Datatypes and Converters
 

--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -1,10 +1,10 @@
 = Spring Data Couchbase - Reference Documentation
-Michael Nitschinger, Oliver Gierke, Simon Basle, Michael Reiche
+Michael Nitschinger, Oliver Gierke, Simon Basle, Michael Reiche, Tigran Babloyan
 :revnumber: {version}
 :revdate: {localdate}
 :spring-data-commons-docs: ../../../../spring-data-commons/src/main/asciidoc
 
-(C) 2014-2022 The original author(s).
+(C) 2014-2023 The original author(s).
 
 NOTE: Copies of this document may be made for your own use and for distribution to others, provided that you do not charge any fee for such copies and further provided that each copy contains this Copyright Notice, whether distributed in print or electronically.
 

--- a/src/main/java/org/springframework/data/couchbase/core/ExecutableInsertByIdOperationSupport.java
+++ b/src/main/java/org/springframework/data/couchbase/core/ExecutableInsertByIdOperationSupport.java
@@ -40,7 +40,7 @@ public class ExecutableInsertByIdOperationSupport implements ExecutableInsertByI
 		Assert.notNull(domainType, "DomainType must not be null!");
 		return new ExecutableInsertByIdSupport<>(template, domainType, OptionsBuilder.getScopeFrom(domainType),
 				OptionsBuilder.getCollectionFrom(domainType), null, OptionsBuilder.getPersistTo(domainType),
-				OptionsBuilder.getReplicateTo(domainType), OptionsBuilder.getDurabilityLevel(domainType),
+				OptionsBuilder.getReplicateTo(domainType), OptionsBuilder.getDurabilityLevel(domainType, template.getConverter()),
 				null);
 	}
 

--- a/src/main/java/org/springframework/data/couchbase/core/ExecutableMutateInByIdOperationSupport.java
+++ b/src/main/java/org/springframework/data/couchbase/core/ExecutableMutateInByIdOperationSupport.java
@@ -51,7 +51,7 @@ public class ExecutableMutateInByIdOperationSupport implements ExecutableMutateI
 		Assert.notNull(domainType, "DomainType must not be null!");
 		return new ExecutableMutateInByIdSupport(template, domainType, OptionsBuilder.getScopeFrom(domainType),
 				OptionsBuilder.getCollectionFrom(domainType), null, OptionsBuilder.getPersistTo(domainType),
-				OptionsBuilder.getReplicateTo(domainType), OptionsBuilder.getDurabilityLevel(domainType),
+				OptionsBuilder.getReplicateTo(domainType), OptionsBuilder.getDurabilityLevel(domainType, template.getConverter()),
 				null, Collections.emptyList(), Collections.emptyList(), Collections.emptyList(),
 				Collections.emptyList(), false);
 	}

--- a/src/main/java/org/springframework/data/couchbase/core/ExecutableRemoveByIdOperationSupport.java
+++ b/src/main/java/org/springframework/data/couchbase/core/ExecutableRemoveByIdOperationSupport.java
@@ -52,7 +52,7 @@ public class ExecutableRemoveByIdOperationSupport implements ExecutableRemoveByI
 
 		return new ExecutableRemoveByIdSupport(template, domainType, OptionsBuilder.getScopeFrom(domainType),
 				OptionsBuilder.getCollectionFrom(domainType), null, OptionsBuilder.getPersistTo(domainType),
-				OptionsBuilder.getReplicateTo(domainType), OptionsBuilder.getDurabilityLevel(domainType),
+				OptionsBuilder.getReplicateTo(domainType), OptionsBuilder.getDurabilityLevel(domainType, template.getConverter()),
 				null);
 	}
 

--- a/src/main/java/org/springframework/data/couchbase/core/ExecutableReplaceByIdOperationSupport.java
+++ b/src/main/java/org/springframework/data/couchbase/core/ExecutableReplaceByIdOperationSupport.java
@@ -40,7 +40,7 @@ public class ExecutableReplaceByIdOperationSupport implements ExecutableReplaceB
 		Assert.notNull(domainType, "DomainType must not be null!");
 		return new ExecutableReplaceByIdSupport<>(template, domainType, OptionsBuilder.getScopeFrom(domainType),
 				OptionsBuilder.getCollectionFrom(domainType), null, OptionsBuilder.getPersistTo(domainType),
-				OptionsBuilder.getReplicateTo(domainType), OptionsBuilder.getDurabilityLevel(domainType),
+				OptionsBuilder.getReplicateTo(domainType), OptionsBuilder.getDurabilityLevel(domainType, template.getConverter()),
 				null);
 	}
 

--- a/src/main/java/org/springframework/data/couchbase/core/ExecutableUpsertByIdOperationSupport.java
+++ b/src/main/java/org/springframework/data/couchbase/core/ExecutableUpsertByIdOperationSupport.java
@@ -40,7 +40,7 @@ public class ExecutableUpsertByIdOperationSupport implements ExecutableUpsertByI
 		Assert.notNull(domainType, "DomainType must not be null!");
 		return new ExecutableUpsertByIdSupport<>(template, domainType, OptionsBuilder.getScopeFrom(domainType),
 				OptionsBuilder.getCollectionFrom(domainType), null, OptionsBuilder.getPersistTo(domainType),
-				OptionsBuilder.getReplicateTo(domainType), OptionsBuilder.getDurabilityLevel(domainType),
+				OptionsBuilder.getReplicateTo(domainType), OptionsBuilder.getDurabilityLevel(domainType, template.getConverter()),
 				null);
 	}
 

--- a/src/main/java/org/springframework/data/couchbase/core/ReactiveInsertByIdOperationSupport.java
+++ b/src/main/java/org/springframework/data/couchbase/core/ReactiveInsertByIdOperationSupport.java
@@ -61,7 +61,7 @@ public class ReactiveInsertByIdOperationSupport implements ReactiveInsertByIdOpe
 		Assert.notNull(domainType, "DomainType must not be null!");
 		return new ReactiveInsertByIdSupport<>(template, domainType, OptionsBuilder.getScopeFrom(domainType),
 				OptionsBuilder.getCollectionFrom(domainType), null, OptionsBuilder.getPersistTo(domainType),
-				OptionsBuilder.getReplicateTo(domainType), OptionsBuilder.getDurabilityLevel(domainType),
+				OptionsBuilder.getReplicateTo(domainType), OptionsBuilder.getDurabilityLevel(domainType, template.getConverter()),
 				null, template.support());
 	}
 

--- a/src/main/java/org/springframework/data/couchbase/core/ReactiveMutateInByIdOperationSupport.java
+++ b/src/main/java/org/springframework/data/couchbase/core/ReactiveMutateInByIdOperationSupport.java
@@ -52,7 +52,7 @@ public class ReactiveMutateInByIdOperationSupport implements ReactiveMutateInByI
 		Assert.notNull(domainType, "DomainType must not be null!");
 		return new ReactiveMutateInByIdSupport<>(template, domainType, OptionsBuilder.getScopeFrom(domainType),
 				OptionsBuilder.getCollectionFrom(domainType), null, OptionsBuilder.getPersistTo(domainType),
-				OptionsBuilder.getReplicateTo(domainType), OptionsBuilder.getDurabilityLevel(domainType),
+				OptionsBuilder.getReplicateTo(domainType), OptionsBuilder.getDurabilityLevel(domainType, template.getConverter()),
 				null, template.support(), Collections.emptyList(), Collections.emptyList(), Collections.emptyList(),
 				Collections.emptyList(), false);
 	}

--- a/src/main/java/org/springframework/data/couchbase/core/ReactiveRemoveByIdOperationSupport.java
+++ b/src/main/java/org/springframework/data/couchbase/core/ReactiveRemoveByIdOperationSupport.java
@@ -67,7 +67,7 @@ public class ReactiveRemoveByIdOperationSupport implements ReactiveRemoveByIdOpe
 	public ReactiveRemoveById removeById(Class<?> domainType) {
 		return new ReactiveRemoveByIdSupport(template, domainType, OptionsBuilder.getScopeFrom(domainType),
 				OptionsBuilder.getCollectionFrom(domainType), null, OptionsBuilder.getPersistTo(domainType),
-				OptionsBuilder.getReplicateTo(domainType), OptionsBuilder.getDurabilityLevel(domainType),
+				OptionsBuilder.getReplicateTo(domainType), OptionsBuilder.getDurabilityLevel(domainType, template.getConverter()),
 				null);
 	}
 

--- a/src/main/java/org/springframework/data/couchbase/core/ReactiveReplaceByIdOperationSupport.java
+++ b/src/main/java/org/springframework/data/couchbase/core/ReactiveReplaceByIdOperationSupport.java
@@ -64,7 +64,7 @@ public class ReactiveReplaceByIdOperationSupport implements ReactiveReplaceByIdO
 		Assert.notNull(domainType, "DomainType must not be null!");
 		return new ReactiveReplaceByIdSupport<>(template, domainType, OptionsBuilder.getScopeFrom(domainType),
 				OptionsBuilder.getCollectionFrom(domainType), null, OptionsBuilder.getPersistTo(domainType),
-				OptionsBuilder.getReplicateTo(domainType), OptionsBuilder.getDurabilityLevel(domainType),
+				OptionsBuilder.getReplicateTo(domainType), OptionsBuilder.getDurabilityLevel(domainType, template.getConverter()),
 				null, template.support());
 	}
 

--- a/src/main/java/org/springframework/data/couchbase/core/ReactiveUpsertByIdOperationSupport.java
+++ b/src/main/java/org/springframework/data/couchbase/core/ReactiveUpsertByIdOperationSupport.java
@@ -53,7 +53,7 @@ public class ReactiveUpsertByIdOperationSupport implements ReactiveUpsertByIdOpe
 		Assert.notNull(domainType, "DomainType must not be null!");
 		return new ReactiveUpsertByIdSupport<>(template, domainType, OptionsBuilder.getScopeFrom(domainType),
 				OptionsBuilder.getCollectionFrom(domainType), null, OptionsBuilder.getPersistTo(domainType),
-				OptionsBuilder.getReplicateTo(domainType), OptionsBuilder.getDurabilityLevel(domainType),
+				OptionsBuilder.getReplicateTo(domainType), OptionsBuilder.getDurabilityLevel(domainType, template.getConverter()),
 				null, template.support());
 	}
 

--- a/src/main/java/org/springframework/data/couchbase/core/mapping/CouchbasePersistentEntity.java
+++ b/src/main/java/org/springframework/data/couchbase/core/mapping/CouchbasePersistentEntity.java
@@ -18,6 +18,7 @@ package org.springframework.data.couchbase.core.mapping;
 
 import java.time.Duration;
 
+import com.couchbase.client.core.msg.kv.DurabilityLevel;
 import org.springframework.data.mapping.PersistentEntity;
 
 /**
@@ -25,6 +26,7 @@ import org.springframework.data.mapping.PersistentEntity;
  *
  * @author Michael Nitschinger
  * @author Michael Reiche
+ * @author Tigran Babloyan
  */
 public interface CouchbasePersistentEntity<T> extends PersistentEntity<T, CouchbasePersistentProperty> {
 
@@ -53,6 +55,15 @@ public interface CouchbasePersistentEntity<T> extends PersistentEntity<T, Couchb
 	 * @return the expiration time Duration
 	 */
 	Duration getExpiryDuration();
+
+	/**
+	 * Returns the durability level of the entity.
+	 * <p>
+	 * Allows the application to wait until this replication (or persistence) is successful before proceeding
+	 *
+	 * @return the durability level.
+	 */
+	DurabilityLevel getDurabilityLevel();
 
 	/**
 	 * Flag for using getAndTouch operations for reads, resetting the expiration (if one was set) when the entity is

--- a/src/main/java/org/springframework/data/couchbase/core/mapping/Document.java
+++ b/src/main/java/org/springframework/data/couchbase/core/mapping/Document.java
@@ -47,6 +47,7 @@ import com.couchbase.client.java.query.QueryScanConsistency;
 @Target({ ElementType.TYPE })
 @Expiry
 @ScanConsistency
+@Durability
 public @interface Document {
 
 	/**
@@ -105,5 +106,16 @@ public @interface Document {
 	 * The optional durabilityLevel for all mutating operations, allows the application to wait until this replication
 	 * (or persistence) is successful before proceeding
 	 */
+	@AliasFor(annotation = Durability.class, attribute = "durabilityLevel")
 	DurabilityLevel durabilityLevel() default DurabilityLevel.NONE;
+
+	/**
+	 * Same as {@link #durabilityLevel()} but allows the actual value to be set using standard Spring property sources mechanism.
+	 * Only one might be set at the same time: either {@link #durabilityLevel()} or {@link #durabilityExpression()}. <br />
+	 * Syntax is the same as for {@link org.springframework.core.env.Environment#resolveRequiredPlaceholders(String)}.
+	 * <br />
+	 * SpEL is NOT supported.
+	 */
+	@AliasFor(annotation = Durability.class, attribute = "durabilityExpression")
+	String durabilityExpression() default "";
 }

--- a/src/main/java/org/springframework/data/couchbase/core/mapping/Durability.java
+++ b/src/main/java/org/springframework/data/couchbase/core/mapping/Durability.java
@@ -1,0 +1,32 @@
+package org.springframework.data.couchbase.core.mapping;
+
+import com.couchbase.client.core.msg.kv.DurabilityLevel;
+import org.springframework.data.annotation.Persistent;
+
+import java.lang.annotation.*;
+
+/**
+ * Durability annotation
+ *
+ * @author Tigran Babloyan
+ */
+@Persistent
+@Inherited
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.TYPE, ElementType.ANNOTATION_TYPE })
+public @interface Durability {
+    /**
+     * The optional durabilityLevel for all mutating operations, allows the application to wait until this replication
+     * (or persistence) is successful before proceeding
+     */
+    DurabilityLevel durabilityLevel() default DurabilityLevel.NONE;
+
+    /**
+     * Same as {@link #durabilityLevel()} but allows the actual value to be set using standard Spring property sources mechanism.
+     * Only one might be set at the same time: either {@link #durabilityLevel()} or {@link #durabilityExpression()}. <br />
+     * Syntax is the same as for {@link org.springframework.core.env.Environment#resolveRequiredPlaceholders(String)}.
+     * <br />
+     * SpEL is NOT supported.
+     */
+    String durabilityExpression() default "";
+}

--- a/src/main/java/org/springframework/data/couchbase/core/query/OptionsBuilder.java
+++ b/src/main/java/org/springframework/data/couchbase/core/query/OptionsBuilder.java
@@ -35,7 +35,9 @@ import com.couchbase.client.core.error.InvalidArgumentException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.core.annotation.AnnotatedElementUtils;
+import org.springframework.data.couchbase.core.convert.CouchbaseConverter;
 import org.springframework.data.couchbase.core.mapping.CouchbaseDocument;
+import org.springframework.data.couchbase.core.mapping.CouchbasePersistentEntity;
 import org.springframework.data.couchbase.core.mapping.Document;
 import org.springframework.data.couchbase.repository.Collection;
 import org.springframework.data.couchbase.repository.ScanConsistency;
@@ -284,12 +286,14 @@ public class OptionsBuilder {
 		return null;
 	}
 	
-	public static DurabilityLevel getDurabilityLevel(Class<?> domainType) {
+	public static DurabilityLevel getDurabilityLevel(Class<?> domainType, CouchbaseConverter converter) {
 		if (domainType == null) {
 			return DurabilityLevel.NONE;
 		}
-		Document document = AnnotatedElementUtils.findMergedAnnotation(domainType, Document.class);
-		return document != null ? document.durabilityLevel() : DurabilityLevel.NONE;
+		final CouchbasePersistentEntity<?> entity = converter.getMappingContext()
+				.getRequiredPersistentEntity(domainType);
+
+		return entity.getDurabilityLevel();
 	}
 
 	public static PersistTo getPersistTo(Class<?> domainType) {

--- a/src/test/java/org/springframework/data/couchbase/core/mapping/BasicCouchbasePersistentEntityTests.java
+++ b/src/test/java/org/springframework/data/couchbase/core/mapping/BasicCouchbasePersistentEntityTests.java
@@ -23,6 +23,7 @@ import java.util.Calendar;
 import java.util.TimeZone;
 import java.util.concurrent.TimeUnit;
 
+import com.couchbase.client.core.msg.kv.DurabilityLevel;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Configuration;
@@ -33,7 +34,8 @@ import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
 @SpringJUnitConfig
-@TestPropertySource(properties = { "valid.document.expiry = 10", "invalid.document.expiry = abc" })
+@TestPropertySource(properties = { "valid.document.expiry = 10", "invalid.document.expiry = abc",
+		"invalid.document.durability = some", "valid.document.durability = MAJORITY" })
 public class BasicCouchbasePersistentEntityTests {
 
 	@Autowired ConfigurableEnvironment environment;
@@ -180,6 +182,34 @@ public class BasicCouchbasePersistentEntityTests {
 				() -> getBasicCouchbasePersistentEntity(ExpiryAndExpression.class).getExpiry());
 	}
 
+	@Test
+	void doesNotAllowUseDurabilityAndExpressionSimultaneously() {
+		assertThrows(IllegalArgumentException.class,
+				() -> getBasicCouchbasePersistentEntity(DurabilityAndExpression.class).getDurabilityLevel());
+	}
+
+	@Test
+	void failsIfDurabilityExpressionMissesRequiredProperty() {
+		assertThrows(IllegalArgumentException.class,
+				() -> getBasicCouchbasePersistentEntity(DurabilityWithMissingProperty.class).getDurabilityLevel());
+	}
+
+	@Test
+	void doesNotAllowUseDurabilityFromInvalidExpression() {
+		assertThrows(IllegalArgumentException.class,
+				() -> getBasicCouchbasePersistentEntity(DurabilityWithInvalidExpression.class).getDurabilityLevel());
+	}
+
+	@Test
+	void usesGetDurabilityExpression() {
+		assertThat(getBasicCouchbasePersistentEntity(ConstantDurabilityExpression.class).getDurabilityLevel()).isEqualTo(DurabilityLevel.MAJORITY);
+	}
+
+	@Test
+	void usesGetDurabilityFromValidExpression() {
+		assertThat(getBasicCouchbasePersistentEntity(DurabilityWithValidExpression.class).getDurabilityLevel()).isEqualTo(DurabilityLevel.MAJORITY);
+	}
+
 	private BasicCouchbasePersistentEntity getBasicCouchbasePersistentEntity(Class<?> clazz) {
 		BasicCouchbasePersistentEntity basicCouchbasePersistentEntity = new BasicCouchbasePersistentEntity(
 				ClassTypeInformation.from(clazz));
@@ -263,5 +293,35 @@ public class BasicCouchbasePersistentEntityTests {
 	 */
 	@Document(expiry = 10, expiryExpression = "10")
 	class ExpiryAndExpression {}
+
+	/**
+	 * Simple POJO to test that durability and durability expression cannot be used simultaneously
+	 */
+	@Document(durabilityLevel = DurabilityLevel.MAJORITY, durabilityExpression = "MAJORITY")
+	class DurabilityAndExpression {}
+
+	/**
+	 * Simple POJO to test durability expression logic failure to resolve property placeholder
+	 */
+	@Document(durabilityExpression = "${missing.durability}")
+	class DurabilityWithMissingProperty {}
+
+	/**
+	 * Simple POJO to test invalid durability expression
+	 */
+	@Document(durabilityExpression = "${invalid.document.durability}")
+	class DurabilityWithInvalidExpression {}
+
+	/**
+	 * Simple POJO to test constant expiry expression
+	 */
+	@Document(durabilityExpression = "MAJORITY")
+	class ConstantDurabilityExpression {}
+
+	/**
+	 * Simple POJO to test valid expiry expression by resolving simple property from environment
+	 */
+	@Document(durabilityExpression = "${valid.document.durability}")
+	class DurabilityWithValidExpression {}
 
 }

--- a/src/test/java/org/springframework/data/couchbase/domain/UserAnnotatedDurabilityExpression.java
+++ b/src/test/java/org/springframework/data/couchbase/domain/UserAnnotatedDurabilityExpression.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2020-2023 the original author or authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.data.couchbase.domain;
+
+import com.couchbase.client.core.msg.kv.DurabilityLevel;
+import org.springframework.data.couchbase.core.mapping.Document;
+
+import java.io.Serializable;
+
+/**
+ * Annotated User entity for tests
+ *
+ * @author Tigran Babloyan
+ */
+
+@Document(durabilityExpression = "${valid.document.durability}")
+public class UserAnnotatedDurabilityExpression extends User implements Serializable {
+
+	public UserAnnotatedDurabilityExpression(String id, String firstname, String lastname) {
+		super(id, firstname, lastname);
+	}
+}


### PR DESCRIPTION
Added `@Durability` annotation and added support for expression-based durability levels.
Currently, `@Durability`  can not be set via annotating the insert/update methods and repositories, so only Document level durability assignment works.

Closes #1063.


- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATACOUCH).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
