### PR TITLE
Propagated CouchbaseCustomConverters bean into MappingConverter

### DIFF
--- a/src/main/java/org/springframework/data/couchbase/config/AbstractCouchbaseConfiguration.java
+++ b/src/main/java/org/springframework/data/couchbase/config/AbstractCouchbaseConfiguration.java
@@ -35,7 +35,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ClassPathScanningCandidateComponentProvider;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Role;
-import org.springframework.core.convert.converter.GenericConverter;
 import org.springframework.core.type.filter.AnnotationTypeFilter;
 import org.springframework.data.convert.CustomConversions;
 import org.springframework.data.convert.PropertyValueConverterRegistrar;
@@ -67,8 +66,6 @@ import org.springframework.data.mapping.model.FieldNamingStrategy;
 import org.springframework.data.mapping.model.PropertyNameFieldNamingStrategy;
 import org.springframework.transaction.TransactionManager;
 import org.springframework.transaction.annotation.AnnotationTransactionAttributeSource;
-import org.springframework.transaction.annotation.ProxyTransactionManagementConfiguration;
-import org.springframework.transaction.config.TransactionManagementConfigUtils;
 import org.springframework.transaction.interceptor.TransactionAttributeSource;
 import org.springframework.transaction.interceptor.TransactionInterceptor;
 import org.springframework.transaction.support.TransactionTemplate;
@@ -100,6 +97,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
  * @author Subhashni Balakrishnan
  * @author Jorge Rodriguez Martin
  * @author Michael Reiche
