### PR TITLE
Non-reactive template.save() use non-reactive auditor and close clusters

### DIFF
--- a/src/test/java/org/springframework/data/couchbase/cache/CouchbaseCacheCollectionIntegrationTests.java
+++ b/src/test/java/org/springframework/data/couchbase/cache/CouchbaseCacheCollectionIntegrationTests.java
@@ -24,10 +24,15 @@ import java.util.UUID;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.couchbase.core.CouchbaseTemplate;
 import org.springframework.data.couchbase.util.Capabilities;
 import org.springframework.data.couchbase.util.ClusterType;
 import org.springframework.data.couchbase.util.CollectionAwareIntegrationTests;
 import org.springframework.data.couchbase.util.IgnoreWhen;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+import org.springframework.data.couchbase.domain.Config;
 
 /**
  * CouchbaseCache tests Theses tests rely on a cb server running.
@@ -35,9 +40,13 @@ import org.springframework.data.couchbase.util.IgnoreWhen;
  * @author Michael Reiche
  */
 @IgnoreWhen(clusterTypes = ClusterType.MOCKED, missesCapabilities = { Capabilities.COLLECTIONS })
+@SpringJUnitConfig(Config.class)
+@DirtiesContext
 class CouchbaseCacheCollectionIntegrationTests extends CollectionAwareIntegrationTests {
 
 	volatile CouchbaseCache cache;
+
+    @Autowired CouchbaseTemplate couchbaseTemplate;
 
 	@BeforeEach
 	@Override

--- a/src/test/java/org/springframework/data/couchbase/cache/CouchbaseCacheIntegrationTests.java
+++ b/src/test/java/org/springframework/data/couchbase/cache/CouchbaseCacheIntegrationTests.java
@@ -26,14 +26,14 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.ApplicationContext;
-import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.data.couchbase.core.CouchbaseTemplate;
 import org.springframework.data.couchbase.domain.Config;
 import org.springframework.data.couchbase.domain.User;
 import org.springframework.data.couchbase.domain.UserRepository;
 import org.springframework.data.couchbase.util.ClusterType;
 import org.springframework.data.couchbase.util.IgnoreWhen;
 import org.springframework.data.couchbase.util.JavaIntegrationTests;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
 /**
@@ -43,11 +43,13 @@ import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
  */
 @IgnoreWhen(clusterTypes = ClusterType.MOCKED)
 @SpringJUnitConfig(Config.class)
+@DirtiesContext
 class CouchbaseCacheIntegrationTests extends JavaIntegrationTests {
 
 	volatile CouchbaseCache cache;
 	@Autowired CouchbaseCacheManager cacheManager; // autowired not working
 	@Autowired UserRepository userRepository; // autowired not working
+    @Autowired CouchbaseTemplate couchbaseTemplate;
 
 	@BeforeEach
 	@Override
@@ -56,9 +58,6 @@ class CouchbaseCacheIntegrationTests extends JavaIntegrationTests {
 		cache = CouchbaseCacheManager.create(couchbaseTemplate.getCouchbaseClientFactory()).createCouchbaseCache("myCache",
 				CouchbaseCacheConfiguration.defaultCacheConfig());
 		cache.clear();
-		ApplicationContext ac = new AnnotationConfigApplicationContext(Config.class);
-		cacheManager = ac.getBean(CouchbaseCacheManager.class);
-		userRepository = ac.getBean(UserRepository.class);
 	}
 
 	@AfterEach
@@ -134,5 +133,4 @@ class CouchbaseCacheIntegrationTests extends JavaIntegrationTests {
 
 	@Test
 	public void noOpt() {}
-
 }

--- a/src/test/java/org/springframework/data/couchbase/core/CouchbaseTemplateKeyValueIntegrationTests.java
+++ b/src/test/java/org/springframework/data/couchbase/core/CouchbaseTemplateKeyValueIntegrationTests.java
@@ -40,6 +40,7 @@ import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.dao.DuplicateKeyException;
 import org.springframework.dao.InvalidDataAccessResourceUsageException;
 import org.springframework.dao.OptimisticLockingFailureException;
@@ -69,6 +70,7 @@ import org.springframework.data.couchbase.domain.UserSubmission;
 import org.springframework.data.couchbase.util.ClusterType;
 import org.springframework.data.couchbase.util.IgnoreWhen;
 import org.springframework.data.couchbase.util.JavaIntegrationTests;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
@@ -93,6 +95,7 @@ import com.couchbase.client.java.query.QueryScanConsistency;
  */
 @IgnoreWhen(clusterTypes = ClusterType.MOCKED)
 @SpringJUnitConfig(Config.class)
+@DirtiesContext
 @TestPropertySource(properties = { "valid.document.durability = MAJORITY" })
 class CouchbaseTemplateKeyValueIntegrationTests extends JavaIntegrationTests {
 
@@ -102,6 +105,7 @@ class CouchbaseTemplateKeyValueIntegrationTests extends JavaIntegrationTests {
 	@BeforeEach
 	@Override
 	public void beforeEach() {
+		super.beforeEach();
 		couchbaseTemplate.removeByQuery(User.class).all();
 		couchbaseTemplate.removeByQuery(UserAnnotated.class).all();
 		couchbaseTemplate.removeByQuery(UserAnnotated2.class).all();
@@ -1337,11 +1341,9 @@ class CouchbaseTemplateKeyValueIntegrationTests extends JavaIntegrationTests {
 
 	}
 
-
 	private void sleepSecs(int i) {
 		try {
 			Thread.sleep(i * 1000);
 		} catch (InterruptedException ie) {}
 	}
-
 }

--- a/src/test/java/org/springframework/data/couchbase/core/CouchbaseTemplateQueryCollectionIntegrationTests.java
+++ b/src/test/java/org/springframework/data/couchbase/core/CouchbaseTemplateQueryCollectionIntegrationTests.java
@@ -43,8 +43,8 @@ import org.springframework.data.couchbase.core.query.Query;
 import org.springframework.data.couchbase.core.query.QueryCriteria;
 import org.springframework.data.couchbase.domain.Address;
 import org.springframework.data.couchbase.domain.Airport;
-import org.springframework.data.couchbase.domain.CollectionsConfig;
 import org.springframework.data.couchbase.domain.Course;
+import org.springframework.data.couchbase.domain.ConfigScoped;
 import org.springframework.data.couchbase.domain.NaiveAuditorAware;
 import org.springframework.data.couchbase.domain.Submission;
 import org.springframework.data.couchbase.domain.User;
@@ -57,6 +57,7 @@ import org.springframework.data.couchbase.util.Capabilities;
 import org.springframework.data.couchbase.util.ClusterType;
 import org.springframework.data.couchbase.util.CollectionAwareIntegrationTests;
 import org.springframework.data.couchbase.util.IgnoreWhen;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
 import com.couchbase.client.core.error.AmbiguousTimeoutException;
@@ -80,7 +81,8 @@ import com.couchbase.client.java.query.QueryOptions;
  * @author Michael Reiche
  */
 @IgnoreWhen(missesCapabilities = { Capabilities.QUERY, Capabilities.COLLECTIONS }, clusterTypes = ClusterType.MOCKED)
-@SpringJUnitConfig(CollectionsConfig.class)
+@SpringJUnitConfig(ConfigScoped.class)
+@DirtiesContext
 class CouchbaseTemplateQueryCollectionIntegrationTests extends CollectionAwareIntegrationTests {
 
 	@Autowired public CouchbaseTemplate couchbaseTemplate;

--- a/src/test/java/org/springframework/data/couchbase/core/CouchbaseTemplateQueryIntegrationTests.java
+++ b/src/test/java/org/springframework/data/couchbase/core/CouchbaseTemplateQueryIntegrationTests.java
@@ -38,13 +38,14 @@ import java.util.stream.Collectors;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.data.couchbase.core.query.Query;
 import org.springframework.data.couchbase.core.query.QueryCriteria;
 import org.springframework.data.couchbase.domain.Address;
 import org.springframework.data.couchbase.domain.Airport;
 import org.springframework.data.couchbase.domain.AssessmentDO;
-import org.springframework.data.couchbase.domain.Config;
 import org.springframework.data.couchbase.domain.Course;
+import org.springframework.data.couchbase.domain.Config;
 import org.springframework.data.couchbase.domain.NaiveAuditorAware;
 import org.springframework.data.couchbase.domain.PersonWithMaps;
 import org.springframework.data.couchbase.domain.Submission;
@@ -60,6 +61,7 @@ import org.springframework.data.couchbase.util.JavaIntegrationTests;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
 /**
@@ -72,6 +74,7 @@ import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
  */
 @IgnoreWhen(missesCapabilities = Capabilities.QUERY, clusterTypes = ClusterType.MOCKED)
 @SpringJUnitConfig(Config.class)
+@DirtiesContext
 class CouchbaseTemplateQueryIntegrationTests extends JavaIntegrationTests {
 
 	@Autowired public CouchbaseTemplate couchbaseTemplate;

--- a/src/test/java/org/springframework/data/couchbase/core/CustomTypeKeyIntegrationTests.java
+++ b/src/test/java/org/springframework/data/couchbase/core/CustomTypeKeyIntegrationTests.java
@@ -24,15 +24,14 @@ import java.util.UUID;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.data.couchbase.CouchbaseClientFactory;
 import org.springframework.data.couchbase.config.AbstractCouchbaseConfiguration;
 import org.springframework.data.couchbase.core.convert.DefaultCouchbaseTypeMapper;
 import org.springframework.data.couchbase.domain.User;
-import org.springframework.data.couchbase.repository.config.EnableCouchbaseRepositories;
 import org.springframework.data.couchbase.util.ClusterAwareIntegrationTests;
 import org.springframework.data.couchbase.util.ClusterType;
 import org.springframework.data.couchbase.util.IgnoreWhen;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
 import com.couchbase.client.core.deps.io.netty.handler.ssl.util.InsecureTrustManagerFactory;
@@ -45,6 +44,7 @@ import com.couchbase.client.java.kv.GetResult;
  */
 @SpringJUnitConfig(CustomTypeKeyIntegrationTests.Config.class)
 @IgnoreWhen(clusterTypes = ClusterType.MOCKED)
+@DirtiesContext
 public class CustomTypeKeyIntegrationTests extends ClusterAwareIntegrationTests {
 
 	private static final String CUSTOM_TYPE_KEY = "javaClass";
@@ -70,43 +70,11 @@ public class CustomTypeKeyIntegrationTests extends ClusterAwareIntegrationTests 
 		operations.removeById(User.class).one(user.getId());
 	}
 
-	@Configuration
-	@EnableCouchbaseRepositories("org.springframework.data.couchbase")
-	static class Config extends AbstractCouchbaseConfiguration {
-
-		@Override
-		public String getConnectionString() {
-			return connectionString();
-		}
-
-		@Override
-		public String getUserName() {
-			return config().adminUsername();
-		}
-
-		@Override
-		public String getPassword() {
-			return config().adminPassword();
-		}
-
-		@Override
-		public String getBucketName() {
-			return bucketName();
-		}
-
-		@Override
-		protected void configureEnvironment(ClusterEnvironment.Builder builder) {
-			if (config().isUsingCloud()) {
-				builder.securityConfig(
-						SecurityConfig.builder().trustManagerFactory(InsecureTrustManagerFactory.INSTANCE).enableTls(true));
-			}
-		}
-
+	static class Config extends org.springframework.data.couchbase.domain.Config {
 		@Override
 		public String typeKey() {
 			return CUSTOM_TYPE_KEY;
 		}
-
 	}
 
 }

--- a/src/test/java/org/springframework/data/couchbase/core/ReactiveCouchbaseTemplateConcurrencyTests.java
+++ b/src/test/java/org/springframework/data/couchbase/core/ReactiveCouchbaseTemplateConcurrencyTests.java
@@ -1,20 +1,21 @@
 package org.springframework.data.couchbase.core;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import java.util.concurrent.Semaphore;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.couchbase.core.support.PseudoArgs;
 import org.springframework.data.couchbase.domain.Config;
 import org.springframework.data.couchbase.util.ClusterType;
 import org.springframework.data.couchbase.util.IgnoreWhen;
-
-import org.junit.jupiter.api.Test;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
-import org.springframework.beans.factory.annotation.Autowired;
-
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
 @IgnoreWhen(clusterTypes = ClusterType.MOCKED)
 @SpringJUnitConfig(Config.class)
+@DirtiesContext
 public class ReactiveCouchbaseTemplateConcurrencyTests {
 
     @Autowired public CouchbaseTemplate couchbaseTemplate;

--- a/src/test/java/org/springframework/data/couchbase/core/ReactiveCouchbaseTemplateKeyValueIntegrationTests.java
+++ b/src/test/java/org/springframework/data/couchbase/core/ReactiveCouchbaseTemplateKeyValueIntegrationTests.java
@@ -28,15 +28,19 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.time.Duration;
-import java.util.*;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
 
-import com.couchbase.client.core.error.TimeoutException;
-import com.couchbase.client.core.msg.kv.DurabilityLevel;
-import com.couchbase.client.core.retry.RetryReason;
-import com.couchbase.client.java.query.QueryScanConsistency;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.dao.DuplicateKeyException;
 import org.springframework.dao.InvalidDataAccessResourceUsageException;
 import org.springframework.dao.OptimisticLockingFailureException;
@@ -47,14 +51,31 @@ import org.springframework.data.couchbase.core.support.OneAndAllEntityReactive;
 import org.springframework.data.couchbase.core.support.OneAndAllIdReactive;
 import org.springframework.data.couchbase.core.support.WithDurability;
 import org.springframework.data.couchbase.core.support.WithExpiry;
-import org.springframework.data.couchbase.domain.*;
+import org.springframework.data.couchbase.domain.Address;
+import org.springframework.data.couchbase.domain.Config;
+import org.springframework.data.couchbase.domain.MutableUser;
+import org.springframework.data.couchbase.domain.PersonValue;
+import org.springframework.data.couchbase.domain.ReactiveNaiveAuditorAware;
+import org.springframework.data.couchbase.domain.User;
+import org.springframework.data.couchbase.domain.UserAnnotated;
+import org.springframework.data.couchbase.domain.UserAnnotated2;
+import org.springframework.data.couchbase.domain.UserAnnotated3;
+import org.springframework.data.couchbase.domain.UserAnnotatedDurability;
+import org.springframework.data.couchbase.domain.UserAnnotatedPersistTo;
+import org.springframework.data.couchbase.domain.UserAnnotatedReplicateTo;
+import org.springframework.data.couchbase.repository.config.EnableCouchbaseRepositories;
 import org.springframework.data.couchbase.util.ClusterType;
 import org.springframework.data.couchbase.util.IgnoreWhen;
 import org.springframework.data.couchbase.util.JavaIntegrationTests;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
+import com.couchbase.client.core.error.TimeoutException;
+import com.couchbase.client.core.msg.kv.DurabilityLevel;
+import com.couchbase.client.core.retry.RetryReason;
 import com.couchbase.client.java.kv.PersistTo;
 import com.couchbase.client.java.kv.ReplicateTo;
+import com.couchbase.client.java.query.QueryScanConsistency;
 
 /**
  * KV tests Theses tests rely on a cb server running.
@@ -65,6 +86,7 @@ import com.couchbase.client.java.kv.ReplicateTo;
  */
 @IgnoreWhen(clusterTypes = ClusterType.MOCKED)
 @SpringJUnitConfig(Config.class)
+@DirtiesContext
 class ReactiveCouchbaseTemplateKeyValueIntegrationTests extends JavaIntegrationTests {
 
 	@Autowired public CouchbaseTemplate couchbaseTemplate;

--- a/src/test/java/org/springframework/data/couchbase/core/query/ReactiveCouchbaseTemplateQueryCollectionIntegrationTests.java
+++ b/src/test/java/org/springframework/data/couchbase/core/query/ReactiveCouchbaseTemplateQueryCollectionIntegrationTests.java
@@ -38,12 +38,13 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.data.couchbase.core.CouchbaseTemplate;
 import org.springframework.data.couchbase.core.ReactiveCouchbaseTemplate;
 import org.springframework.data.couchbase.core.RemoveResult;
 import org.springframework.data.couchbase.domain.Address;
 import org.springframework.data.couchbase.domain.Airport;
-import org.springframework.data.couchbase.domain.CollectionsConfig;
+import org.springframework.data.couchbase.domain.ConfigScoped;
 import org.springframework.data.couchbase.domain.Course;
 import org.springframework.data.couchbase.domain.NaiveAuditorAware;
 import org.springframework.data.couchbase.domain.Submission;
@@ -52,10 +53,12 @@ import org.springframework.data.couchbase.domain.UserJustLastName;
 import org.springframework.data.couchbase.domain.UserSubmission;
 import org.springframework.data.couchbase.domain.UserSubmissionProjected;
 import org.springframework.data.couchbase.domain.time.AuditingDateTimeProvider;
+import org.springframework.data.couchbase.repository.config.EnableReactiveCouchbaseRepositories;
 import org.springframework.data.couchbase.util.Capabilities;
 import org.springframework.data.couchbase.util.ClusterType;
 import org.springframework.data.couchbase.util.CollectionAwareIntegrationTests;
 import org.springframework.data.couchbase.util.IgnoreWhen;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
 import com.couchbase.client.core.error.AmbiguousTimeoutException;
@@ -78,7 +81,8 @@ import com.couchbase.client.java.query.QueryOptions;
  * @author Michael Reiche
  */
 @IgnoreWhen(missesCapabilities = { Capabilities.QUERY, Capabilities.COLLECTIONS }, clusterTypes = ClusterType.MOCKED)
-@SpringJUnitConfig(CollectionsConfig.class)
+@SpringJUnitConfig(ConfigScoped.class)
+@DirtiesContext
 class ReactiveCouchbaseTemplateQueryCollectionIntegrationTests extends CollectionAwareIntegrationTests {
 
 	@Autowired public CouchbaseTemplate couchbaseTemplate;

--- a/src/test/java/org/springframework/data/couchbase/domain/ConfigScoped.java
+++ b/src/test/java/org/springframework/data/couchbase/domain/ConfigScoped.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2012-2023 the original author or authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.data.couchbase.domain;
+
+/**
+ * @author Michael Reiche
+ */
+public class ConfigScoped extends Config{
+    @Override
+    protected java.lang.String getScopeName() {
+        return "my_scope";
+    }
+}

--- a/src/test/java/org/springframework/data/couchbase/domain/PersonWithoutVersion.java
+++ b/src/test/java/org/springframework/data/couchbase/domain/PersonWithoutVersion.java
@@ -46,4 +46,25 @@ public class PersonWithoutVersion extends AbstractEntity {
 		this.lastname = Optional.of(lastname);
 		setId(id);
 	}
+
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("PersonWithoutVersion : {\n");
+        sb.append("  id : " + getId());
+        sb.append(optional(", firstname", firstname));
+        sb.append(optional(", lastname", lastname));
+        sb.append("\n}");
+        return sb.toString();
+    }
+
+    static String optional(String name, Optional<String> obj) {
+        if (obj != null) {
+            if (obj.isPresent()) {
+                return ("  " + name + ": '" + obj.get() + "'");
+            } else {
+                return "  " + name + ": null";
+            }
+        }
+        return "";
+    }
 }

--- a/src/test/java/org/springframework/data/couchbase/repository/CouchbaseAbstractRepositoryIntegrationTests.java
+++ b/src/test/java/org/springframework/data/couchbase/repository/CouchbaseAbstractRepositoryIntegrationTests.java
@@ -39,6 +39,7 @@ import org.springframework.data.couchbase.repository.config.EnableCouchbaseRepos
 import org.springframework.data.couchbase.util.ClusterAwareIntegrationTests;
 import org.springframework.data.couchbase.util.ClusterType;
 import org.springframework.data.couchbase.util.IgnoreWhen;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
 import com.couchbase.client.core.deps.io.netty.handler.ssl.util.InsecureTrustManagerFactory;
@@ -51,6 +52,7 @@ import com.couchbase.client.java.env.ClusterEnvironment;
  * @author Michael Reiche
  */
 @SpringJUnitConfig(CouchbaseAbstractRepositoryIntegrationTests.Config.class)
+@DirtiesContext
 @IgnoreWhen(clusterTypes = ClusterType.MOCKED)
 public class CouchbaseAbstractRepositoryIntegrationTests extends ClusterAwareIntegrationTests {
 
@@ -108,38 +110,7 @@ public class CouchbaseAbstractRepositoryIntegrationTests extends ClusterAwareInt
 
 	}
 
-	@Configuration
-	@EnableCouchbaseRepositories("org.springframework.data.couchbase")
-	static class Config extends AbstractCouchbaseConfiguration {
-
-		@Override
-		public String getConnectionString() {
-			return connectionString();
-		}
-
-		@Override
-		public String getUserName() {
-			return config().adminUsername();
-		}
-
-		@Override
-		public String getPassword() {
-			return config().adminPassword();
-		}
-
-		@Override
-		public String getBucketName() {
-			return bucketName();
-		}
-
-		@Override
-		protected void configureEnvironment(ClusterEnvironment.Builder builder) {
-			if (config().isUsingCloud()) {
-				builder.securityConfig(
-						SecurityConfig.builder().trustManagerFactory(InsecureTrustManagerFactory.INSTANCE).enableTls(true));
-			}
-		}
-
+	static class Config extends org.springframework.data.couchbase.domain.Config {
 		/**
 		 * This uses a CustomMappingCouchbaseConverter instead of MappingCouchbaseConverter, which in turn uses
 		 * AbstractTypeMapper which has special mapping for AbstractUser

--- a/src/test/java/org/springframework/data/couchbase/repository/CouchbaseRepositoryAutoQueryIndexIntegrationTests.java
+++ b/src/test/java/org/springframework/data/couchbase/repository/CouchbaseRepositoryAutoQueryIndexIntegrationTests.java
@@ -32,12 +32,14 @@ import org.springframework.data.couchbase.util.Capabilities;
 import org.springframework.data.couchbase.util.ClusterAwareIntegrationTests;
 import org.springframework.data.couchbase.util.ClusterType;
 import org.springframework.data.couchbase.util.IgnoreWhen;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
 import com.couchbase.client.java.Cluster;
 import com.couchbase.client.java.manager.query.QueryIndex;
 
 @SpringJUnitConfig(CouchbaseRepositoryAutoQueryIndexIntegrationTests.Config.class)
+@DirtiesContext
 @IgnoreWhen(missesCapabilities = Capabilities.QUERY, clusterTypes = ClusterType.MOCKED)
 public class CouchbaseRepositoryAutoQueryIndexIntegrationTests extends ClusterAwareIntegrationTests {
 

--- a/src/test/java/org/springframework/data/couchbase/repository/CouchbaseRepositoryFieldLevelEncryptionIntegrationTests.java
+++ b/src/test/java/org/springframework/data/couchbase/repository/CouchbaseRepositoryFieldLevelEncryptionIntegrationTests.java
@@ -42,10 +42,10 @@ import org.springframework.data.couchbase.domain.ETurbulenceCategory;
 import org.springframework.data.couchbase.domain.TestEncrypted;
 import org.springframework.data.couchbase.domain.UserEncrypted;
 import org.springframework.data.couchbase.domain.UserEncryptedRepository;
-import org.springframework.data.couchbase.repository.config.EnableCouchbaseRepositories;
 import org.springframework.data.couchbase.util.ClusterAwareIntegrationTests;
 import org.springframework.data.couchbase.util.ClusterType;
 import org.springframework.data.couchbase.util.IgnoreWhen;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
 import com.couchbase.client.core.deps.io.netty.handler.ssl.util.InsecureTrustManagerFactory;
@@ -66,6 +66,7 @@ import com.fasterxml.jackson.datatype.joda.JodaModule;
  * @author Michael Reiche
  */
 @SpringJUnitConfig(CouchbaseRepositoryFieldLevelEncryptionIntegrationTests.Config.class)
+@DirtiesContext
 @IgnoreWhen(clusterTypes = ClusterType.MOCKED)
 public class CouchbaseRepositoryFieldLevelEncryptionIntegrationTests extends ClusterAwareIntegrationTests {
 
@@ -329,43 +330,13 @@ public class CouchbaseRepositoryFieldLevelEncryptionIntegrationTests extends Clu
 		}
 	}
 
-	@Configuration
-	@EnableCouchbaseRepositories("org.springframework.data.couchbase")
-	static class Config extends AbstractCouchbaseConfiguration {
-
-		@Override
-		public String getConnectionString() {
-			return connectionString();
-		}
-
-		@Override
-		public String getUserName() {
-			return config().adminUsername();
-		}
-
-		@Override
-		public String getPassword() {
-			return config().adminPassword();
-		}
-
-		@Override
-		public String getBucketName() {
-			return bucketName();
-		}
+	static class Config extends org.springframework.data.couchbase.domain.Config {
 
 		@Override
 		public ObjectMapper couchbaseObjectMapper() {
 			ObjectMapper om = super.couchbaseObjectMapper();
 			om.registerModule(new JodaModule()); // to test joda mapping
 			return om;
-		}
-
-		@Override
-		protected void configureEnvironment(ClusterEnvironment.Builder builder) {
-			if (config().isUsingCloud()) {
-				builder.securityConfig(
-						SecurityConfig.builder().trustManagerFactory(InsecureTrustManagerFactory.INSTANCE).enableTls(true));
-			}
 		}
 
 		@Override

--- a/src/test/java/org/springframework/data/couchbase/repository/CouchbaseRepositoryKeyValueIntegrationTests.java
+++ b/src/test/java/org/springframework/data/couchbase/repository/CouchbaseRepositoryKeyValueIntegrationTests.java
@@ -41,6 +41,7 @@ import org.springframework.data.couchbase.core.CouchbaseTemplate;
 import org.springframework.data.couchbase.domain.Airline;
 import org.springframework.data.couchbase.domain.AirlineRepository;
 import org.springframework.data.couchbase.domain.Course;
+import org.springframework.data.couchbase.domain.Config;
 import org.springframework.data.couchbase.domain.Library;
 import org.springframework.data.couchbase.domain.LibraryRepository;
 import org.springframework.data.couchbase.domain.PersonValue;
@@ -52,10 +53,10 @@ import org.springframework.data.couchbase.domain.User;
 import org.springframework.data.couchbase.domain.UserRepository;
 import org.springframework.data.couchbase.domain.UserSubmission;
 import org.springframework.data.couchbase.domain.UserSubmissionRepository;
-import org.springframework.data.couchbase.repository.config.EnableCouchbaseRepositories;
 import org.springframework.data.couchbase.util.ClusterAwareIntegrationTests;
 import org.springframework.data.couchbase.util.ClusterType;
 import org.springframework.data.couchbase.util.IgnoreWhen;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
 import com.couchbase.client.core.deps.io.netty.handler.ssl.util.InsecureTrustManagerFactory;
@@ -69,7 +70,8 @@ import com.couchbase.client.java.kv.GetResult;
  * @author Michael Nitschinger
  * @author Michael Reiche
  */
-@SpringJUnitConfig(CouchbaseRepositoryKeyValueIntegrationTests.Config.class)
+@SpringJUnitConfig(Config.class)
+@DirtiesContext
 @IgnoreWhen(clusterTypes = ClusterType.MOCKED)
 public class CouchbaseRepositoryKeyValueIntegrationTests extends ClusterAwareIntegrationTests {
 
@@ -196,39 +198,6 @@ public class CouchbaseRepositoryKeyValueIntegrationTests extends ClusterAwareInt
 		assertEquals(user.getCourses().get(0).getId(), found.get().getCourses().get(0).getId());
 		assertEquals(user, found.get());
 		userSubmissionRepository.delete(user);
-	}
-
-	@Configuration
-	@EnableCouchbaseRepositories("org.springframework.data.couchbase")
-	static class Config extends AbstractCouchbaseConfiguration {
-
-		@Override
-		public String getConnectionString() {
-			return connectionString();
-		}
-
-		@Override
-		public String getUserName() {
-			return config().adminUsername();
-		}
-
-		@Override
-		public String getPassword() {
-			return config().adminPassword();
-		}
-
-		@Override
-		public String getBucketName() {
-			return bucketName();
-		}
-
-		@Override
-		protected void configureEnvironment(ClusterEnvironment.Builder builder) {
-			if (config().isUsingCloud()) {
-				builder.securityConfig(
-						SecurityConfig.builder().trustManagerFactory(InsecureTrustManagerFactory.INSTANCE).enableTls(true));
-			}
-		}
 	}
 
 }

--- a/src/test/java/org/springframework/data/couchbase/repository/ReactiveCouchbaseRepositoryKeyValueIntegrationTests.java
+++ b/src/test/java/org/springframework/data/couchbase/repository/ReactiveCouchbaseRepositoryKeyValueIntegrationTests.java
@@ -34,6 +34,7 @@ import org.springframework.data.auditing.DateTimeProvider;
 import org.springframework.data.couchbase.config.AbstractCouchbaseConfiguration;
 import org.springframework.data.couchbase.domain.Airline;
 import org.springframework.data.couchbase.domain.Airport;
+import org.springframework.data.couchbase.domain.Config;
 import org.springframework.data.couchbase.domain.ReactiveAirlineRepository;
 import org.springframework.data.couchbase.domain.ReactiveAirportRepository;
 import org.springframework.data.couchbase.domain.ReactiveNaiveAuditorAware;
@@ -45,6 +46,7 @@ import org.springframework.data.couchbase.repository.config.EnableReactiveCouchb
 import org.springframework.data.couchbase.util.ClusterAwareIntegrationTests;
 import org.springframework.data.couchbase.util.ClusterType;
 import org.springframework.data.couchbase.util.IgnoreWhen;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
 import com.couchbase.client.core.deps.io.netty.handler.ssl.util.InsecureTrustManagerFactory;
@@ -54,7 +56,8 @@ import com.couchbase.client.java.env.ClusterEnvironment;
 /**
  * @author Michael Reiche
  */
-@SpringJUnitConfig(ReactiveCouchbaseRepositoryKeyValueIntegrationTests.Config.class)
+@SpringJUnitConfig(Config.class)
+@DirtiesContext
 @IgnoreWhen(clusterTypes = ClusterType.MOCKED)
 public class ReactiveCouchbaseRepositoryKeyValueIntegrationTests extends ClusterAwareIntegrationTests {
 
@@ -115,51 +118,6 @@ public class ReactiveCouchbaseRepositoryKeyValueIntegrationTests extends Cluster
 		} finally {
 			reactiveAirportRepository.delete(vie).block();
 		}
-	}
-
-	@Configuration
-	@EnableReactiveCouchbaseRepositories("org.springframework.data.couchbase")
-	@EnableReactiveCouchbaseAuditing(dateTimeProviderRef = "dateTimeProviderRef")
-	static class Config extends AbstractCouchbaseConfiguration {
-
-		@Override
-		public String getConnectionString() {
-			return connectionString();
-		}
-
-		@Override
-		public String getUserName() {
-			return config().adminUsername();
-		}
-
-		@Override
-		public String getPassword() {
-			return config().adminPassword();
-		}
-
-		@Override
-		public String getBucketName() {
-			return bucketName();
-		}
-
-		@Override
-		protected void configureEnvironment(ClusterEnvironment.Builder builder) {
-			if (config().isUsingCloud()) {
-				builder.securityConfig(
-						SecurityConfig.builder().trustManagerFactory(InsecureTrustManagerFactory.INSTANCE).enableTls(true));
-			}
-		}
-
-		@Bean(name = "auditorAwareRef")
-		public ReactiveNaiveAuditorAware testAuditorAware() {
-			return new ReactiveNaiveAuditorAware();
-		}
-
-		@Bean(name = "dateTimeProviderRef")
-		public DateTimeProvider testDateTimeProvider() {
-			return new AuditingDateTimeProvider();
-		}
-
 	}
 
 }

--- a/src/test/java/org/springframework/data/couchbase/repository/ReactiveCouchbaseRepositoryQueryIntegrationTests.java
+++ b/src/test/java/org/springframework/data/couchbase/repository/ReactiveCouchbaseRepositoryQueryIntegrationTests.java
@@ -22,6 +22,8 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import org.springframework.data.couchbase.domain.Config;
+import org.springframework.test.annotation.DirtiesContext;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
@@ -66,7 +68,8 @@ import com.couchbase.client.java.env.ClusterEnvironment;
  * @author Michael Nitschinger
  * @author Michael Reiche
  */
-@SpringJUnitConfig(ReactiveCouchbaseRepositoryQueryIntegrationTests.Config.class)
+@SpringJUnitConfig(Config.class)
+@DirtiesContext
 @IgnoreWhen(missesCapabilities = Capabilities.QUERY, clusterTypes = ClusterType.MOCKED)
 public class ReactiveCouchbaseRepositoryQueryIntegrationTests extends JavaIntegrationTests {
 
@@ -292,39 +295,6 @@ public class ReactiveCouchbaseRepositoryQueryIntegrationTests extends JavaIntegr
 			reactiveAirportRepository.findAll().as(StepVerifier::create).verifyComplete();
 		} finally {
 			reactiveAirportRepository.deleteAll().block();
-		}
-	}
-
-	@Configuration
-	@EnableReactiveCouchbaseRepositories("org.springframework.data.couchbase")
-	static class Config extends AbstractCouchbaseConfiguration {
-
-		@Override
-		public String getConnectionString() {
-			return connectionString();
-		}
-
-		@Override
-		public String getUserName() {
-			return config().adminUsername();
-		}
-
-		@Override
-		public String getPassword() {
-			return config().adminPassword();
-		}
-
-		@Override
-		public String getBucketName() {
-			return bucketName();
-		}
-
-		@Override
-		protected void configureEnvironment(ClusterEnvironment.Builder builder) {
-			if (config().isUsingCloud()) {
-				builder.securityConfig(
-						SecurityConfig.builder().trustManagerFactory(InsecureTrustManagerFactory.INSTANCE).enableTls(true));
-			}
 		}
 	}
 

--- a/src/test/java/org/springframework/data/couchbase/repository/query/CouchbaseRepositoryQueryCollectionIntegrationTests.java
+++ b/src/test/java/org/springframework/data/couchbase/repository/query/CouchbaseRepositoryQueryCollectionIntegrationTests.java
@@ -30,6 +30,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.dao.DataRetrievalFailureException;
 import org.springframework.data.couchbase.core.CouchbaseTemplate;
 import org.springframework.data.couchbase.core.ReactiveCouchbaseTemplate;
@@ -39,7 +40,7 @@ import org.springframework.data.couchbase.domain.AddressAnnotated;
 import org.springframework.data.couchbase.domain.Airport;
 import org.springframework.data.couchbase.domain.AirportRepository;
 import org.springframework.data.couchbase.domain.AirportRepositoryAnnotated;
-import org.springframework.data.couchbase.domain.CollectionsConfig;
+import org.springframework.data.couchbase.domain.ConfigScoped;
 import org.springframework.data.couchbase.domain.User;
 import org.springframework.data.couchbase.domain.UserCol;
 import org.springframework.data.couchbase.domain.UserColRepository;
@@ -51,6 +52,7 @@ import org.springframework.data.couchbase.util.Capabilities;
 import org.springframework.data.couchbase.util.ClusterType;
 import org.springframework.data.couchbase.util.CollectionAwareIntegrationTests;
 import org.springframework.data.couchbase.util.IgnoreWhen;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
 import com.couchbase.client.core.error.IndexFailureException;
@@ -64,7 +66,8 @@ import com.couchbase.client.java.query.QueryOptions;
  * @author Michael Reiche
  */
 @IgnoreWhen(missesCapabilities = { Capabilities.QUERY, Capabilities.COLLECTIONS }, clusterTypes = ClusterType.MOCKED)
-@SpringJUnitConfig(CollectionsConfig.class)
+@SpringJUnitConfig(ConfigScoped.class)
+@DirtiesContext
 public class CouchbaseRepositoryQueryCollectionIntegrationTests extends CollectionAwareIntegrationTests {
 
 	@Autowired AirportRepositoryAnnotated airportRepositoryAnnotated;

--- a/src/test/java/org/springframework/data/couchbase/repository/query/ReactiveCouchbaseRepositoryQueryCollectionIntegrationTests.java
+++ b/src/test/java/org/springframework/data/couchbase/repository/query/ReactiveCouchbaseRepositoryQueryCollectionIntegrationTests.java
@@ -30,7 +30,7 @@ import org.springframework.dao.DataRetrievalFailureException;
 import org.springframework.data.couchbase.core.CouchbaseTemplate;
 import org.springframework.data.couchbase.core.ReactiveCouchbaseTemplate;
 import org.springframework.data.couchbase.domain.Airport;
-import org.springframework.data.couchbase.domain.CollectionsConfig;
+import org.springframework.data.couchbase.domain.ConfigScoped;;
 import org.springframework.data.couchbase.domain.ReactiveAirportRepository;
 import org.springframework.data.couchbase.domain.ReactiveAirportRepositoryAnnotated;
 import org.springframework.data.couchbase.domain.ReactiveUserColRepository;
@@ -40,6 +40,7 @@ import org.springframework.data.couchbase.util.Capabilities;
 import org.springframework.data.couchbase.util.ClusterType;
 import org.springframework.data.couchbase.util.CollectionAwareIntegrationTests;
 import org.springframework.data.couchbase.util.IgnoreWhen;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
 import com.couchbase.client.core.error.IndexFailureException;
@@ -53,8 +54,9 @@ import com.couchbase.client.java.query.QueryScanConsistency;
  *
  * @author Michael Reiche
  */
-@SpringJUnitConfig(CollectionsConfig.class)
+@SpringJUnitConfig(ConfigScoped.class)
 @IgnoreWhen(missesCapabilities = { Capabilities.QUERY, Capabilities.COLLECTIONS }, clusterTypes = ClusterType.MOCKED)
+@DirtiesContext
 public class ReactiveCouchbaseRepositoryQueryCollectionIntegrationTests extends CollectionAwareIntegrationTests {
 
 	@Autowired ReactiveAirportRepository reactiveAirportRepository;

--- a/src/test/java/org/springframework/data/couchbase/repository/query/StringN1qlQueryCreatorIntegrationTests.java
+++ b/src/test/java/org/springframework/data/couchbase/repository/query/StringN1qlQueryCreatorIntegrationTests.java
@@ -22,11 +22,8 @@ import java.util.Optional;
 import java.util.Properties;
 import java.util.UUID;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.annotation.Configuration;
-import org.springframework.data.couchbase.config.AbstractCouchbaseConfiguration;
 import org.springframework.data.couchbase.core.CouchbaseTemplate;
 import org.springframework.data.couchbase.core.ExecutableFindByQueryOperation.ExecutableFindByQuery;
 import org.springframework.data.couchbase.core.convert.CouchbaseConverter;
@@ -34,8 +31,8 @@ import org.springframework.data.couchbase.core.mapping.CouchbasePersistentEntity
 import org.springframework.data.couchbase.core.mapping.CouchbasePersistentProperty;
 import org.springframework.data.couchbase.core.query.Query;
 import org.springframework.data.couchbase.domain.Airline;
+import org.springframework.data.couchbase.domain.Config;
 import org.springframework.data.couchbase.domain.AirlineRepository;
-import org.springframework.data.couchbase.repository.config.EnableCouchbaseRepositories;
 import org.springframework.data.couchbase.util.Capabilities;
 import org.springframework.data.couchbase.util.ClusterAwareIntegrationTests;
 import org.springframework.data.couchbase.util.ClusterType;
@@ -51,28 +48,24 @@ import org.springframework.data.repository.query.Parameters;
 import org.springframework.data.repository.query.ParametersParameterAccessor;
 import org.springframework.data.repository.query.QueryMethodEvaluationContextProvider;
 import org.springframework.expression.spel.standard.SpelExpressionParser;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
-import com.couchbase.client.core.deps.io.netty.handler.ssl.util.InsecureTrustManagerFactory;
-import com.couchbase.client.core.env.SecurityConfig;
-import com.couchbase.client.java.env.ClusterEnvironment;
 import com.couchbase.client.java.query.QueryScanConsistency;
 
 /**
  * @author Michael Nitschinger
  * @author Michael Reiche
  */
-@SpringJUnitConfig(StringN1qlQueryCreatorIntegrationTests.Config.class)
+@SpringJUnitConfig(Config.class)
 @IgnoreWhen(clusterTypes = ClusterType.MOCKED)
+@DirtiesContext
 class StringN1qlQueryCreatorIntegrationTests extends ClusterAwareIntegrationTests {
 
 	@Autowired MappingContext<? extends CouchbasePersistentEntity<?>, CouchbasePersistentProperty> context;
 	@Autowired CouchbaseConverter converter;
 	@Autowired CouchbaseTemplate couchbaseTemplate;
 	static NamedQueries namedQueries = new PropertiesBasedNamedQueries(new Properties());
-
-	@BeforeEach
-	public void beforeEach() {}
 
 	@Test
 	@IgnoreWhen(missesCapabilities = Capabilities.QUERY, clusterTypes = ClusterType.MOCKED)
@@ -148,42 +141,10 @@ class StringN1qlQueryCreatorIntegrationTests extends ClusterAwareIntegrationTest
 		return new DefaultParameters(method);
 	}
 
-	@Configuration
-	@EnableCouchbaseRepositories("org.springframework.data.couchbase")
-	static class Config extends AbstractCouchbaseConfiguration {
-
-		@Override
-		public String getConnectionString() {
-			return connectionString();
-		}
-
-		@Override
-		public String getUserName() {
-			return config().adminUsername();
-		}
-
-		@Override
-		public String getPassword() {
-			return config().adminPassword();
-		}
-
-		@Override
-		public String getBucketName() {
-			return bucketName();
-		}
-
-		@Override
-		protected void configureEnvironment(ClusterEnvironment.Builder builder) {
-			if (config().isUsingCloud()) {
-				builder.securityConfig(
-						SecurityConfig.builder().trustManagerFactory(InsecureTrustManagerFactory.INSTANCE).enableTls(true));
-			}
-		}
-
-		@Override
-		protected boolean autoIndexCreation() {
-			return true;
-		}
-
-	}
+    // static class Config extends org.springframework.data.couchbase.domain.Config {
+    //		@Override
+    //		protected boolean autoIndexCreation() {
+    //			return true;
+    //		}
+    //	}
 }

--- a/src/test/java/org/springframework/data/couchbase/transactions/CouchbasePersonTransactionIntegrationTests.java
+++ b/src/test/java/org/springframework/data/couchbase/transactions/CouchbasePersonTransactionIntegrationTests.java
@@ -22,6 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import lombok.Data;
+import org.springframework.test.annotation.DirtiesContext;
 import reactor.core.publisher.Mono;
 
 import java.util.List;
@@ -66,7 +67,9 @@ import com.couchbase.client.java.transactions.TransactionResult;
  * @author Michael Reiche
  */
 @IgnoreWhen(missesCapabilities = Capabilities.QUERY, clusterTypes = ClusterType.MOCKED)
-@SpringJUnitConfig(classes = { TransactionsConfig.class, PersonService.class })
+@SpringJUnitConfig(
+        classes = { TransactionsConfig.class, PersonService.class })
+@DirtiesContext
 public class CouchbasePersonTransactionIntegrationTests extends JavaIntegrationTests {
 	// intellij flags "Could not autowire" when config classes are specified with classes={...}. But they are populated.
 	@Autowired CouchbaseClientFactory couchbaseClientFactory;

--- a/src/test/java/org/springframework/data/couchbase/transactions/CouchbasePersonTransactionReactiveIntegrationTests.java
+++ b/src/test/java/org/springframework/data/couchbase/transactions/CouchbasePersonTransactionReactiveIntegrationTests.java
@@ -19,7 +19,7 @@ package org.springframework.data.couchbase.transactions;
 import static com.couchbase.client.java.query.QueryScanConsistency.REQUEST_PLUS;
 
 import lombok.Data;
-import org.springframework.data.couchbase.domain.PersonWithoutVersion;
+import org.springframework.test.annotation.DirtiesContext;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
@@ -37,6 +37,7 @@ import org.springframework.data.couchbase.core.ReactiveCouchbaseTemplate;
 import org.springframework.data.couchbase.core.RemoveResult;
 import org.springframework.data.couchbase.domain.Person;
 import org.springframework.data.couchbase.domain.PersonRepository;
+import org.springframework.data.couchbase.domain.PersonWithoutVersion;
 import org.springframework.data.couchbase.domain.ReactivePersonRepository;
 import org.springframework.data.couchbase.transaction.error.TransactionSystemUnambiguousException;
 import org.springframework.data.couchbase.transactions.util.TransactionTestUtil;
@@ -58,6 +59,7 @@ import com.couchbase.client.java.Cluster;
  */
 @IgnoreWhen(missesCapabilities = Capabilities.QUERY, clusterTypes = ClusterType.MOCKED)
 @SpringJUnitConfig(classes = { TransactionsConfig.class, PersonServiceReactive.class })
+@DirtiesContext
 public class CouchbasePersonTransactionReactiveIntegrationTests extends JavaIntegrationTests {
 	// intellij flags "Could not autowire" when config classes are specified with classes={...}. But they are populated.
 	@Autowired CouchbaseClientFactory couchbaseClientFactory;
@@ -234,4 +236,5 @@ public class CouchbasePersonTransactionReactiveIntegrationTests extends JavaInte
 		String action;
 		@Version Long version;
 	}
+
 }

--- a/src/test/java/org/springframework/data/couchbase/transactions/CouchbaseReactiveTransactionNativeIntegrationTests.java
+++ b/src/test/java/org/springframework/data/couchbase/transactions/CouchbaseReactiveTransactionNativeIntegrationTests.java
@@ -21,6 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import org.springframework.test.annotation.DirtiesContext;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
@@ -55,6 +56,7 @@ import org.springframework.transaction.reactive.TransactionalOperator;
  */
 @IgnoreWhen(missesCapabilities = Capabilities.QUERY, clusterTypes = ClusterType.MOCKED)
 @SpringJUnitConfig(TransactionsConfig.class)
+@DirtiesContext
 public class CouchbaseReactiveTransactionNativeIntegrationTests extends JavaIntegrationTests {
 
 	@Autowired CouchbaseClientFactory couchbaseClientFactory;
@@ -228,4 +230,5 @@ public class CouchbaseReactiveTransactionNativeIntegrationTests extends JavaInte
 				.as(txOperator::transactional);
 	}
 
+    static public class TransactionsConfig extends org.springframework.data.couchbase.transactions.TransactionsConfig {}
 }

--- a/src/test/java/org/springframework/data/couchbase/transactions/CouchbaseTransactionNativeIntegrationTests.java
+++ b/src/test/java/org/springframework/data/couchbase/transactions/CouchbaseTransactionNativeIntegrationTests.java
@@ -41,6 +41,7 @@ import org.springframework.data.couchbase.util.Capabilities;
 import org.springframework.data.couchbase.util.ClusterType;
 import org.springframework.data.couchbase.util.IgnoreWhen;
 import org.springframework.data.couchbase.util.JavaIntegrationTests;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 import org.springframework.transaction.TransactionManager;
 import org.springframework.transaction.reactive.TransactionalOperator;
@@ -54,6 +55,7 @@ import org.springframework.transaction.reactive.TransactionalOperator;
  */
 @IgnoreWhen(missesCapabilities = Capabilities.QUERY, clusterTypes = ClusterType.MOCKED)
 @SpringJUnitConfig(TransactionsConfig.class)
+@DirtiesContext
 // I think these are all redundant (see CouchbaseReactiveTransactionNativeTests). There does not seem to be a blocking
 // form of TransactionalOperator. Also there does not seem to be a need for a CouchbaseTransactionalOperator as
 // TransactionalOperator.create(reactiveCouchbaseTransactionManager) seems to work just fine. (I don't recall what
@@ -185,4 +187,5 @@ public class CouchbaseTransactionNativeIntegrationTests extends JavaIntegrationT
 		assertEquals(person.getFirstname(), pFound.getFirstname(), "firstname should be Walter");
 	}
 
+    static public class TransactionsConfig extends org.springframework.data.couchbase.transactions.TransactionsConfig {}
 }

--- a/src/test/java/org/springframework/data/couchbase/transactions/CouchbaseTransactionalNonAllowableOperationsIntegrationTests.java
+++ b/src/test/java/org/springframework/data/couchbase/transactions/CouchbaseTransactionalNonAllowableOperationsIntegrationTests.java
@@ -37,8 +37,8 @@ import org.springframework.data.couchbase.util.ClusterType;
 import org.springframework.data.couchbase.util.IgnoreWhen;
 import org.springframework.data.couchbase.util.JavaIntegrationTests;
 import org.springframework.stereotype.Service;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
-import org.springframework.transaction.annotation.EnableTransactionManagement;
 import org.springframework.transaction.annotation.Transactional;
 
 /**
@@ -50,6 +50,7 @@ import org.springframework.transaction.annotation.Transactional;
 @IgnoreWhen(missesCapabilities = Capabilities.QUERY, clusterTypes = ClusterType.MOCKED)
 @SpringJUnitConfig(classes = { TransactionsConfig.class,
 		CouchbaseTransactionalNonAllowableOperationsIntegrationTests.PersonService.class })
+@DirtiesContext
 public class CouchbaseTransactionalNonAllowableOperationsIntegrationTests extends JavaIntegrationTests {
 
 	@Autowired CouchbaseClientFactory couchbaseClientFactory;
@@ -127,4 +128,5 @@ public class CouchbaseTransactionalNonAllowableOperationsIntegrationTests extend
 			return callback.apply(personOperations);
 		}
 	}
+
 }

--- a/src/test/java/org/springframework/data/couchbase/transactions/CouchbaseTransactionalOperatorTemplateIntegrationTests.java
+++ b/src/test/java/org/springframework/data/couchbase/transactions/CouchbaseTransactionalOperatorTemplateIntegrationTests.java
@@ -22,6 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.springframework.data.couchbase.transactions.util.TransactionTestUtil.assertNotInTransaction;
 
+import org.springframework.test.annotation.DirtiesContext;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
@@ -57,6 +58,7 @@ import org.springframework.transaction.reactive.TransactionalOperator;
  */
 @IgnoreWhen(missesCapabilities = Capabilities.QUERY, clusterTypes = ClusterType.MOCKED)
 @SpringJUnitConfig(TransactionsConfig.class)
+@DirtiesContext
 public class CouchbaseTransactionalOperatorTemplateIntegrationTests extends JavaIntegrationTests {
 	@Autowired CouchbaseClientFactory couchbaseClientFactory;
 	@Autowired ReactiveCouchbaseTemplate ops;
@@ -326,4 +328,5 @@ public class CouchbaseTransactionalOperatorTemplateIntegrationTests extends Java
 		assertEquals("Changed by transaction", fetched.getFirstname());
 		assertEquals(2, attempts.get());
 	}
+
 }

--- a/src/test/java/org/springframework/data/couchbase/transactions/CouchbaseTransactionalOptionsIntegrationTests.java
+++ b/src/test/java/org/springframework/data/couchbase/transactions/CouchbaseTransactionalOptionsIntegrationTests.java
@@ -37,8 +37,8 @@ import org.springframework.data.couchbase.util.ClusterType;
 import org.springframework.data.couchbase.util.IgnoreWhen;
 import org.springframework.data.couchbase.util.JavaIntegrationTests;
 import org.springframework.stereotype.Service;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
-import org.springframework.transaction.annotation.EnableTransactionManagement;
 import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -51,7 +51,8 @@ import com.couchbase.client.core.error.transaction.AttemptExpiredException;
  */
 @IgnoreWhen(clusterTypes = ClusterType.MOCKED)
 @SpringJUnitConfig(
-		classes = { TransactionsConfig.class, CouchbaseTransactionalOptionsIntegrationTests.PersonService.class })
+        classes = { TransactionsConfig.class, CouchbaseTransactionalOptionsIntegrationTests.PersonService.class })
+@DirtiesContext
 public class CouchbaseTransactionalOptionsIntegrationTests extends JavaIntegrationTests {
 
 	@Autowired CouchbaseClientFactory couchbaseClientFactory;
@@ -127,4 +128,5 @@ public class CouchbaseTransactionalOptionsIntegrationTests extends JavaIntegrati
 		@Transactional(isolation = Isolation.READ_COMMITTED)
 		public void supportedIsolation() {}
 	}
+
 }

--- a/src/test/java/org/springframework/data/couchbase/transactions/CouchbaseTransactionalPropagationIntegrationTests.java
+++ b/src/test/java/org/springframework/data/couchbase/transactions/CouchbaseTransactionalPropagationIntegrationTests.java
@@ -44,9 +44,9 @@ import org.springframework.data.couchbase.util.IgnoreWhen;
 import org.springframework.data.couchbase.util.JavaIntegrationTests;
 import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Service;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 import org.springframework.transaction.IllegalTransactionStateException;
-import org.springframework.transaction.annotation.EnableTransactionManagement;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -59,7 +59,8 @@ import com.couchbase.client.core.error.transaction.RetryTransactionException;
  */
 @IgnoreWhen(clusterTypes = ClusterType.MOCKED)
 @SpringJUnitConfig(
-		classes = { TransactionsConfig.class, CouchbaseTransactionalPropagationIntegrationTests.PersonService.class })
+        classes = { TransactionsConfig.class, CouchbaseTransactionalPropagationIntegrationTests.PersonService.class })
+@DirtiesContext
 public class CouchbaseTransactionalPropagationIntegrationTests extends JavaIntegrationTests {
 	private static final Logger LOGGER = LoggerFactory.getLogger(CouchbaseTransactionalPropagationIntegrationTests.class);
 
@@ -348,4 +349,5 @@ public class CouchbaseTransactionalPropagationIntegrationTests extends JavaInteg
 				callback.accept(ops);
 		}
 	}
