### PR TITLE
Remove javax.inject dependency in 5.0.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,19 @@
             <groupId>com.querydsl</groupId>
             <artifactId>querydsl-apt</artifactId>
             <version>${querydsl}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>javax.inject</groupId>
+                    <artifactId>javax.inject</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>javax.inject</groupId>
+            <artifactId>javax.inject</artifactId>
+            <version>1</version>
+            <scope>test</scope>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Closes #1917.
