### PR TITLE
Switch to OpenFeign QueryDSL

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,6 +26,7 @@
         <jodatime>2.10.13</jodatime>
         <jackson-joda>2.13.4</jackson-joda>
         <jakarta.el>4.0.0</jakarta.el>
+        <querydsl_of>6.11</querydsl_of>
     </properties>
 
     <dependencyManagement>
@@ -43,10 +44,12 @@
     <dependencies>
 
         <dependency>
+<!--
             <groupId>com.querydsl</groupId>
+-->
+            <groupId>io.github.openfeign.querydsl</groupId>
             <artifactId>querydsl-apt</artifactId>
-            <version>${querydsl}</version>
-            <classifier>jakarta</classifier>
+            <version>${querydsl_of}</version>
             <scope>provided</scope>
         </dependency>
 

--- a/src/test/java/org/springframework/data/couchbase/repository/query/CouchbaseRepositoryQuerydslIntegrationTests.java
+++ b/src/test/java/org/springframework/data/couchbase/repository/query/CouchbaseRepositoryQuerydslIntegrationTests.java
@@ -20,6 +20,7 @@ import static com.couchbase.client.java.query.QueryScanConsistency.REQUEST_PLUS;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.springframework.data.couchbase.util.Util.comprises;
 import static org.springframework.data.couchbase.util.Util.exactly;
 
@@ -29,6 +30,7 @@ import java.util.Locale;
 import java.util.Optional;
 import java.util.stream.StreamSupport;
 
+import com.querydsl.core.types.dsl.PathBuilder;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -43,8 +45,10 @@ import org.springframework.data.couchbase.core.CouchbaseTemplate;
 import org.springframework.data.couchbase.core.mapping.event.ValidatingCouchbaseEventListener;
 import org.springframework.data.couchbase.core.query.QueryCriteriaDefinition;
 import org.springframework.data.couchbase.domain.Airline;
+import org.springframework.data.couchbase.domain.AirlineCollectioned;
 import org.springframework.data.couchbase.domain.AirlineRepository;
 import org.springframework.data.couchbase.domain.QAirline;
+import org.springframework.data.couchbase.domain.QAirlineCollectioned;
 import org.springframework.data.couchbase.repository.auditing.EnableCouchbaseAuditing;
 import org.springframework.data.couchbase.repository.auditing.EnableReactiveCouchbaseAuditing;
 import org.springframework.data.couchbase.repository.config.EnableCouchbaseRepositories;
@@ -145,6 +149,13 @@ public class CouchbaseRepositoryQuerydslIntegrationTests extends JavaIntegration
 					"[unexpected] -> [missing]");
 			assertEquals(" WHERE name = $1", bq(predicate));
 		}
+	}
+
+	@Test
+	void testInjection() {
+		String userSpecifiedPath = "1 = 1) OR (2";
+		PathBuilder<QAirline> pathBuilder = new PathBuilder<>(QAirline.class, "xyz");
+		assertThrows(IllegalStateException.class, () -> pathBuilder.get(userSpecifiedPath).eq("2"));
 	}
 
 	// this gives hqCountry == "" and hqCountry is missing


### PR DESCRIPTION
because of CVE-2024-49203.

Closes #2409.