+
 }

--- a/src/test/java/org/springframework/data/couchbase/transactions/CouchbaseTransactionalRepositoryCollectionIntegrationTests.java
+++ b/src/test/java/org/springframework/data/couchbase/transactions/CouchbaseTransactionalRepositoryCollectionIntegrationTests.java
@@ -39,6 +39,7 @@ import org.springframework.data.couchbase.util.ClusterType;
 import org.springframework.data.couchbase.util.CollectionAwareIntegrationTests;
 import org.springframework.data.couchbase.util.IgnoreWhen;
 import org.springframework.stereotype.Service;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -48,17 +49,17 @@ import org.springframework.transaction.annotation.Transactional;
  * @author Michael Reiche
  */
 @IgnoreWhen(clusterTypes = ClusterType.MOCKED)
-@SpringJUnitConfig(classes = { TransactionsConfig.class,
-		CouchbaseTransactionalRepositoryCollectionIntegrationTests.UserService.class })
+@SpringJUnitConfig(classes = { TransactionsConfig.class, CouchbaseTransactionalRepositoryCollectionIntegrationTests.UserService.class })
+@DirtiesContext
 public class CouchbaseTransactionalRepositoryCollectionIntegrationTests extends CollectionAwareIntegrationTests {
 	// intellij flags "Could not autowire" when config classes are specified with classes={...}. But they are populated.
-	@Autowired UserColRepository userRepo;
-	@Autowired UserService userService;
+    @Autowired UserColRepository userRepo;
+    @Autowired UserService userService;
 	//@Autowired CouchbaseTemplate operations;
 
 	@BeforeAll
 	public static void beforeAll() {
-		callSuperBeforeAll(new Object() {});
+        callSuperBeforeAll(new Object() {});
 	}
 
 	@BeforeEach
@@ -121,7 +122,7 @@ public class CouchbaseTransactionalRepositoryCollectionIntegrationTests extends 
 
 	@Service // this will work in the unit tests even without @Service because of explicit loading by @SpringJUnitConfig
 	static class UserService {
-		@Autowired UserColRepository userRepo;
+        @Autowired UserColRepository userRepo;
 
 		@Transactional
 		public void run(Consumer<UserColRepository> callback) {

--- a/src/test/java/org/springframework/data/couchbase/transactions/CouchbaseTransactionalRepositoryIntegrationTests.java
+++ b/src/test/java/org/springframework/data/couchbase/transactions/CouchbaseTransactionalRepositoryIntegrationTests.java
@@ -41,8 +41,8 @@ import org.springframework.data.couchbase.util.ClusterType;
 import org.springframework.data.couchbase.util.IgnoreWhen;
 import org.springframework.data.couchbase.util.JavaIntegrationTests;
 import org.springframework.stereotype.Service;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
-import org.springframework.transaction.annotation.EnableTransactionManagement;
 import org.springframework.transaction.annotation.Transactional;
 
 /**
@@ -52,7 +52,8 @@ import org.springframework.transaction.annotation.Transactional;
  */
 @IgnoreWhen(clusterTypes = ClusterType.MOCKED)
 @SpringJUnitConfig(
-		classes = { TransactionsConfig.class, CouchbaseTransactionalRepositoryIntegrationTests.UserService.class })
+        classes = { TransactionsConfig.class, CouchbaseTransactionalRepositoryIntegrationTests.UserService.class })
+@DirtiesContext
 public class CouchbaseTransactionalRepositoryIntegrationTests extends JavaIntegrationTests {
 	// intellij flags "Could not autowire" when config classes are specified with classes={...}. But they are populated.
 	@Autowired UserRepository userRepo;

--- a/src/test/java/org/springframework/data/couchbase/transactions/CouchbaseTransactionalTemplateCollectionDefaultScopeIntegrationTests.java
+++ b/src/test/java/org/springframework/data/couchbase/transactions/CouchbaseTransactionalTemplateCollectionDefaultScopeIntegrationTests.java
@@ -53,6 +53,7 @@ import org.springframework.data.couchbase.util.ClusterType;
 import org.springframework.data.couchbase.util.CollectionAwareDefaultScopeIntegrationTests;
 import org.springframework.data.couchbase.util.IgnoreWhen;
 import org.springframework.stereotype.Service;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -65,7 +66,8 @@ import com.couchbase.client.core.error.transaction.AttemptExpiredException;
  */
 @IgnoreWhen(missesCapabilities = Capabilities.QUERY, clusterTypes = ClusterType.MOCKED)
 @SpringJUnitConfig(
-  classes = { TransactionsConfig.class, CouchbaseTransactionalTemplateCollectionDefaultScopeIntegrationTests.PersonService.class })
+        classes = { TransactionsConfig.class, CouchbaseTransactionalTemplateCollectionDefaultScopeIntegrationTests.PersonService.class })
+@DirtiesContext
 public class CouchbaseTransactionalTemplateCollectionDefaultScopeIntegrationTests extends CollectionAwareDefaultScopeIntegrationTests {
   // intellij flags "Could not autowire" when config classes are specified with classes={...}. But they are populated.
   @Autowired CouchbaseClientFactory couchbaseClientFactory;
@@ -496,4 +498,5 @@ public class CouchbaseTransactionalTemplateCollectionDefaultScopeIntegrationTest
     throw new RuntimeException(
       "in transaction = " + (!inTransaction) + " but expected in annotation transaction = " + inTransaction);
   }
+
 }

--- a/src/test/java/org/springframework/data/couchbase/transactions/CouchbaseTransactionalTemplateCollectionIntegrationTests.java
+++ b/src/test/java/org/springframework/data/couchbase/transactions/CouchbaseTransactionalTemplateCollectionIntegrationTests.java
@@ -50,10 +50,10 @@ import org.springframework.data.couchbase.transaction.CouchbaseCallbackTransacti
 import org.springframework.data.couchbase.transaction.error.TransactionSystemUnambiguousException;
 import org.springframework.data.couchbase.util.Capabilities;
 import org.springframework.data.couchbase.util.ClusterType;
-import org.springframework.data.couchbase.util.CollectionAwareDefaultScopeIntegrationTests;
 import org.springframework.data.couchbase.util.CollectionAwareIntegrationTests;
 import org.springframework.data.couchbase.util.IgnoreWhen;
 import org.springframework.stereotype.Service;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -66,7 +66,8 @@ import com.couchbase.client.core.error.transaction.AttemptExpiredException;
  */
 @IgnoreWhen(missesCapabilities = Capabilities.QUERY, clusterTypes = ClusterType.MOCKED)
 @SpringJUnitConfig(
-  classes = { TransactionsConfig.class, CouchbaseTransactionalTemplateCollectionIntegrationTests.PersonService.class })
+        classes = { TransactionsConfig.class, CouchbaseTransactionalTemplateCollectionIntegrationTests.PersonService.class })
+@DirtiesContext
 public class CouchbaseTransactionalTemplateCollectionIntegrationTests extends CollectionAwareIntegrationTests {
   // intellij flags "Could not autowire" when config classes are specified with classes={...}. But they are populated.
   @Autowired CouchbaseClientFactory couchbaseClientFactory;
@@ -497,4 +498,5 @@ public class CouchbaseTransactionalTemplateCollectionIntegrationTests extends Co
     throw new RuntimeException(
       "in transaction = " + (!inTransaction) + " but expected in annotation transaction = " + inTransaction);
   }
