### PR TITLE
Remove the "provided" from querydsl dependency.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,6 @@
             <groupId>com.querydsl</groupId>
             <artifactId>querydsl-apt</artifactId>
             <version>${querydsl}</version>
-            <scope>provided</scope>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Tested with juliojgd's reproducer on https://github.com/spring-projects/spring-boot/issues/39740

Closes #1909.


