### PR TITLE
Revert "Fix ci/clean.sh permission denied. (#1974)"

### DIFF
--- a/ci/clean.sh
+++ b/ci/clean.sh
@@ -1,7 +1,6 @@
 #!/bin/bash -x
 
 set -euo pipefail
-chown -R 1001:1001 .
 
 export JENKINS_USER=${JENKINS_USER_NAME}
 


### PR DESCRIPTION
This reverts commit 13d39949ad69fba675ea9f7c2c39092411b223d5.

Closes #1975.