+
 }

--- a/src/test/java/org/springframework/data/couchbase/transactions/CouchbaseTransactionalTemplateIntegrationTests.java
+++ b/src/test/java/org/springframework/data/couchbase/transactions/CouchbaseTransactionalTemplateIntegrationTests.java
@@ -53,8 +53,8 @@ import org.springframework.data.couchbase.util.ClusterType;
 import org.springframework.data.couchbase.util.IgnoreWhen;
 import org.springframework.data.couchbase.util.JavaIntegrationTests;
 import org.springframework.stereotype.Service;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
-import org.springframework.transaction.annotation.EnableTransactionManagement;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.couchbase.client.core.error.transaction.AttemptExpiredException;
@@ -66,7 +66,8 @@ import com.couchbase.client.core.error.transaction.AttemptExpiredException;
  */
 @IgnoreWhen(missesCapabilities = Capabilities.QUERY, clusterTypes = ClusterType.MOCKED)
 @SpringJUnitConfig(
-		classes = { TransactionsConfig.class, CouchbaseTransactionalTemplateIntegrationTests.PersonService.class })
+        classes = { TransactionsConfig.class, CouchbaseTransactionalTemplateIntegrationTests.PersonService.class })
+@DirtiesContext
 public class CouchbaseTransactionalTemplateIntegrationTests extends JavaIntegrationTests {
 	// intellij flags "Could not autowire" when config classes are specified with classes={...}. But they are populated.
 	@Autowired CouchbaseClientFactory couchbaseClientFactory;
@@ -497,4 +498,5 @@ public class CouchbaseTransactionalTemplateIntegrationTests extends JavaIntegrat
 		throw new RuntimeException(
 				"in transaction = " + (!inTransaction) + " but expected in annotation transaction = " + inTransaction);
 	}
