### PR TITLE
Remove dependency on javax.inject from querydsl.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,19 +47,7 @@
             <artifactId>querydsl-apt</artifactId>
             <version>${querydsl}</version>
             <classifier>jakarta</classifier>
-            <exclusions>
-                <exclusion>
-                    <groupId>javax.inject</groupId>
-                    <artifactId>javax.inject</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-
-        <dependency>
-            <groupId>javax.inject</groupId>
-            <artifactId>javax.inject</artifactId>
-            <version>1</version>
-            <scope>test</scope>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>
@@ -261,9 +249,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <proc>none</proc>
-                </configuration>
                 <executions>
                     <execution>
                         <id>test-annotation-processing</id>

--- a/src/main/java/org/springframework/data/couchbase/repository/support/CouchbaseAnnotationProcessor.java
+++ b/src/main/java/org/springframework/data/couchbase/repository/support/CouchbaseAnnotationProcessor.java
@@ -79,7 +79,7 @@ public class CouchbaseAnnotationProcessor extends AbstractQuerydslProcessor {
 			return ALLOW_OTHER_PROCESSORS_TO_CLAIM_ANNOTATIONS;
 		}
 
-    Configuration conf = createConfiguration(roundEnv);
+                Configuration conf = createConfiguration(roundEnv);
 		try {
 			conf.getTypeMappings();
 		} catch (NoClassDefFoundError cnfe ){

--- a/src/main/resources/META-INF/services/javax.annotation.processing.Processor
+++ b/src/main/resources/META-INF/services/javax.annotation.processing.Processor
@@ -1,1 +1,0 @@
-org.springframework.data.couchbase.repository.support.CouchbaseAnnotationProcessor


### PR DESCRIPTION
To use querydsl, the spring application will need to add a dependency

    <dependency>
        <groupId>com.querydsl</groupId>
        <artifactId>querydsl-apt</artifactId>
        <version>${querydsl}</version>
        <classifier>jakarta</classifier>
        <scope>provided</scope>
    </dependency>

And explicitly specify CouchbasseAnnotationProcessor

    <plugin>
        <groupId>org.apache.maven.plugins</groupId>
        <artifactId>maven-compiler-plugin</artifactId>
        <executions>
            <execution>
                <id>annotation-processing</id>
                <phase>generate-sources</phase>
                <goals>
                    <goal>compile</goal>
                </goals>
                <configuration>
                    <proc>only</proc>
                    <annotationProcessors>
                        <annotationProcessor>org.springframework.data.couchbase.repository.support.CouchbaseAnnotationProcessor</annotationProcessor>
                    </annotationProcessors>
                    <generatedTestSourcesDirectory>target/generated-test-sources</generatedTestSourcesDirectory>
                    <compilerArgs>
                        <arg>-Aquerydsl.logInfo=true</arg>
                    </compilerArgs>
                </configuration>
            </execution>
        </executions>
    </plugin>

Closes #1989.
