### PR TITLE
Fix ThreadLocal Issue with Repository Save.

### DIFF
--- a/src/main/java/org/springframework/data/couchbase/core/ReactiveCouchbaseTemplate.java
+++ b/src/main/java/org/springframework/data/couchbase/core/ReactiveCouchbaseTemplate.java
@@ -53,7 +53,7 @@ public class ReactiveCouchbaseTemplate implements ReactiveCouchbaseOperations, A
 	private final CouchbaseConverter converter;
 	private final PersistenceExceptionTranslator exceptionTranslator;
 	private final ReactiveCouchbaseTemplateSupport templateSupport;
-	private ThreadLocal<PseudoArgs<?>> threadLocalArgs = new ThreadLocal<>();
+	private final ThreadLocal<PseudoArgs<?>> threadLocalArgs = new ThreadLocal<>();
 	private final QueryScanConsistency scanConsistency;
 
 	public ReactiveCouchbaseTemplate(final CouchbaseClientFactory clientFactory, final CouchbaseConverter converter) {
@@ -257,14 +257,6 @@ public class ReactiveCouchbaseTemplate implements ReactiveCouchbaseOperations, A
 	 * set the ThreadLocal field
 	 */
 	public void setPseudoArgs(PseudoArgs<?> threadLocalArgs) {
-		if (this.threadLocalArgs == null) {
-			synchronized (this) {
-				if (this.threadLocalArgs == null) {
-					this.threadLocalArgs = new ThreadLocal<>();
-				}
-			}
-		}
-
 		this.threadLocalArgs.set(threadLocalArgs);
 	}
 

--- a/src/test/java/org/springframework/data/couchbase/domain/ReactiveAirportMustScopeRepository.java
+++ b/src/test/java/org/springframework/data/couchbase/domain/ReactiveAirportMustScopeRepository.java
@@ -1,0 +1,9 @@
+package org.springframework.data.couchbase.domain;
+
+import org.springframework.data.couchbase.repository.Collection;
+import org.springframework.data.couchbase.repository.Scope;
+
+@Scope("must set scope name")
+@Collection("my_collection")
+public interface ReactiveAirportMustScopeRepository extends ReactiveAirportRepository {
+}


### PR DESCRIPTION
The issue was introduced when the Mono.deferContextual() was added to determine if the save() is in a transaction. It may be executing in a different thread when the PseudoArgs (scope, collection, and options) are retrieved ThreadLocal. This change ensures scope and collection are retrieved, but options are ignored and discarded.

Closes #1838.