+
 }

--- a/src/test/java/org/springframework/data/couchbase/transactions/CouchbaseTransactionalUnsettableParametersIntegrationTests.java
+++ b/src/test/java/org/springframework/data/couchbase/transactions/CouchbaseTransactionalUnsettableParametersIntegrationTests.java
@@ -39,6 +39,7 @@ import org.springframework.data.couchbase.util.ClusterType;
 import org.springframework.data.couchbase.util.IgnoreWhen;
 import org.springframework.data.couchbase.util.JavaIntegrationTests;
 import org.springframework.stereotype.Service;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -59,8 +60,8 @@ import com.couchbase.client.java.kv.ReplicateTo;
  * @author Tigran Babloyan
  */
 @IgnoreWhen(missesCapabilities = Capabilities.QUERY, clusterTypes = ClusterType.MOCKED)
-@SpringJUnitConfig(classes = { TransactionsConfig.class,
-		CouchbaseTransactionalUnsettableParametersIntegrationTests.PersonService.class })
+@SpringJUnitConfig(classes = { TransactionsConfig.class, CouchbaseTransactionalUnsettableParametersIntegrationTests.PersonService.class })
+@DirtiesContext
 public class CouchbaseTransactionalUnsettableParametersIntegrationTests extends JavaIntegrationTests {
 
 	@Autowired CouchbaseClientFactory couchbaseClientFactory;
@@ -265,4 +266,5 @@ public class CouchbaseTransactionalUnsettableParametersIntegrationTests extends 
 			return callback.apply(personOperations);
 		}
 	}
