### PR TITLE
Make CrudMethodMetadataPostProcessor public.

### DIFF
--- a/src/main/java/org/springframework/data/couchbase/repository/support/CouchbaseRepositoryFactory.java
+++ b/src/main/java/org/springframework/data/couchbase/repository/support/CouchbaseRepositoryFactory.java
@@ -118,7 +118,7 @@ public class CouchbaseRepositoryFactory extends RepositoryFactorySupport {
 	 * @return a new created repository.
 	 */
 	@Override
-	protected final Object getTargetRepository(final RepositoryInformation metadata) {
+	protected Object getTargetRepository(final RepositoryInformation metadata) {
 		CouchbaseOperations couchbaseOperations = couchbaseOperationsMapping.resolve(metadata.getRepositoryInterface(),
 				metadata.getDomainType());
 		CouchbaseEntityInformation<?, Serializable> entityInformation = getEntityInformation(metadata.getDomainType());

--- a/src/main/java/org/springframework/data/couchbase/repository/support/CrudMethodMetadataPostProcessor.java
+++ b/src/main/java/org/springframework/data/couchbase/repository/support/CrudMethodMetadataPostProcessor.java
@@ -55,7 +55,7 @@ import com.couchbase.client.java.query.QueryScanConsistency;
  * @author Jens Schauder
  * @author Michael Reiche
  */
-class CrudMethodMetadataPostProcessor implements RepositoryProxyPostProcessor, BeanClassLoaderAware {
+public class CrudMethodMetadataPostProcessor implements RepositoryProxyPostProcessor, BeanClassLoaderAware {
 
 	private @Nullable ClassLoader classLoader = ClassUtils.getDefaultClassLoader();
 

--- a/src/main/java/org/springframework/data/couchbase/repository/support/ReactiveCouchbaseRepositoryFactory.java
+++ b/src/main/java/org/springframework/data/couchbase/repository/support/ReactiveCouchbaseRepositoryFactory.java
@@ -106,7 +106,7 @@ public class ReactiveCouchbaseRepositoryFactory extends ReactiveRepositoryFactor
 	 * @return a new created repository.
 	 */
 	@Override
-	protected final Object getTargetRepository(final RepositoryInformation metadata) {
+	protected Object getTargetRepository(final RepositoryInformation metadata) {
 		ReactiveCouchbaseOperations couchbaseOperations = couchbaseOperationsMapping
 				.resolve(metadata.getRepositoryInterface(), metadata.getDomainType());
 		CouchbaseEntityInformation<?, Serializable> entityInformation = getEntityInformation(metadata.getDomainType());


### PR DESCRIPTION
Make CrudMethodMetadataPostProcessor public and make factory
getTargetRepository() not final (so factory can be extended)
This is to ease extending spring-data-couchbase.

Closes #1877.