+ * @author Vipul Gupta
  */
 @Configuration
 public abstract class AbstractCouchbaseConfiguration {
@@ -280,8 +278,7 @@ public abstract class AbstractCouchbaseConfiguration {
 	@Bean
 	public MappingCouchbaseConverter mappingCouchbaseConverter(CouchbaseMappingContext couchbaseMappingContext,
 			CouchbaseCustomConversions couchbaseCustomConversions) {
-		MappingCouchbaseConverter converter = new MappingCouchbaseConverter(couchbaseMappingContext, typeKey());
-		converter.setCustomConversions(couchbaseCustomConversions);
+		MappingCouchbaseConverter converter = new MappingCouchbaseConverter(couchbaseMappingContext, typeKey(), couchbaseCustomConversions);
 		couchbaseMappingContext.setSimpleTypeHolder(couchbaseCustomConversions.getSimpleTypeHolder());
 		return converter;
 	}

--- a/src/main/java/org/springframework/data/couchbase/core/convert/AbstractCouchbaseConverter.java
+++ b/src/main/java/org/springframework/data/couchbase/core/convert/AbstractCouchbaseConverter.java
@@ -57,15 +57,6 @@ public abstract class AbstractCouchbaseConverter implements CouchbaseConverter, 
 	protected CustomConversions conversions;
 
 	/**
-	 * Create a new converter and hand it over the {@link ConversionService}
-	 *
-	 * @param conversionService the conversion service to use.
-	 */
-	protected AbstractCouchbaseConverter(final GenericConversionService conversionService) {
-		this(conversionService, new CouchbaseCustomConversions(Collections.emptyList()));
-	}
-
-	/**
 	 * Create a new converter with custom conversions and hand it over the {@link ConversionService}
 	 *
 	 * @param conversionService the conversion service to use.

--- a/src/main/java/org/springframework/data/couchbase/core/convert/AbstractCouchbaseConverter.java
+++ b/src/main/java/org/springframework/data/couchbase/core/convert/AbstractCouchbaseConverter.java
@@ -37,6 +37,7 @@ import org.springframework.data.util.TypeInformation;
  * @author Michael Nitschinger
  * @author Mark Paluch
  * @author Michael Reiche
+ * @author Vipul Gupta
  */
 public abstract class AbstractCouchbaseConverter implements CouchbaseConverter, InitializingBean {
 
@@ -53,7 +54,7 @@ public abstract class AbstractCouchbaseConverter implements CouchbaseConverter, 
 	/**
 	 * Holds the custom conversions.
 	 */
-	protected CustomConversions conversions = new CouchbaseCustomConversions(Collections.emptyList());
+	protected CustomConversions conversions;
 
 	/**
 	 * Create a new converter and hand it over the {@link ConversionService}
@@ -61,7 +62,18 @@ public abstract class AbstractCouchbaseConverter implements CouchbaseConverter, 
 	 * @param conversionService the conversion service to use.
 	 */
 	protected AbstractCouchbaseConverter(final GenericConversionService conversionService) {
+		this(conversionService, new CouchbaseCustomConversions(Collections.emptyList()));
+	}
+
+	/**
+	 * Create a new converter with custom conversions and hand it over the {@link ConversionService}
+	 *
+	 * @param conversionService the conversion service to use.
+	 * @param customConversions the custom conversions to use
+	 */
+	protected AbstractCouchbaseConverter(final GenericConversionService conversionService, final CustomConversions customConversions) {
 		this.conversionService = conversionService;
+		this.conversions = customConversions;
 	}
 
 	/**

--- a/src/main/java/org/springframework/data/couchbase/core/convert/MappingCouchbaseConverter.java
+++ b/src/main/java/org/springframework/data/couchbase/core/convert/MappingCouchbaseConverter.java
@@ -90,6 +90,7 @@ import com.couchbase.client.java.json.JsonObject;
  * @author Mark Paluch
  * @author Michael Reiche
  * @author Remi Bleuse
+ * @author Vipul Gupta
  */
 public class MappingCouchbaseConverter extends AbstractCouchbaseConverter implements ApplicationContextAware {
 
@@ -141,8 +142,7 @@ public class MappingCouchbaseConverter extends AbstractCouchbaseConverter implem
 	}
 
 	/**
-	 * Create a new {@link MappingCouchbaseConverter} that will store class name for complex types in the <i>typeKey</i>
-	 * attribute.
+	 * Create a new {@link MappingCouchbaseConverter}
 	 *
 	 * @param mappingContext the mapping context to use.
 	 * @param typeKey the attribute name to use to store complex types class name.
@@ -150,12 +150,23 @@ public class MappingCouchbaseConverter extends AbstractCouchbaseConverter implem
 	public MappingCouchbaseConverter(
 			final MappingContext<? extends CouchbasePersistentEntity<?>, CouchbasePersistentProperty> mappingContext,
 			final String typeKey) {
-		super(new DefaultConversionService());
+		this(mappingContext, typeKey, new CouchbaseCustomConversions(Collections.emptyList()));
+	}
+
+	/**
+	 * Create a new {@link MappingCouchbaseConverter} that will store class name for complex types in the <i>typeKey</i>
+	 * attribute.
+	 *
+	 * @param mappingContext the mapping context to use.
+	 * @param typeKey the attribute name to use to store complex types class name.
+	 * @param customConversions the custom conversions to use
+	 */
+	public MappingCouchbaseConverter(
+			final MappingContext<? extends CouchbasePersistentEntity<?>, CouchbasePersistentProperty> mappingContext,
+			final String typeKey,
+			final CustomConversions customConversions) {
+		super(new DefaultConversionService(), customConversions);
 		this.mappingContext = mappingContext;
-		// this is how the MappingCouchbaseConverter gets the custom conversions.
-		// the conversions Service gets them in afterPropertiesSet()
-		CustomConversions customConversions = new CouchbaseCustomConversions(Collections.emptyList());
-		this.setCustomConversions(customConversions);
 		// Don't rely on setSimpleTypeHolder being called in afterPropertiesSet() - some integration tests do not use it
 		// if the mappingContext does not have the SimpleTypes, it will not know that they have converters, then it will
 		// try to access the fields of the type and (maybe) fail with InaccessibleObjectException

--- a/src/test/java/org/springframework/data/couchbase/domain/AbstractingMappingCouchbaseConverter.java
+++ b/src/test/java/org/springframework/data/couchbase/domain/AbstractingMappingCouchbaseConverter.java
@@ -15,6 +15,7 @@
  */
 package org.springframework.data.couchbase.domain;
 
+import org.springframework.data.couchbase.core.convert.CouchbaseCustomConversions;
 import org.springframework.data.couchbase.core.convert.MappingCouchbaseConverter;
 import org.springframework.data.couchbase.core.mapping.CouchbasePersistentEntity;
 import org.springframework.data.couchbase.core.mapping.CouchbasePersistentProperty;
@@ -37,8 +38,9 @@ public class AbstractingMappingCouchbaseConverter extends MappingCouchbaseConver
 	 */
 	public AbstractingMappingCouchbaseConverter(
 			final MappingContext<? extends CouchbasePersistentEntity<?>, CouchbasePersistentProperty> mappingContext,
-			final String typeKey) {
-		super(mappingContext, typeKey);
+			final String typeKey,
+			final CouchbaseCustomConversions couchbaseCustomConversions) {
+		super(mappingContext, typeKey, couchbaseCustomConversions);
 		this.typeMapper = new AbstractingTypeMapper(typeKey);
 	}
 

--- a/src/test/java/org/springframework/data/couchbase/domain/Config.java
+++ b/src/test/java/org/springframework/data/couchbase/domain/Config.java
@@ -211,8 +211,7 @@ public class Config extends AbstractCouchbaseConfiguration {
 		// that has an getAliasFor(info) that just returns getType().getName().
 		// Our CustomMappingCouchbaseConverter uses a TypeBasedCouchbaseTypeMapper that will
 		// use the DocumentType annotation
-		MappingCouchbaseConverter converter = new CustomMappingCouchbaseConverter(couchbaseMappingContext, typeKey());
-		converter.setCustomConversions(couchbaseCustomConversions);
+		MappingCouchbaseConverter converter = new CustomMappingCouchbaseConverter(couchbaseMappingContext, typeKey(), couchbaseCustomConversions);
 		return converter;
 	}
 

--- a/src/test/java/org/springframework/data/couchbase/domain/CustomMappingCouchbaseConverter.java
+++ b/src/test/java/org/springframework/data/couchbase/domain/CustomMappingCouchbaseConverter.java
@@ -15,6 +15,7 @@
  */
 package org.springframework.data.couchbase.domain;
 
+import org.springframework.data.couchbase.core.convert.CouchbaseCustomConversions;
 import org.springframework.data.couchbase.core.convert.MappingCouchbaseConverter;
 import org.springframework.data.couchbase.core.mapping.CouchbasePersistentEntity;
 import org.springframework.data.couchbase.core.mapping.CouchbasePersistentProperty;
@@ -34,6 +35,23 @@ public class CustomMappingCouchbaseConverter extends MappingCouchbaseConverter {
 			final MappingContext<? extends CouchbasePersistentEntity<?>, CouchbasePersistentProperty> mappingContext,
 			final String typeKey) {
 		super(mappingContext, typeKey);
+		this.typeMapper = new TypeBasedCouchbaseTypeMapper(typeKey);
+	}
+
+	/**
+	 * this constructer creates a TypeBasedCouchbaseTypeMapper with the specified couchbaseCustomConversions and typeKey
+	 * while MappingCouchbaseConverter uses a DefaultCouchbaseTypeMapper typeMapper = new DefaultCouchbaseTypeMapper(typeKey != null ? typeKey :
+	 * TYPEKEY_DEFAULT);
+	 *
+	 * @param mappingContext
+	 * @param typeKey - the typeKey to be used (normally "_class")
+	 * @param couchbaseCustomConversions - custom conversions to use
+	 */
+	public CustomMappingCouchbaseConverter(
+			final MappingContext<? extends CouchbasePersistentEntity<?>, CouchbasePersistentProperty> mappingContext,
+			final String typeKey,
+			final CouchbaseCustomConversions couchbaseCustomConversions) {
+		super(mappingContext, typeKey, couchbaseCustomConversions);
 		this.typeMapper = new TypeBasedCouchbaseTypeMapper(typeKey);
 	}
 

--- a/src/test/java/org/springframework/data/couchbase/repository/CouchbaseAbstractRepositoryIntegrationTests.java
+++ b/src/test/java/org/springframework/data/couchbase/repository/CouchbaseAbstractRepositoryIntegrationTests.java
@@ -124,8 +124,8 @@ public class CouchbaseAbstractRepositoryIntegrationTests extends ClusterAwareInt
 			// Our CustomMappingCouchbaseConverter uses a TypeBasedCouchbaseTypeMapper that will
 			// use the DocumentType annotation
 			MappingCouchbaseConverter converter = new AbstractingMappingCouchbaseConverter(couchbaseMappingContext,
-					typeKey());
-			converter.setCustomConversions(couchbaseCustomConversions);
+					typeKey(),
+					couchbaseCustomConversions);
 			return converter;
 		}
 


### PR DESCRIPTION
Propagated CouchbaseCustomConverters bean into MappingConverter.

Just a polishing fix to propagate CouchbaseCustomConversions directly to MappingCouchbaseConverter -> AbstractCouchbaseConverter , So that we won't have to set it explicitly. Fixes https://github.com/spring-projects/spring-data-couchbase/issues/1850 .

<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [ ] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATACOUCH).
- [ ] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