+
 }

--- a/src/test/java/org/springframework/data/couchbase/transactions/DirectPlatformTransactionManagerIntegrationTests.java
+++ b/src/test/java/org/springframework/data/couchbase/transactions/DirectPlatformTransactionManagerIntegrationTests.java
@@ -24,6 +24,7 @@ import org.springframework.data.couchbase.util.Capabilities;
 import org.springframework.data.couchbase.util.ClusterType;
 import org.springframework.data.couchbase.util.IgnoreWhen;
 import org.springframework.data.couchbase.util.JavaIntegrationTests;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.TransactionDefinition;
@@ -36,6 +37,7 @@ import org.springframework.transaction.support.DefaultTransactionDefinition;
  */
 @IgnoreWhen(missesCapabilities = Capabilities.QUERY, clusterTypes = ClusterType.MOCKED)
 @SpringJUnitConfig(TransactionsConfig.class)
+@DirtiesContext
 public class DirectPlatformTransactionManagerIntegrationTests extends JavaIntegrationTests {
 	@Autowired CouchbaseClientFactory couchbaseClientFactory;
 
@@ -48,4 +50,5 @@ public class DirectPlatformTransactionManagerIntegrationTests extends JavaIntegr
 			ptm.getTransaction(def);
 		}, UnsupportedOperationException.class);
 	}
