### PR TITLE
Option to not use typeKey=typeAlias property and predicate.

### DIFF
--- a/src/main/java/org/springframework/data/couchbase/core/convert/DefaultCouchbaseTypeMapper.java
+++ b/src/main/java/org/springframework/data/couchbase/core/convert/DefaultCouchbaseTypeMapper.java
@@ -67,6 +67,9 @@ public class DefaultCouchbaseTypeMapper extends DefaultTypeMapper<CouchbaseDocum
 
 		@Override
 		public Alias readAliasFrom(final CouchbaseDocument source) {
+            if (typeKey == null || typeKey.length() == 0) {
+                return Alias.NONE;
+            }
 			return Alias.ofNullable(source.get(typeKey));
 		}
 

--- a/src/main/java/org/springframework/data/couchbase/core/index/CouchbasePersistentEntityIndexResolver.java
+++ b/src/main/java/org/springframework/data/couchbase/core/index/CouchbasePersistentEntityIndexResolver.java
@@ -15,6 +15,9 @@
  */
 package org.springframework.data.couchbase.core.index;
 
+import static org.springframework.data.couchbase.core.query.N1QLExpression.i;
+import static org.springframework.data.couchbase.core.query.N1QLExpression.s;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -25,6 +28,7 @@ import org.springframework.data.couchbase.core.mapping.CouchbasePersistentEntity
 import org.springframework.data.couchbase.core.mapping.CouchbasePersistentProperty;
 import org.springframework.data.couchbase.core.mapping.Document;
 import org.springframework.data.couchbase.repository.support.MappingCouchbaseEntityInformation;
+import org.springframework.data.mapping.Alias;
 import org.springframework.data.mapping.PropertyHandler;
 import org.springframework.data.mapping.context.MappingContext;
 import org.springframework.data.util.TypeInformation;
