### PR TITLE
Bump Couchbase SDK to 3.4.10 on 5.1.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,8 +18,8 @@
     </parent>
 
     <properties>
-        <couchbase>3.4.8</couchbase>
-        <couchbase.osgi>3.4.8</couchbase.osgi>
+        <couchbase>3.4.10</couchbase>
+        <couchbase.osgi>3.4.10</couchbase.osgi>
         <springdata.commons>3.1.4-SNAPSHOT</springdata.commons>
         <java-module-name>spring.data.couchbase</java-module-name>
         <hibernate.validator>7.0.1.Final</hibernate.validator>


### PR DESCRIPTION
Closes #1823.