+
 }

--- a/src/test/java/org/springframework/data/couchbase/transactions/ReactiveTransactionalTemplateIntegrationTests.java
+++ b/src/test/java/org/springframework/data/couchbase/transactions/ReactiveTransactionalTemplateIntegrationTests.java
@@ -22,6 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.springframework.data.couchbase.transactions.util.TransactionTestUtil.assertNotInTransaction;
 
+import org.springframework.test.annotation.DirtiesContext;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
@@ -48,7 +49,6 @@ import org.springframework.data.couchbase.util.IgnoreWhen;
 import org.springframework.data.couchbase.util.JavaIntegrationTests;
 import org.springframework.stereotype.Service;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
-import org.springframework.transaction.annotation.EnableTransactionManagement;
 import org.springframework.transaction.annotation.Transactional;
 
 /**
@@ -58,7 +58,8 @@ import org.springframework.transaction.annotation.Transactional;
  */
 @IgnoreWhen(clusterTypes = ClusterType.MOCKED)
 @SpringJUnitConfig(
-		classes = { TransactionsConfig.class, ReactiveTransactionalTemplateIntegrationTests.PersonService.class })
+        classes = { TransactionsConfig.class, ReactiveTransactionalTemplateIntegrationTests.PersonService.class })
+@DirtiesContext
 public class ReactiveTransactionalTemplateIntegrationTests extends JavaIntegrationTests {
 	@Autowired CouchbaseClientFactory couchbaseClientFactory;
 	@Autowired PersonService personService;
@@ -200,4 +201,6 @@ public class ReactiveTransactionalTemplateIntegrationTests extends JavaIntegrati
 			});
 		}
 	}
+
+    static public class TransactionsConfig extends org.springframework.data.couchbase.transactions.TransactionsConfig {}
 }

--- a/src/test/java/org/springframework/data/couchbase/transactions/TransactionTemplateIntegrationTests.java
+++ b/src/test/java/org/springframework/data/couchbase/transactions/TransactionTemplateIntegrationTests.java
@@ -49,6 +49,7 @@ import org.springframework.data.couchbase.util.Capabilities;
 import org.springframework.data.couchbase.util.ClusterType;
 import org.springframework.data.couchbase.util.IgnoreWhen;
 import org.springframework.data.couchbase.util.JavaIntegrationTests;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 import org.springframework.transaction.IllegalTransactionStateException;
 import org.springframework.transaction.TransactionDefinition;
@@ -63,6 +64,7 @@ import org.springframework.transaction.support.TransactionTemplate;
  */
 @IgnoreWhen(missesCapabilities = Capabilities.QUERY, clusterTypes = ClusterType.MOCKED)
 @SpringJUnitConfig(TransactionsConfig.class)
+@DirtiesContext
 public class TransactionTemplateIntegrationTests extends JavaIntegrationTests {
 	@Autowired TransactionTemplate transactionTemplate;
 	@Autowired CouchbaseCallbackTransactionManager transactionManager;

--- a/src/test/java/org/springframework/data/couchbase/transactions/sdk/SDKReactiveTransactionsNonAllowableOperationsIntegrationTests.java
+++ b/src/test/java/org/springframework/data/couchbase/transactions/sdk/SDKReactiveTransactionsNonAllowableOperationsIntegrationTests.java
@@ -18,6 +18,8 @@ package org.springframework.data.couchbase.transactions.sdk;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import org.springframework.data.couchbase.transactions.TransactionsConfig;
+import org.springframework.test.annotation.DirtiesContext;
 import reactor.core.publisher.Mono;
 
 import java.util.concurrent.atomic.AtomicInteger;
@@ -31,7 +33,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.couchbase.CouchbaseClientFactory;
 import org.springframework.data.couchbase.core.ReactiveCouchbaseOperations;
 import org.springframework.data.couchbase.domain.Person;
-import org.springframework.data.couchbase.transactions.TransactionsConfig;
 import org.springframework.data.couchbase.transactions.util.TransactionTestUtil;
 import org.springframework.data.couchbase.util.Capabilities;
 import org.springframework.data.couchbase.util.ClusterType;
@@ -51,6 +52,7 @@ import com.couchbase.client.java.transactions.error.TransactionFailedException;
 @IgnoreWhen(missesCapabilities = Capabilities.QUERY, clusterTypes = ClusterType.MOCKED)
 @SpringJUnitConfig(classes = { TransactionsConfig.class,
 		SDKReactiveTransactionsNonAllowableOperationsIntegrationTests.PersonService.class })
+@DirtiesContext
 public class SDKReactiveTransactionsNonAllowableOperationsIntegrationTests extends JavaIntegrationTests {
 
 	@Autowired CouchbaseClientFactory couchbaseClientFactory;
@@ -129,4 +131,5 @@ public class SDKReactiveTransactionsNonAllowableOperationsIntegrationTests exten
 			return callback.apply(personOperations);
 		}
 	}
