### PR TITLE
Allow template.save() to find if it is in a transaction.

### DIFF
--- a/src/main/java/org/springframework/data/couchbase/core/ReactiveCouchbaseTemplate.java
+++ b/src/main/java/org/springframework/data/couchbase/core/ReactiveCouchbaseTemplate.java
@@ -80,7 +80,7 @@ public class ReactiveCouchbaseTemplate implements ReactiveCouchbaseOperations, A
 		
 		String scope = scopeAndCollection.length > 0 ? scopeAndCollection[0] : null;
 		String collection = scopeAndCollection.length > 1 ? scopeAndCollection[1] : null;
-		return Mono.defer(() -> {
+		return Mono.deferContextual( ctx1 -> {
 			final CouchbasePersistentEntity<?> mapperEntity = getConverter().getMappingContext()
 					.getPersistentEntity(entity.getClass());
 			final CouchbasePersistentProperty versionProperty = mapperEntity.getVersionProperty();


### PR DESCRIPTION
Closes #1757.

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATACOUCH).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
