### PR TITLE
Fixed #n1ql.bucket Evaluation

### DIFF
--- a/src/main/java/org/springframework/data/couchbase/repository/query/StringBasedN1qlQueryParser.java
+++ b/src/main/java/org/springframework/data/couchbase/repository/query/StringBasedN1qlQueryParser.java
@@ -62,6 +62,7 @@ import com.couchbase.client.java.json.JsonValue;
 /**
  * @author Subhashni Balakrishnan
  * @author Michael Reiche
+ * @author Tigran Babloyan
  */
 public class StringBasedN1qlQueryParser {
 	public static final String SPEL_PREFIX = "n1ql";
@@ -166,7 +167,7 @@ public class StringBasedN1qlQueryParser {
 		this.queryMethod = queryMethod;
 		this.couchbaseConverter = couchbaseConverter;
 		this.statementContext = queryMethod == null ? null
-				: createN1qlSpelValues(collection != null ? collection : bucketName, scope, collection,
+				: createN1qlSpelValues(bucketName, scope, collection,
 				queryMethod.getEntityInformation().getJavaType(), typeField, typeValue, queryMethod.isCountQuery(), null, null);
 		this.parsedExpression = getExpression(statement, queryMethod, accessor, spelExpressionParser,
 				evaluationContextProvider);

--- a/src/test/java/org/springframework/data/couchbase/repository/query/StringN1qlQueryCreatorTests.java
+++ b/src/test/java/org/springframework/data/couchbase/repository/query/StringN1qlQueryCreatorTests.java
@@ -208,7 +208,7 @@ class StringN1qlQueryCreatorTests {
 
 		assertEquals("SELECT `_class`, `jsonNode`, `jsonObject`, `jsonArray`, META(`myCollection`).`cas`"
 				+ " AS __cas, `createdBy`, `createdDate`, `lastModifiedBy`, `lastModifiedDate`, META(`myCollection`).`id`"
-				+ " AS __id, `firstname`, `lastname`, `subtype` FROM `myCollection`|`_class` = \"abstractuser\"|`myCollection`|`myScope`|`myCollection`",
+				+ " AS __id, `firstname`, `lastname`, `subtype` FROM `myCollection`|`_class` = \"abstractuser\"|`some_bucket`|`myScope`|`myCollection`",
 				query.toN1qlSelectString(converter, bucketName(), "myScope", "myCollection", User.class, null, false, null,
 						null));
 	}


### PR DESCRIPTION
Fixed issue with #n1ql.bucket evaluated as a collection name in string based queries.

Closes #1799

<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATACOUCH).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