+
 }

--- a/src/test/java/org/springframework/data/couchbase/transactions/sdk/SDKReactiveTransactionsPersonIntegrationTests.java
+++ b/src/test/java/org/springframework/data/couchbase/transactions/sdk/SDKReactiveTransactionsPersonIntegrationTests.java
@@ -22,6 +22,8 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.springframework.data.couchbase.transactions.ReplaceLoopThread.updateOutOfTransaction;
 
+import org.springframework.data.couchbase.transactions.TransactionsConfig;
+import org.springframework.test.annotation.DirtiesContext;
 import reactor.core.publisher.Mono;
 
 import java.util.LinkedList;
@@ -47,7 +49,6 @@ import org.springframework.data.couchbase.domain.PersonRepository;
 import org.springframework.data.couchbase.domain.ReactivePersonRepository;
 import org.springframework.data.couchbase.transactions.ReplaceLoopThread;
 import org.springframework.data.couchbase.transactions.SimulateFailureException;
-import org.springframework.data.couchbase.transactions.TransactionsConfig;
 import org.springframework.data.couchbase.transactions.util.TransactionTestUtil;
 import org.springframework.data.couchbase.util.Capabilities;
 import org.springframework.data.couchbase.util.ClusterType;
@@ -66,6 +67,7 @@ import com.couchbase.client.java.transactions.error.TransactionFailedException;
  */
 @IgnoreWhen(missesCapabilities = Capabilities.QUERY, clusterTypes = ClusterType.MOCKED)
 @SpringJUnitConfig(TransactionsConfig.class)
+@DirtiesContext
 public class SDKReactiveTransactionsPersonIntegrationTests extends JavaIntegrationTests {
 	// intellij flags "Could not autowire" when config classes are specified with classes={...}. But they are populated.
 	@Autowired CouchbaseClientFactory couchbaseClientFactory;

--- a/src/test/java/org/springframework/data/couchbase/transactions/sdk/SDKReactiveTransactionsTemplateIntegrationTests.java
+++ b/src/test/java/org/springframework/data/couchbase/transactions/sdk/SDKReactiveTransactionsTemplateIntegrationTests.java
@@ -23,6 +23,8 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.springframework.data.couchbase.transactions.util.TransactionTestUtil.assertNotInTransaction;
 
+import org.springframework.data.couchbase.transactions.TransactionsConfig;
+import org.springframework.test.annotation.DirtiesContext;
 import reactor.core.publisher.Mono;
 import reactor.util.annotation.Nullable;
 
@@ -44,7 +46,6 @@ import org.springframework.data.couchbase.domain.Person;
 import org.springframework.data.couchbase.domain.PersonWithoutVersion;
 import org.springframework.data.couchbase.transactions.ReplaceLoopThread;
 import org.springframework.data.couchbase.transactions.SimulateFailureException;
-import org.springframework.data.couchbase.transactions.TransactionsConfig;
 import org.springframework.data.couchbase.util.Capabilities;
 import org.springframework.data.couchbase.util.ClusterType;
 import org.springframework.data.couchbase.util.IgnoreWhen;
@@ -63,6 +64,7 @@ import com.couchbase.client.java.transactions.error.TransactionFailedException;
  */
 @IgnoreWhen(missesCapabilities = Capabilities.QUERY, clusterTypes = ClusterType.MOCKED)
 @SpringJUnitConfig(TransactionsConfig.class)
+@DirtiesContext
 public class SDKReactiveTransactionsTemplateIntegrationTests extends JavaIntegrationTests {
 	// intellij flags "Could not autowire" when config classes are specified with classes={...}. But they are populated.
 	@Autowired CouchbaseClientFactory couchbaseClientFactory;
@@ -369,4 +371,5 @@ public class SDKReactiveTransactionsTemplateIntegrationTests extends JavaIntegra
 		assertEquals("Changed by transaction", fetched.getFirstname());
 		assertEquals(2, attempts.get());
 	}
+
 }

--- a/src/test/java/org/springframework/data/couchbase/transactions/sdk/SDKTransactionsNonAllowableOperationsIntegrationTests.java
+++ b/src/test/java/org/springframework/data/couchbase/transactions/sdk/SDKTransactionsNonAllowableOperationsIntegrationTests.java
@@ -37,6 +37,7 @@ import org.springframework.data.couchbase.util.ClusterType;
 import org.springframework.data.couchbase.util.IgnoreWhen;
 import org.springframework.data.couchbase.util.JavaIntegrationTests;
 import org.springframework.stereotype.Service;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
 import com.couchbase.client.java.transactions.error.TransactionFailedException;
@@ -49,7 +50,8 @@ import com.couchbase.client.java.transactions.error.TransactionFailedException;
  */
 @IgnoreWhen(missesCapabilities = Capabilities.QUERY, clusterTypes = ClusterType.MOCKED)
 @SpringJUnitConfig(
-		classes = { TransactionsConfig.class, SDKTransactionsNonAllowableOperationsIntegrationTests.PersonService.class })
+        classes = { TransactionsConfig.class, SDKTransactionsNonAllowableOperationsIntegrationTests.PersonService.class })
+@DirtiesContext
 public class SDKTransactionsNonAllowableOperationsIntegrationTests extends JavaIntegrationTests {
 
 	@Autowired CouchbaseClientFactory couchbaseClientFactory;
@@ -129,4 +131,5 @@ public class SDKTransactionsNonAllowableOperationsIntegrationTests extends JavaI
 			return callback.apply(personOperations);
 		}
 	}
+
 }

--- a/src/test/java/org/springframework/data/couchbase/transactions/sdk/SDKTransactionsNonBlockingThreadIntegrationTests.java
+++ b/src/test/java/org/springframework/data/couchbase/transactions/sdk/SDKTransactionsNonBlockingThreadIntegrationTests.java
@@ -20,6 +20,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.springframework.data.couchbase.transactions.util.TransactionTestUtil.assertNotInTransaction;
 
+import org.springframework.data.couchbase.transactions.TransactionsConfig;
+import org.springframework.test.annotation.DirtiesContext;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
 
@@ -32,7 +34,6 @@ import org.springframework.data.couchbase.CouchbaseClientFactory;
 import org.springframework.data.couchbase.core.CouchbaseTemplate;
 import org.springframework.data.couchbase.core.ReactiveCouchbaseTemplate;
 import org.springframework.data.couchbase.domain.Person;
-import org.springframework.data.couchbase.transactions.TransactionsConfig;
 import org.springframework.data.couchbase.util.Capabilities;
 import org.springframework.data.couchbase.util.ClusterType;
 import org.springframework.data.couchbase.util.IgnoreWhen;
@@ -47,6 +48,7 @@ import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
  */
 @IgnoreWhen(missesCapabilities = Capabilities.QUERY, clusterTypes = ClusterType.MOCKED)
 @SpringJUnitConfig(TransactionsConfig.class)
