### PR TITLE
Enhance CouchbaseDocument and CouchbaseList to handle List implementa…

### DIFF
--- a/src/main/java/org/springframework/data/couchbase/core/mapping/CouchbaseDocument.java
+++ b/src/main/java/org/springframework/data/couchbase/core/mapping/CouchbaseDocument.java
@@ -20,6 +20,7 @@ import com.couchbase.client.java.json.JsonObject;
 
 import java.util.TreeMap;
 import java.util.Map;
+import java.util.List;
 
 /**
  * A {@link CouchbaseDocument} is an abstract representation of a document stored inside Couchbase Server.
@@ -275,8 +276,14 @@ public class CouchbaseDocument implements CouchbaseStorable {
 		if (CouchbaseSimpleTypes.DOCUMENT_TYPES.isSimpleType(clazz)) {
 			return;
 		}
+		
+		// Special handling for List implementations like Collections.SingletonList and ArrayList
+		if (value instanceof List) {
+			return;
+		}
+		
 		throw new IllegalArgumentException(
-				"Attribute of type " + clazz.getCanonicalName() + " cannot be stored and must be converted.");
+				"Attribute of type " + clazz.getCanonicalName() + " cannot be stored in document and must be converted.");
 	}
 
 	/**

--- a/src/main/java/org/springframework/data/couchbase/core/mapping/CouchbaseList.java
+++ b/src/main/java/org/springframework/data/couchbase/core/mapping/CouchbaseList.java
@@ -200,9 +200,14 @@ public class CouchbaseList implements CouchbaseStorable {
 		if (simpleTypeHolder.isSimpleType(clazz)) {
 			return;
 		}
+		
+		// Special handling for List implementations like Collections.SingletonList and ArrayList
+		if (value instanceof List) {
+			return;
+		}
 
 		throw new IllegalArgumentException(
-				"Attribute of type " + clazz.getCanonicalName() + " can not be stored and must be converted.");
+				"Attribute of type " + clazz.getCanonicalName() + " cannot be stored in list and must be converted.");
 	}
 
 	/**


### PR DESCRIPTION
# Fix for Collections.SingletonList handling in Spring Data Couchbase

This PR addresses an issue where `Collections.SingletonList` and other List implementations cannot be stored directly in Couchbase documents after upgrading to Spring Boot 3.4.3 with Spring Data Couchbase 5.4.3.

## Details

The error manifests as:
```
java.lang.IllegalArgumentException: Attribute of type java.util.Collections.SingletonList cannot be stored and must be converted.
```

The fix adds special handling for List implementations in the `verifyValueType` methods of both `CouchbaseDocument` and `CouchbaseList` classes, allowing them to be processed without requiring explicit conversion.

## Changes

- Modified `CouchbaseDocument.verifyValueType()` to accept `List` implementations
- Modified `CouchbaseList.verifyValueType()` to accept `List` implementations
- Updated error messages to provide clarity about which component is generating the error

This change ensures backward compatibility with code that worked in Spring Boot 3.2.4 while maintaining proper functionality in Spring Boot 3.4.3.
