### PR TITLE
Bump Couchbase Java SDK to 3.7.7 on 5.4.x.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
     </parent>
 
     <properties>
-        <couchbase>3.7.4</couchbase>
+        <couchbase>3.7.7</couchbase>
         <springdata.commons>3.4.2-SNAPSHOT</springdata.commons>
         <java-module-name>spring.data.couchbase</java-module-name>
         <hibernate.validator>7.0.1.Final</hibernate.validator>


### PR DESCRIPTION
Closes #2020.