+@DirtiesContext
 public class SDKTransactionsNonBlockingThreadIntegrationTests extends JavaIntegrationTests {
 	@Autowired private CouchbaseClientFactory couchbaseClientFactory;
 	@Autowired private CouchbaseTemplate ops;

--- a/src/test/java/org/springframework/data/couchbase/transactions/sdk/SDKTransactionsSaveIntegrationTests.java
+++ b/src/test/java/org/springframework/data/couchbase/transactions/sdk/SDKTransactionsSaveIntegrationTests.java
@@ -16,12 +16,10 @@
 
 package org.springframework.data.couchbase.transactions.sdk;
 
-import static org.springframework.data.couchbase.transactions.util.TransactionTestUtil.assertInTransaction;
 import static org.springframework.data.couchbase.transactions.util.TransactionTestUtil.assertInReactiveTransaction;
+import static org.springframework.data.couchbase.transactions.util.TransactionTestUtil.assertInTransaction;
 import static org.springframework.data.couchbase.transactions.util.TransactionTestUtil.assertNotInReactiveTransaction;
 import static org.springframework.data.couchbase.transactions.util.TransactionTestUtil.assertNotInTransaction;
-
-import org.springframework.data.couchbase.domain.PersonWithoutVersion;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -31,11 +29,13 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.couchbase.CouchbaseClientFactory;
 import org.springframework.data.couchbase.core.CouchbaseTemplate;
 import org.springframework.data.couchbase.core.ReactiveCouchbaseTemplate;
+import org.springframework.data.couchbase.domain.PersonWithoutVersion;
 import org.springframework.data.couchbase.transactions.TransactionsConfig;
 import org.springframework.data.couchbase.util.Capabilities;
 import org.springframework.data.couchbase.util.ClusterType;
 import org.springframework.data.couchbase.util.IgnoreWhen;
 import org.springframework.data.couchbase.util.JavaIntegrationTests;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
 /**
@@ -45,6 +45,7 @@ import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
  */
 @IgnoreWhen(missesCapabilities = Capabilities.QUERY, clusterTypes = ClusterType.MOCKED)
 @SpringJUnitConfig(TransactionsConfig.class)
+@DirtiesContext
 public class SDKTransactionsSaveIntegrationTests extends JavaIntegrationTests {
 	@Autowired private CouchbaseClientFactory couchbaseClientFactory;
 	@Autowired private CouchbaseTemplate ops;
@@ -52,6 +53,7 @@ public class SDKTransactionsSaveIntegrationTests extends JavaIntegrationTests {
 
 	@BeforeEach
 	public void beforeEachTest() {
+        super.beforeEach();
 		assertNotInTransaction();
 		assertNotInReactiveTransaction();
 	}
@@ -66,6 +68,7 @@ public class SDKTransactionsSaveIntegrationTests extends JavaIntegrationTests {
 	@DisplayName("ReactiveCouchbaseTemplate.save() called inside a reactive SDK transaction should work")
 	@Test
 	public void reactiveSaveInReactiveTransaction() {
+        logMessage("xxx reactiveSaveInReactiveTransaction");
 		couchbaseClientFactory.getCluster().reactive().transactions().run(ctx -> {
 			PersonWithoutVersion p = new PersonWithoutVersion("Walter", "White");
 			return reactiveOps.save(p).then(assertInReactiveTransaction());

--- a/src/test/java/org/springframework/data/couchbase/transactions/sdk/SDKTransactionsTemplateIntegrationTests.java
+++ b/src/test/java/org/springframework/data/couchbase/transactions/sdk/SDKTransactionsTemplateIntegrationTests.java
@@ -24,6 +24,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.springframework.data.couchbase.transactions.util.TransactionTestUtil.assertInTransaction;
 import static org.springframework.data.couchbase.transactions.util.TransactionTestUtil.assertNotInTransaction;
 
+import org.springframework.data.couchbase.transactions.TransactionsConfig;
+import org.springframework.test.annotation.DirtiesContext;
 import reactor.util.annotation.Nullable;
 
 import java.time.Duration;
@@ -46,7 +48,6 @@ import org.springframework.data.couchbase.domain.PersonWithoutVersion;
 import org.springframework.data.couchbase.transaction.error.UncategorizedTransactionDataAccessException;
 import org.springframework.data.couchbase.transactions.ReplaceLoopThread;
 import org.springframework.data.couchbase.transactions.SimulateFailureException;
-import org.springframework.data.couchbase.transactions.TransactionsConfig;
 import org.springframework.data.couchbase.util.Capabilities;
 import org.springframework.data.couchbase.util.ClusterType;
 import org.springframework.data.couchbase.util.IgnoreWhen;
@@ -69,6 +70,7 @@ import com.couchbase.client.java.transactions.error.TransactionFailedException;
  */
 @IgnoreWhen(missesCapabilities = Capabilities.QUERY, clusterTypes = ClusterType.MOCKED)
 @SpringJUnitConfig(TransactionsConfig.class)
+@DirtiesContext
 public class SDKTransactionsTemplateIntegrationTests extends JavaIntegrationTests {
 	// intellij flags "Could not autowire" when config classes are specified with classes={...}. But they are populated.
 	@Autowired CouchbaseClientFactory couchbaseClientFactory;

--- a/src/test/java/org/springframework/data/couchbase/util/CollectionAwareDefaultScopeIntegrationTests.java
+++ b/src/test/java/org/springframework/data/couchbase/util/CollectionAwareDefaultScopeIntegrationTests.java
@@ -15,19 +15,12 @@
  */
 package org.springframework.data.couchbase.util;
 
-import static org.springframework.data.couchbase.config.BeanNames.COUCHBASE_TEMPLATE;
-import static org.springframework.data.couchbase.config.BeanNames.REACTIVE_COUCHBASE_TEMPLATE;
-
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import org.springframework.context.ApplicationContext;
-import org.springframework.context.annotation.AnnotationConfigApplicationContext;
-import org.springframework.data.couchbase.core.CouchbaseTemplate;
-import org.springframework.data.couchbase.core.ReactiveCouchbaseTemplate;
 import org.springframework.data.couchbase.domain.Config;
 
 import com.couchbase.client.core.error.IndexExistsException;
@@ -42,7 +35,7 @@ import com.couchbase.client.java.manager.collection.CollectionManager;
  *
  * @Author Michael Reiche
  */
-public class CollectionAwareDefaultScopeIntegrationTests extends CollectionAwareIntegrationTests {
+public class CollectionAwareDefaultScopeIntegrationTests extends JavaIntegrationTests {
 
 	public static String scopeName = "_default";// + randomString();
 	public static String collectionName = "my_collection";// + randomString();
@@ -56,7 +49,7 @@ public class CollectionAwareDefaultScopeIntegrationTests extends CollectionAware
 		callSuperBeforeAll(new Object() {
 		});
 		Cluster cluster = Cluster.connect(connectionString(),
-			ClusterOptions.clusterOptions(authenticator()).environment(environment().build()));
+                ClusterOptions.clusterOptions(authenticator()).environment(environment().build()));
 		Bucket bucket = cluster.bucket(config().bucketname());
 		bucket.waitUntilReady(Duration.ofSeconds(30));
 		waitForService(bucket, ServiceType.QUERY);
@@ -78,25 +71,26 @@ public class CollectionAwareDefaultScopeIntegrationTests extends CollectionAware
 			List<String> fieldList = new ArrayList<>();
 			fieldList.add("parentId");
 			cluster.query("CREATE INDEX `parent_idx` ON default:`" + bucketName() + "`." + scopeName + "." + collectionName2
-				+ "(parentId)");
+                    + "(parentId)");
 		} catch (IndexExistsException ife) {
 			LOGGER.warn("IndexFailureException occurred - ignoring: ", ife.toString());
 		}
-
+        logDisconnect(cluster, CollectionAwareDefaultScopeIntegrationTests.class.getSimpleName());
 		Config.setScopeName(scopeName);
-		ApplicationContext ac = new AnnotationConfigApplicationContext(Config.class);
+        // ApplicationContext ac = new AnnotationConfigApplicationContext();
+        // System.out.println(ac);
 		// the Config class has been modified, these need to be loaded again
-		couchbaseTemplate = (CouchbaseTemplate) ac.getBean(COUCHBASE_TEMPLATE);
-		reactiveCouchbaseTemplate = (ReactiveCouchbaseTemplate) ac.getBean(REACTIVE_COUCHBASE_TEMPLATE);
+        // couchbaseTemplate = (CouchbaseTemplate) ac.getBean(COUCHBASE_TEMPLATE);
+        // reactiveCouchbaseTemplate = (ReactiveCouchbaseTemplate) ac.getBean(REACTIVE_COUCHBASE_TEMPLATE);
 	}
 
 	@AfterAll
 	public static void afterAll() {
 		Config.setScopeName(null);
-		ApplicationContext ac = new AnnotationConfigApplicationContext(Config.class);
+        // ApplicationContext ac = new AnnotationConfigApplicationContext(Config.class);
 		// the Config class has been modified, these need to be loaded again
-		couchbaseTemplate = (CouchbaseTemplate) ac.getBean(COUCHBASE_TEMPLATE);
-		reactiveCouchbaseTemplate = (ReactiveCouchbaseTemplate) ac.getBean(REACTIVE_COUCHBASE_TEMPLATE);
+        // couchbaseTemplate = (CouchbaseTemplate) ac.getBean(COUCHBASE_TEMPLATE);
+        // reactiveCouchbaseTemplate = (ReactiveCouchbaseTemplate) ac.getBean(REACTIVE_COUCHBASE_TEMPLATE);
 		callSuperAfterAll(new Object() {
 		});
 	}

--- a/src/test/java/org/springframework/data/couchbase/util/CollectionAwareIntegrationTests.java
+++ b/src/test/java/org/springframework/data/couchbase/util/CollectionAwareIntegrationTests.java
@@ -15,19 +15,12 @@
  */
 package org.springframework.data.couchbase.util;
 
-import static org.springframework.data.couchbase.config.BeanNames.COUCHBASE_TEMPLATE;
-import static org.springframework.data.couchbase.config.BeanNames.REACTIVE_COUCHBASE_TEMPLATE;
-
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import org.springframework.context.ApplicationContext;
-import org.springframework.context.annotation.AnnotationConfigApplicationContext;
-import org.springframework.data.couchbase.core.CouchbaseTemplate;
-import org.springframework.data.couchbase.core.ReactiveCouchbaseTemplate;
 import org.springframework.data.couchbase.domain.Config;
 
 import com.couchbase.client.core.error.IndexExistsException;
@@ -80,21 +73,22 @@ public class CollectionAwareIntegrationTests extends JavaIntegrationTests {
 		} catch (IndexExistsException ife) {
 			LOGGER.warn("IndexFailureException occurred - ignoring: ", ife.toString());
 		}
-
+        logDisconnect(cluster, CollectionAwareIntegrationTests.class.getSimpleName());
 		Config.setScopeName(scopeName);
-		ApplicationContext ac = new AnnotationConfigApplicationContext(Config.class);
+        // ApplicationContext ac = new AnnotationConfigApplicationContext(Config.class);
+        // System.out.println(ac);
 		// the Config class has been modified, these need to be loaded again
-		couchbaseTemplate = (CouchbaseTemplate) ac.getBean(COUCHBASE_TEMPLATE);
-		reactiveCouchbaseTemplate = (ReactiveCouchbaseTemplate) ac.getBean(REACTIVE_COUCHBASE_TEMPLATE);
+        // couchbaseTemplate = (CouchbaseTemplate) ac.getBean(COUCHBASE_TEMPLATE);
+        // reactiveCouchbaseTemplate = (ReactiveCouchbaseTemplate) ac.getBean(REACTIVE_COUCHBASE_TEMPLATE);
 	}
 
 	@AfterAll
 	public static void afterAll() {
 		Config.setScopeName(null);
-		ApplicationContext ac = new AnnotationConfigApplicationContext(Config.class);
+        // ApplicationContext ac = new AnnotationConfigApplicationContext(Config.class);
 		// the Config class has been modified, these need to be loaded again
-		couchbaseTemplate = (CouchbaseTemplate) ac.getBean(COUCHBASE_TEMPLATE);
-		reactiveCouchbaseTemplate = (ReactiveCouchbaseTemplate) ac.getBean(REACTIVE_COUCHBASE_TEMPLATE);
+        // couchbaseTemplate = (CouchbaseTemplate) ac.getBean(COUCHBASE_TEMPLATE);
+        // reactiveCouchbaseTemplate = (ReactiveCouchbaseTemplate) ac.getBean(REACTIVE_COUCHBASE_TEMPLATE);
 		callSuperAfterAll(new Object() {});
 	}
 }

--- a/src/test/java/org/springframework/data/couchbase/util/JavaIntegrationTests.java
+++ b/src/test/java/org/springframework/data/couchbase/util/JavaIntegrationTests.java
@@ -23,8 +23,6 @@ import static com.couchbase.client.java.manager.query.CreatePrimaryQueryIndexOpt
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.springframework.data.couchbase.config.BeanNames.COUCHBASE_TEMPLATE;
-import static org.springframework.data.couchbase.config.BeanNames.REACTIVE_COUCHBASE_TEMPLATE;
 import static org.springframework.data.couchbase.util.Util.waitUntilCondition;
 
 import java.io.IOException;
@@ -44,12 +42,8 @@ import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.function.Executable;
 import org.junit.platform.commons.util.UnrecoverableExceptions;
 import org.opentest4j.AssertionFailedError;
-import org.springframework.context.ApplicationContext;
-import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.data.couchbase.CouchbaseClientFactory;
 import org.springframework.data.couchbase.SimpleCouchbaseClientFactory;
-import org.springframework.data.couchbase.core.CouchbaseTemplate;
-import org.springframework.data.couchbase.core.ReactiveCouchbaseTemplate;
 import org.springframework.data.couchbase.domain.Config;
 import org.springframework.data.couchbase.transactions.SimulateFailureException;
 
@@ -85,6 +79,8 @@ import com.couchbase.client.java.query.QueryResult;
 import com.couchbase.client.java.search.SearchQuery;
 import com.couchbase.client.java.search.result.SearchResult;
 
+;
+
 /**
  * Extends the {@link ClusterAwareIntegrationTests} with java-client specific code.
  *
@@ -94,21 +90,15 @@ import com.couchbase.client.java.search.result.SearchResult;
 @Timeout(value = 10, unit = TimeUnit.MINUTES) // Safety timer so tests can't block CI executors
 public class JavaIntegrationTests extends ClusterAwareIntegrationTests {
 
-	// Autowired annotation is not supported on static fields
-	static public CouchbaseTemplate couchbaseTemplate;
-	static public ReactiveCouchbaseTemplate reactiveCouchbaseTemplate;
-
 	@BeforeAll
 	public static void beforeAll() {
 		Config.setScopeName(null);
 		callSuperBeforeAll(new Object() {});
-		ApplicationContext ac = new AnnotationConfigApplicationContext(Config.class);
-		couchbaseTemplate = (CouchbaseTemplate) ac.getBean(COUCHBASE_TEMPLATE);
-		reactiveCouchbaseTemplate = (ReactiveCouchbaseTemplate) ac.getBean(REACTIVE_COUCHBASE_TEMPLATE);
 		try (CouchbaseClientFactory couchbaseClientFactory = new SimpleCouchbaseClientFactory(connectionString(),
 				authenticator(), bucketName())) {
 			couchbaseClientFactory.getCluster().queryIndexes().createPrimaryIndex(bucketName(),
 					CreatePrimaryQueryIndexOptions.createPrimaryQueryIndexOptions().ignoreIfExists(true));
+            logCluster(couchbaseClientFactory.getCluster(), "-");
 		} catch (IOException ioe) {
 			throw new RuntimeException(ioe);
 		}


### PR DESCRIPTION

Closed #1756, #1764.
