### PR TITLE
Exclude javax.inject and CB AnnotationProcessor to exit gracefully w/o.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,6 @@
         <springdata.commons>3.3.0-SNAPSHOT</springdata.commons>
         <java-module-name>spring.data.couchbase</java-module-name>
         <hibernate.validator>7.0.1.Final</hibernate.validator>
-        <mysema.querydsl>3.7.4</mysema.querydsl>
         <couchbase.encryption>3.1.0</couchbase.encryption>
         <jodatime>2.10.13</jodatime>
         <jackson-joda>2.13.4</jackson-joda>
@@ -49,6 +48,19 @@
             <artifactId>querydsl-apt</artifactId>
             <version>${querydsl}</version>
             <classifier>jakarta</classifier>
+            <exclusions>
+                <exclusion>
+                    <groupId>javax.inject</groupId>
+                    <artifactId>javax.inject</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>javax.inject</groupId>
+            <artifactId>javax.inject</artifactId>
+            <version>1</version>
+            <scope>test</scope>
         </dependency>
 
         <dependency>
@@ -250,13 +262,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <dependencies>
-                    <dependency>
-                        <groupId>com.querydsl</groupId>
-                        <artifactId>querydsl-apt</artifactId>
-                        <version>${querydsl}</version>
-                    </dependency>
-                </dependencies>
                 <configuration>
                     <proc>none</proc>
                 </configuration>
@@ -273,6 +278,9 @@
                                 <annotationProcessor>org.springframework.data.couchbase.repository.support.CouchbaseAnnotationProcessor</annotationProcessor>
                             </annotationProcessors>
                             <generatedTestSourcesDirectory>target/generated-test-sources</generatedTestSourcesDirectory>
+                            <compilerArgs>
+                                <arg>-Aquerydsl.logInfo=true</arg>
+                            </compilerArgs>
                         </configuration>
                     </execution>
                 </executions>

--- a/src/test/java/org/springframework/data/couchbase/core/CouchbaseTemplateKeyValueIntegrationTests.java
+++ b/src/test/java/org/springframework/data/couchbase/core/CouchbaseTemplateKeyValueIntegrationTests.java
@@ -1329,7 +1329,7 @@ class CouchbaseTemplateKeyValueIntegrationTests extends JavaIntegrationTests {
 		MutationToken mt = couchbaseTemplate.getCouchbaseClientFactory().getDefaultCollection()
 			.upsert(id, JsonObject.create().put("id", id)).mutationToken().get();
     Stream<User> users = couchbaseTemplate.rangeScan(User.class).consistentWith(MutationState.from(mt))
-        /*.withSort(ScanSort.ASCENDING)*/.samplingScan(5l, null);
+        /*.withSort(ScanSort.ASCENDING)*/.samplingScan(5l, (Long)null);
     List<User> usersList = users.toList();
 		assertEquals(5, usersList.size(), "number in sample");
     for (User u : usersList) {

--- a/src/test/java/org/springframework/data/couchbase/core/query/QueryCriteriaTests.java
+++ b/src/test/java/org/springframework/data/couchbase/core/query/QueryCriteriaTests.java
@@ -90,7 +90,7 @@ class QueryCriteriaTests {
 	@Test
 	void testNestedNotIn() {
 		QueryCriteria c = where(i("name")).is("Bubba").or(where(i("age")).gt(12).and(i("country")).is("Austria"))
-				.and(where(i("state")).notIn(new String[] { "Alabama", "Florida" }));
+				.and(where(i("state")).notIn( "Alabama", "Florida" ));
 		JsonArray parameters = JsonArray.create();
 		assertEquals("  (  (`name` = $1) or   (`age` > $2 and `country` = $3)) and   (not( (`state` in $4) ))",
 				c.export(new int[1], parameters, null));

--- a/src/test/java/org/springframework/data/couchbase/domain/BigAirlineRepository.java
+++ b/src/test/java/org/springframework/data/couchbase/domain/BigAirlineRepository.java
@@ -30,7 +30,7 @@ import org.springframework.stereotype.Repository;
  */
 @Repository
 public interface BigAirlineRepository extends CouchbaseRepository<BigAirline, String>,
-		QuerydslPredicateExecutor<BigAirline>, DynamicProxyable<BigAirlineRepository> {
+		 DynamicProxyable<BigAirlineRepository> {
 
 	@Query("#{#n1ql.selectEntity} where #{#n1ql.filter} and (name = $1)")
 	List<Airline> getByName(@Param("airline_name") String airlineName);


### PR DESCRIPTION
CouchbaseAnnotationProcessor will provide a warning and skip generation if javax.inject is not present.

Closes #1929.