@@ -142,7 +146,15 @@ public class CouchbasePersistentEntityIndexResolver implements QueryIndexResolve
 	private String getPredicate(final MappingCouchbaseEntityInformation<?, Object> entityInfo) {
 		String typeKey = operations.getConverter().getTypeKey();
 		String typeValue = entityInfo.getJavaType().getName();
-		return "`" + typeKey + "` = \"" + typeValue + "\"";
+		Alias alias = operations.getConverter().getTypeAlias(TypeInformation.of(entityInfo.getJavaType()));
+		if (alias != null && alias.isPresent()) {
+			typeValue = alias.toString();
+		}
+        return !empty(typeKey) && !empty(typeValue) ? i(typeKey).eq(s(typeValue)).toString() : null;
+	}
+
+	private static boolean empty(String s){
+		return s == null || s.length() == 0;
 	}
 
 	public static class IndexDefinitionHolder implements IndexDefinition {

--- a/src/main/java/org/springframework/data/couchbase/core/query/Query.java
+++ b/src/main/java/org/springframework/data/couchbase/core/query/Query.java
@@ -353,7 +353,9 @@ public class Query {
 				domainClass, returnClass, isCount, distinctFields, fields);
 		final StringBuilder statement = new StringBuilder();
 		appendString(statement, n1ql.selectEntity); // select ...
-		appendWhereString(statement, n1ql.filter); // typeKey = typeValue
+        if (n1ql.filter != null) {
+            appendWhereString(statement, n1ql.filter); // typeKey = typeValue
+        }
 		appendWhere(statement, new int[] { 0 }, converter); // criteria on this Query
 		if (!isCount) {
 			appendSort(statement);
@@ -368,7 +370,9 @@ public class Query {
 				domainClass, null, false, null, null);
 		final StringBuilder statement = new StringBuilder();
 		appendString(statement, n1ql.delete); // delete ...
-		appendWhereString(statement, n1ql.filter); // typeKey = typeValue
+        if (n1ql.filter != null) {
+            appendWhereString(statement, n1ql.filter); // typeKey = typeValue
+        }
 		appendWhere(statement, null, converter); // criteria on this Query
 		appendString(statement, n1ql.returning);
 		return statement.toString();

--- a/src/main/java/org/springframework/data/couchbase/repository/query/N1qlMutateQueryCreator.java
+++ b/src/main/java/org/springframework/data/couchbase/repository/query/N1qlMutateQueryCreator.java
@@ -37,6 +37,7 @@ import com.couchbase.client.java.json.JsonValue;
  * supported
  *
  * @author Subhashni Balakrishnan
+ * @author Michael Reiche
  */
 public class N1qlMutateQueryCreator extends AbstractQueryCreator<N1QLExpression, N1QLExpression>
 		implements PartTreeN1qlQueryCreator {
@@ -82,6 +83,9 @@ public class N1qlMutateQueryCreator extends AbstractQueryCreator<N1QLExpression,
 	protected N1QLExpression complete(N1QLExpression criteria, Sort sort) {
 		N1QLExpression whereCriteria = N1qlUtils.createWhereFilterForEntity(criteria, this.converter,
 				this.queryMethod.getEntityInformation());
+        if (whereCriteria == null) {
+            return mutateFrom;
+        }
 		return mutateFrom.where(whereCriteria);
 	}
 

--- a/src/main/java/org/springframework/data/couchbase/repository/query/OldN1qlQueryCreator.java
+++ b/src/main/java/org/springframework/data/couchbase/repository/query/OldN1qlQueryCreator.java
@@ -124,7 +124,7 @@ public class OldN1qlQueryCreator extends AbstractQueryCreator<N1QLExpression, N1
 		N1QLExpression whereCriteria = N1qlUtils.createWhereFilterForEntity(criteria, this.converter,
 				this.queryMethod.getEntityInformation());
 
-		N1QLExpression selectFromWhere = selectFrom.where(whereCriteria);
+		N1QLExpression selectFromWhere = whereCriteria != null ?  selectFrom.where(whereCriteria) : selectFrom;
 
 		// sort of the Pageable takes precedence over the sort in the query name
 		if ((queryMethod.isPageQuery() || queryMethod.isSliceQuery()) && accessor.getPageable().isPaged()) {

--- a/src/test/java/org/springframework/data/couchbase/domain/UserNoAlias.java
+++ b/src/test/java/org/springframework/data/couchbase/domain/UserNoAlias.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2012-2023 the original author or authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.data.couchbase.domain;
+
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+import org.springframework.data.annotation.CreatedBy;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedBy;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.annotation.PersistenceConstructor;
+import org.springframework.data.annotation.Transient;
+import org.springframework.data.annotation.TypeAlias;
+import org.springframework.data.annotation.Version;
+import org.springframework.data.couchbase.core.mapping.Document;
+
+import com.couchbase.client.java.json.JsonArray;
+import com.couchbase.client.java.json.JsonObject;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+/**
+ * User entity with an empty TypeAlias for tests
+ *
+ * @author Michael Nitschinger
+ * @author Michael Reiche
+ */
+
+@Document
+@TypeAlias("")
+public class UserNoAlias extends AbstractUser implements Serializable {
+
+	public JsonNode jsonNode;
+	public JsonObject jsonObject;
+	public JsonArray jsonArray;
+
+	@PersistenceConstructor
+	public UserNoAlias(final String id, final String firstname, final String lastname) {
+		this.id = id;
+		this.firstname = firstname;
+		this.lastname = lastname;
+		this.subtype = AbstractingTypeMapper.Type.USER;
+		this.jsonNode = new ObjectNode(JsonNodeFactory.instance);
+		try {
+			jsonNode = (new ObjectNode(JsonNodeFactory.instance)).put("myNumber", uid());
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
+		Map map = new HashMap();
+		map.put("myNumber", uid());
+		this.jsonObject = JsonObject.jo().put("yourNumber",Long.valueOf(uid()));
+		this.jsonArray = JsonArray.from(Long.valueOf(uid()), Long.valueOf(uid()));
+	}
+
+	@Transient int uid=1000;
+	long uid(){
+		return uid++;
+	}
+
+
+	@Version protected long version;
+	@Transient protected String transientInfo;
+	@CreatedBy protected String createdBy;
+	@CreatedDate protected long createdDate;
+	@LastModifiedBy protected String lastModifiedBy;
+	@LastModifiedDate protected long lastModifiedDate;
+
+	public String getLastname() {
+		return lastname;
+	}
+
+	public long getCreatedDate() {
+		return createdDate;
+	}
+
+	public void setCreatedDate(long createdDate) {
+		this.createdDate = createdDate;
+	}
+
+	public String getCreatedBy() {
+		return createdBy;
+	}
+
+	public void setCreatedBy(String createdBy) {
+		this.createdBy = createdBy;
+	}
+
+	public long getLastModifiedDate() {
+		return lastModifiedDate;
+	}
+
+	public String getLastModifiedBy() {
+		return lastModifiedBy;
+	}
+
+	public long getVersion() {
+		return version;
+	}
+
+	public void setVersion(long version) {
+		this.version = version;
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(getId(), firstname, lastname);
+	}
+
+	public String getTransientInfo() {
+		return transientInfo;
+	}
+
+	public void setTransientInfo(String something) {
+		transientInfo = something;
+	}
+
+}


### PR DESCRIPTION
If the configuration getType() or the @TypeAlias is an empty string, then do not add the typeKey:typeAlias property when storing documents, and do not add the typeKey=typeAlias property on queries - including removeByQuery.